### PR TITLE
Add basic implementation of Control Plane

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/nandemo-ya/kecs/internal/controlplane/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/nandemo-ya/kecs
+
+go 1.23.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/controlplane/cmd/root.go
+++ b/internal/controlplane/cmd/root.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Used for flags
+	port     int
+	logLevel string
+
+	// RootCmd represents the base command when called without any subcommands
+	RootCmd = &cobra.Command{
+		Use:   "controlplane",
+		Short: "KECS Control Plane - Kubernetes-based ECS Compatible Service",
+		Long: `KECS Control Plane provides Amazon ECS compatible APIs running on Kubernetes.
+It allows you to run ECS workloads locally or in any Kubernetes cluster without AWS dependencies.`,
+		// The default command when no subcommands are specified
+		Run: func(cmd *cobra.Command, args []string) {
+			// This will start the server by default
+			startServer()
+		},
+	}
+)
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Define persistent flags that will be inherited by all subcommands
+	RootCmd.PersistentFlags().IntVarP(&port, "port", "p", 8080, "Port to run the control plane server on")
+	RootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "Log level (debug, info, warn, error)")
+
+	// Add subcommands
+	RootCmd.AddCommand(serverCmd)
+	RootCmd.AddCommand(versionCmd)
+}
+
+// startServer is the default action when no subcommands are specified
+func startServer() {
+	fmt.Printf("Starting KECS Control Plane on port %d with log level %s\n", port, logLevel)
+	// TODO: Implement actual control plane server startup logic
+}

--- a/internal/controlplane/cmd/server.go
+++ b/internal/controlplane/cmd/server.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Additional server-specific flags
+	kubeconfig string
+
+	// serverCmd represents the server command
+	serverCmd = &cobra.Command{
+		Use:   "server",
+		Short: "Start the KECS Control Plane server",
+		Long: `Start the KECS Control Plane server that provides Amazon ECS compatible APIs.
+The server connects to a Kubernetes cluster and translates ECS API calls to Kubernetes resources.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServer()
+		},
+	}
+)
+
+func init() {
+	// Add server-specific flags
+	serverCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file (default is $HOME/.kube/config)")
+}
+
+func runServer() {
+	fmt.Printf("Starting KECS Control Plane server on port %d with log level %s\n", port, logLevel)
+	if kubeconfig != "" {
+		fmt.Printf("Using kubeconfig: %s\n", kubeconfig)
+	} else {
+		fmt.Println("Using in-cluster configuration or default kubeconfig")
+	}
+	// TODO: Implement actual server startup logic
+}

--- a/internal/controlplane/cmd/version.go
+++ b/internal/controlplane/cmd/version.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version information
+var (
+	Version   = "0.1.0"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+
+	// versionCmd represents the version command
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version information",
+		Long:  `Print the version, git commit, and build date of the KECS Control Plane.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("KECS Control Plane\n")
+			fmt.Printf("Version:    %s\n", Version)
+			fmt.Printf("Git commit: %s\n", GitCommit)
+			fmt.Printf("Built:      %s\n", BuildDate)
+		},
+	}
+)


### PR DESCRIPTION
## Overview
Added the basic implementation of KECS Control Plane. Implemented a CLI structure using cobra and made it executable from cmd/controlplane/main.go.

## Changes
- Set up Control Plane to be executable from cmd/controlplane/main.go
- Implemented CLI structure using cobra
- Added basic commands including server startup and version display
- Configured necessary flags (port, log level, kubeconfig, etc.)

## Verification
Verified with the following commands:
- `go run cmd/controlplane/main.go` - Default server startup
- `go run cmd/controlplane/main.go version` - Display version information
- `go run cmd/controlplane/main.go server --kubeconfig=~/.kube/config` - Explicit server startup

## Future Work
- Implement actual server startup logic
- Integration with Kubernetes API
- Implementation of ECS-compatible API endpoints