### PR TITLE
Add HTTP-based API server endpoints to Control Plane

### DIFF
--- a/internal/controlplane/api/account_setting.go
+++ b/internal/controlplane/api/account_setting.go
@@ -1,0 +1,188 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// AccountSetting represents an ECS account setting
+type AccountSetting struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// PutAccountSettingRequest represents the request to put an account setting
+type PutAccountSettingRequest struct {
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+	PrincipalArn string `json:"principalArn,omitempty"`
+}
+
+// PutAccountSettingResponse represents the response from putting an account setting
+type PutAccountSettingResponse struct {
+	Setting AccountSetting `json:"setting"`
+}
+
+// PutAccountSettingDefaultRequest represents the request to put an account setting default
+type PutAccountSettingDefaultRequest struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// PutAccountSettingDefaultResponse represents the response from putting an account setting default
+type PutAccountSettingDefaultResponse struct {
+	Setting AccountSetting `json:"setting"`
+}
+
+// DeleteAccountSettingRequest represents the request to delete an account setting
+type DeleteAccountSettingRequest struct {
+	Name         string `json:"name"`
+	PrincipalArn string `json:"principalArn,omitempty"`
+}
+
+// DeleteAccountSettingResponse represents the response from deleting an account setting
+type DeleteAccountSettingResponse struct {
+	Setting AccountSetting `json:"setting"`
+}
+
+// ListAccountSettingsRequest represents the request to list account settings
+type ListAccountSettingsRequest struct {
+	Name         string `json:"name,omitempty"`
+	Value        string `json:"value,omitempty"`
+	PrincipalArn string `json:"principalArn,omitempty"`
+	EffectiveSettings bool `json:"effectiveSettings,omitempty"`
+	NextToken    string `json:"nextToken,omitempty"`
+	MaxResults   int    `json:"maxResults,omitempty"`
+}
+
+// ListAccountSettingsResponse represents the response from listing account settings
+type ListAccountSettingsResponse struct {
+	Settings  []AccountSetting `json:"settings"`
+	NextToken string           `json:"nextToken,omitempty"`
+}
+
+// registerAccountSettingEndpoints registers all account setting-related API endpoints
+func (s *Server) registerAccountSettingEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/putaccountsetting", s.handlePutAccountSetting)
+	mux.HandleFunc("/v1/putaccountsettingdefault", s.handlePutAccountSettingDefault)
+	mux.HandleFunc("/v1/deleteaccountsetting", s.handleDeleteAccountSetting)
+	mux.HandleFunc("/v1/listaccountsettings", s.handleListAccountSettings)
+}
+
+// handlePutAccountSetting handles the PutAccountSetting API endpoint
+func (s *Server) handlePutAccountSetting(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req PutAccountSettingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual account setting update logic
+
+	// For now, return a mock response
+	resp := PutAccountSettingResponse{
+		Setting: AccountSetting{
+			Name:  req.Name,
+			Value: req.Value,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handlePutAccountSettingDefault handles the PutAccountSettingDefault API endpoint
+func (s *Server) handlePutAccountSettingDefault(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req PutAccountSettingDefaultRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual account setting default update logic
+
+	// For now, return a mock response
+	resp := PutAccountSettingDefaultResponse{
+		Setting: AccountSetting{
+			Name:  req.Name,
+			Value: req.Value,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteAccountSetting handles the DeleteAccountSetting API endpoint
+func (s *Server) handleDeleteAccountSetting(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteAccountSettingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual account setting deletion logic
+
+	// For now, return a mock response
+	resp := DeleteAccountSettingResponse{
+		Setting: AccountSetting{
+			Name:  req.Name,
+			Value: "",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListAccountSettings handles the ListAccountSettings API endpoint
+func (s *Server) handleListAccountSettings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListAccountSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual account setting listing logic
+
+	// For now, return a mock response with some default settings
+	resp := ListAccountSettingsResponse{
+		Settings: []AccountSetting{
+			{
+				Name:  "serviceLongArnFormat",
+				Value: "enabled",
+			},
+			{
+				Name:  "taskLongArnFormat",
+				Value: "enabled",
+			},
+			{
+				Name:  "containerInstanceLongArnFormat",
+				Value: "enabled",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/attribute.go
+++ b/internal/controlplane/api/attribute.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// PutAttributesRequest represents the request to put attributes
+type PutAttributesRequest struct {
+	Cluster     string      `json:"cluster,omitempty"`
+	Attributes  []Attribute `json:"attributes"`
+}
+
+// PutAttributesResponse represents the response from putting attributes
+type PutAttributesResponse struct {
+	Attributes []Attribute `json:"attributes"`
+}
+
+// DeleteAttributesRequest represents the request to delete attributes
+type DeleteAttributesRequest struct {
+	Cluster     string      `json:"cluster,omitempty"`
+	Attributes  []Attribute `json:"attributes"`
+}
+
+// DeleteAttributesResponse represents the response from deleting attributes
+type DeleteAttributesResponse struct {
+	Attributes []Attribute `json:"attributes"`
+}
+
+// ListAttributesRequest represents the request to list attributes
+type ListAttributesRequest struct {
+	Cluster            string `json:"cluster,omitempty"`
+	TargetType         string `json:"targetType,omitempty"`
+	AttributeName      string `json:"attributeName,omitempty"`
+	AttributeValue     string `json:"attributeValue,omitempty"`
+	NextToken          string `json:"nextToken,omitempty"`
+	MaxResults         int    `json:"maxResults,omitempty"`
+}
+
+// ListAttributesResponse represents the response from listing attributes
+type ListAttributesResponse struct {
+	Attributes []Attribute `json:"attributes"`
+	NextToken  string      `json:"nextToken,omitempty"`
+}
+
+// registerAttributeEndpoints registers all attribute-related API endpoints
+func (s *Server) registerAttributeEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/putattributes", s.handlePutAttributes)
+	mux.HandleFunc("/v1/deleteattributes", s.handleDeleteAttributes)
+	mux.HandleFunc("/v1/listattributes", s.handleListAttributes)
+}
+
+// handlePutAttributes handles the PutAttributes API endpoint
+func (s *Server) handlePutAttributes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req PutAttributesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual attribute creation logic
+
+	// For now, return a mock response
+	resp := PutAttributesResponse{
+		Attributes: req.Attributes,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteAttributes handles the DeleteAttributes API endpoint
+func (s *Server) handleDeleteAttributes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteAttributesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual attribute deletion logic
+
+	// For now, return a mock response
+	resp := DeleteAttributesResponse{
+		Attributes: req.Attributes,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListAttributes handles the ListAttributes API endpoint
+func (s *Server) handleListAttributes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListAttributesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual attribute listing logic
+
+	// For now, return a mock response
+	resp := ListAttributesResponse{
+		Attributes: []Attribute{
+			{
+				Name:  "ecs.instance-type",
+				Value: "t3.medium",
+			},
+			{
+				Name:  "ecs.availability-zone",
+				Value: "us-west-2a",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/capacity_provider.go
+++ b/internal/controlplane/api/capacity_provider.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// CapacityProvider represents an ECS capacity provider
+type CapacityProvider struct {
+	CapacityProviderArn          string                       `json:"capacityProviderArn,omitempty"`
+	Name                         string                       `json:"name"`
+	Status                       string                       `json:"status,omitempty"`
+	AutoScalingGroupProvider     *AutoScalingGroupProvider    `json:"autoScalingGroupProvider,omitempty"`
+	UpdateStatus                 string                       `json:"updateStatus,omitempty"`
+	UpdateStatusReason           string                       `json:"updateStatusReason,omitempty"`
+	Tags                         []Tag                        `json:"tags,omitempty"`
+}
+
+// AutoScalingGroupProvider represents an auto scaling group provider for a capacity provider
+type AutoScalingGroupProvider struct {
+	AutoScalingGroupArn            string                     `json:"autoScalingGroupArn"`
+	ManagedScaling                 *ManagedScaling            `json:"managedScaling,omitempty"`
+	ManagedTerminationProtection   string                     `json:"managedTerminationProtection,omitempty"`
+	ManagedDraining                string                     `json:"managedDraining,omitempty"`
+}
+
+// ManagedScaling represents managed scaling for an auto scaling group provider
+type ManagedScaling struct {
+	Status                          string                    `json:"status,omitempty"`
+	TargetCapacity                  int                       `json:"targetCapacity,omitempty"`
+	MinimumScalingStepSize          int                       `json:"minimumScalingStepSize,omitempty"`
+	MaximumScalingStepSize          int                       `json:"maximumScalingStepSize,omitempty"`
+	InstanceWarmupPeriod            int                       `json:"instanceWarmupPeriod,omitempty"`
+}
+
+// CreateCapacityProviderRequest represents the request to create a capacity provider
+type CreateCapacityProviderRequest struct {
+	Name                         string                       `json:"name"`
+	AutoScalingGroupProvider     *AutoScalingGroupProvider    `json:"autoScalingGroupProvider"`
+	Tags                         []Tag                        `json:"tags,omitempty"`
+}
+
+// CreateCapacityProviderResponse represents the response from creating a capacity provider
+type CreateCapacityProviderResponse struct {
+	CapacityProvider CapacityProvider `json:"capacityProvider"`
+}
+
+// UpdateCapacityProviderRequest represents the request to update a capacity provider
+type UpdateCapacityProviderRequest struct {
+	Name                         string                       `json:"name"`
+	AutoScalingGroupProvider     *AutoScalingGroupProvider    `json:"autoScalingGroupProvider"`
+}
+
+// UpdateCapacityProviderResponse represents the response from updating a capacity provider
+type UpdateCapacityProviderResponse struct {
+	CapacityProvider CapacityProvider `json:"capacityProvider"`
+}
+
+// DeleteCapacityProviderRequest represents the request to delete a capacity provider
+type DeleteCapacityProviderRequest struct {
+	CapacityProvider string `json:"capacityProvider"`
+}
+
+// DeleteCapacityProviderResponse represents the response from deleting a capacity provider
+type DeleteCapacityProviderResponse struct {
+	CapacityProvider CapacityProvider `json:"capacityProvider"`
+}
+
+// DescribeCapacityProvidersRequest represents the request to describe capacity providers
+type DescribeCapacityProvidersRequest struct {
+	CapacityProviders []string `json:"capacityProviders,omitempty"`
+	Include           []string `json:"include,omitempty"`
+}
+
+// DescribeCapacityProvidersResponse represents the response from describing capacity providers
+type DescribeCapacityProvidersResponse struct {
+	CapacityProviders []CapacityProvider `json:"capacityProviders"`
+	Failures          []Failure          `json:"failures,omitempty"`
+}
+
+// PutClusterCapacityProvidersRequest represents the request to put cluster capacity providers
+type PutClusterCapacityProvidersRequest struct {
+	Cluster                       string             `json:"cluster"`
+	CapacityProviders             []string           `json:"capacityProviders"`
+	DefaultCapacityProviderStrategy []CapacityStrategy `json:"defaultCapacityProviderStrategy"`
+}
+
+// PutClusterCapacityProvidersResponse represents the response from putting cluster capacity providers
+type PutClusterCapacityProvidersResponse struct {
+	Cluster Cluster `json:"cluster"`
+}
+
+// registerCapacityProviderEndpoints registers all capacity provider-related API endpoints
+func (s *Server) registerCapacityProviderEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/createcapacityprovider", s.handleCreateCapacityProvider)
+	mux.HandleFunc("/v1/updatecapacityprovider", s.handleUpdateCapacityProvider)
+	mux.HandleFunc("/v1/deletecapacityprovider", s.handleDeleteCapacityProvider)
+	mux.HandleFunc("/v1/describecapacityproviders", s.handleDescribeCapacityProviders)
+	mux.HandleFunc("/v1/putclustercapacityproviders", s.handlePutClusterCapacityProviders)
+}
+
+// handleCreateCapacityProvider handles the CreateCapacityProvider API endpoint
+func (s *Server) handleCreateCapacityProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req CreateCapacityProviderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual capacity provider creation logic
+
+	// For now, return a mock response
+	resp := CreateCapacityProviderResponse{
+		CapacityProvider: CapacityProvider{
+			CapacityProviderArn:      "arn:aws:ecs:region:account:capacity-provider/" + req.Name,
+			Name:                     req.Name,
+			Status:                   "ACTIVE",
+			AutoScalingGroupProvider: req.AutoScalingGroupProvider,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUpdateCapacityProvider handles the UpdateCapacityProvider API endpoint
+func (s *Server) handleUpdateCapacityProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateCapacityProviderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual capacity provider update logic
+
+	// For now, return a mock response
+	resp := UpdateCapacityProviderResponse{
+		CapacityProvider: CapacityProvider{
+			CapacityProviderArn:      "arn:aws:ecs:region:account:capacity-provider/" + req.Name,
+			Name:                     req.Name,
+			Status:                   "ACTIVE",
+			AutoScalingGroupProvider: req.AutoScalingGroupProvider,
+			UpdateStatus:             "UPDATE_COMPLETE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteCapacityProvider handles the DeleteCapacityProvider API endpoint
+func (s *Server) handleDeleteCapacityProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteCapacityProviderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual capacity provider deletion logic
+
+	// For now, return a mock response
+	resp := DeleteCapacityProviderResponse{
+		CapacityProvider: CapacityProvider{
+			CapacityProviderArn: "arn:aws:ecs:region:account:capacity-provider/" + req.CapacityProvider,
+			Name:               req.CapacityProvider,
+			Status:             "INACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeCapacityProviders handles the DescribeCapacityProviders API endpoint
+func (s *Server) handleDescribeCapacityProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeCapacityProvidersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual capacity provider description logic
+
+	// For now, return a mock response
+	capacityProviders := []CapacityProvider{}
+	
+	if len(req.CapacityProviders) > 0 {
+		for _, name := range req.CapacityProviders {
+			capacityProviders = append(capacityProviders, CapacityProvider{
+				CapacityProviderArn: "arn:aws:ecs:region:account:capacity-provider/" + name,
+				Name:               name,
+				Status:             "ACTIVE",
+			})
+		}
+	} else {
+		// Return default capacity providers if none specified
+		capacityProviders = append(capacityProviders, CapacityProvider{
+			CapacityProviderArn: "arn:aws:ecs:region:account:capacity-provider/FARGATE",
+			Name:               "FARGATE",
+			Status:             "ACTIVE",
+		})
+		capacityProviders = append(capacityProviders, CapacityProvider{
+			CapacityProviderArn: "arn:aws:ecs:region:account:capacity-provider/FARGATE_SPOT",
+			Name:               "FARGATE_SPOT",
+			Status:             "ACTIVE",
+		})
+	}
+
+	resp := DescribeCapacityProvidersResponse{
+		CapacityProviders: capacityProviders,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handlePutClusterCapacityProviders handles the PutClusterCapacityProviders API endpoint
+func (s *Server) handlePutClusterCapacityProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req PutClusterCapacityProvidersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual cluster capacity provider update logic
+
+	// For now, return a mock response
+	resp := PutClusterCapacityProvidersResponse{
+		Cluster: Cluster{
+			ClusterArn:                    "arn:aws:ecs:region:account:cluster/" + req.Cluster,
+			ClusterName:                   req.Cluster,
+			Status:                        "ACTIVE",
+			CapacityProviders:             req.CapacityProviders,
+			DefaultCapacityProviderStrategy: req.DefaultCapacityProviderStrategy,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/cluster.go
+++ b/internal/controlplane/api/cluster.go
@@ -1,0 +1,272 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Cluster represents an ECS cluster
+type Cluster struct {
+	ClusterArn                        string            `json:"clusterArn,omitempty"`
+	ClusterName                       string            `json:"clusterName"`
+	Status                            string            `json:"status,omitempty"`
+	RegisteredContainerInstancesCount int               `json:"registeredContainerInstancesCount,omitempty"`
+	RunningTasksCount                 int               `json:"runningTasksCount,omitempty"`
+	PendingTasksCount                 int               `json:"pendingTasksCount,omitempty"`
+	ActiveServicesCount               int               `json:"activeServicesCount,omitempty"`
+	Statistics                        []KeyValuePair    `json:"statistics,omitempty"`
+	Tags                              []Tag             `json:"tags,omitempty"`
+	Settings                          []ClusterSetting  `json:"settings,omitempty"`
+	CapacityProviders                 []string          `json:"capacityProviders,omitempty"`
+	DefaultCapacityProviderStrategy   []CapacityStrategy `json:"defaultCapacityProviderStrategy,omitempty"`
+	Attachments                       []Attachment      `json:"attachments,omitempty"`
+	AttachmentsStatus                 string            `json:"attachmentsStatus,omitempty"`
+}
+
+// ClusterSetting represents a setting for an ECS cluster
+type ClusterSetting struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+// CapacityStrategy represents a capacity provider strategy
+type CapacityStrategy struct {
+	CapacityProvider string `json:"capacityProvider"`
+	Weight           int    `json:"weight,omitempty"`
+	Base             int    `json:"base,omitempty"`
+}
+
+// KeyValuePair represents a key-value pair
+type KeyValuePair struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+// Tag represents a resource tag
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value,omitempty"`
+}
+
+// Attachment represents an attachment to a resource
+type Attachment struct {
+	Id                 string            `json:"id,omitempty"`
+	Type               string            `json:"type,omitempty"`
+	Status             string            `json:"status,omitempty"`
+	Details            []KeyValuePair    `json:"details,omitempty"`
+}
+
+// CreateClusterRequest represents the request to create a cluster
+type CreateClusterRequest struct {
+	ClusterName                     string            `json:"clusterName,omitempty"`
+	Tags                            []Tag             `json:"tags,omitempty"`
+	Settings                        []ClusterSetting  `json:"settings,omitempty"`
+	CapacityProviders               []string          `json:"capacityProviders,omitempty"`
+	DefaultCapacityProviderStrategy []CapacityStrategy `json:"defaultCapacityProviderStrategy,omitempty"`
+}
+
+// CreateClusterResponse represents the response from creating a cluster
+type CreateClusterResponse struct {
+	Cluster Cluster `json:"cluster"`
+}
+
+// DescribeClustersRequest represents the request to describe clusters
+type DescribeClustersRequest struct {
+	Clusters []string `json:"clusters,omitempty"`
+	Include  []string `json:"include,omitempty"`
+}
+
+// DescribeClustersResponse represents the response from describing clusters
+type DescribeClustersResponse struct {
+	Clusters []Cluster `json:"clusters"`
+	Failures []Failure `json:"failures,omitempty"`
+}
+
+// ListClustersRequest represents the request to list clusters
+type ListClustersRequest struct {
+	MaxResults int    `json:"maxResults,omitempty"`
+	NextToken  string `json:"nextToken,omitempty"`
+}
+
+// ListClustersResponse represents the response from listing clusters
+type ListClustersResponse struct {
+	ClusterArns []string `json:"clusterArns"`
+	NextToken   string   `json:"nextToken,omitempty"`
+}
+
+// DeleteClusterRequest represents the request to delete a cluster
+type DeleteClusterRequest struct {
+	Cluster string `json:"cluster"`
+}
+
+// DeleteClusterResponse represents the response from deleting a cluster
+type DeleteClusterResponse struct {
+	Cluster Cluster `json:"cluster"`
+}
+
+// Failure represents a failure in an API operation
+type Failure struct {
+	Arn    string `json:"arn,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// UpdateClusterRequest represents the request to update a cluster
+type UpdateClusterRequest struct {
+	Cluster                         string            `json:"cluster"`
+	Settings                        []ClusterSetting  `json:"settings,omitempty"`
+	CapacityProviders               []string          `json:"capacityProviders,omitempty"`
+	DefaultCapacityProviderStrategy []CapacityStrategy `json:"defaultCapacityProviderStrategy,omitempty"`
+}
+
+// UpdateClusterResponse represents the response from updating a cluster
+type UpdateClusterResponse struct {
+	Cluster Cluster `json:"cluster"`
+}
+
+// registerClusterEndpoints registers all cluster-related API endpoints
+func (s *Server) registerClusterEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/createcluster", s.handleCreateCluster)
+	mux.HandleFunc("/v1/describeclusters", s.handleDescribeClusters)
+	mux.HandleFunc("/v1/listclusters", s.handleListClusters)
+	mux.HandleFunc("/v1/deletecluster", s.handleDeleteCluster)
+	mux.HandleFunc("/v1/updatecluster", s.handleUpdateCluster)
+}
+
+// handleCreateCluster handles the CreateCluster API endpoint
+func (s *Server) handleCreateCluster(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req CreateClusterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual cluster creation logic
+
+	// For now, return a mock response
+	resp := CreateClusterResponse{
+		Cluster: Cluster{
+			ClusterArn:  "arn:aws:ecs:region:account:cluster/" + req.ClusterName,
+			ClusterName: req.ClusterName,
+			Status:      "ACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeClusters handles the DescribeClusters API endpoint
+func (s *Server) handleDescribeClusters(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeClustersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual cluster description logic
+
+	// For now, return a mock response
+	resp := DescribeClustersResponse{
+		Clusters: []Cluster{
+			{
+				ClusterArn:  "arn:aws:ecs:region:account:cluster/default",
+				ClusterName: "default",
+				Status:      "ACTIVE",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListClusters handles the ListClusters API endpoint
+func (s *Server) handleListClusters(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListClustersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual cluster listing logic
+
+	// For now, return a mock response
+	resp := ListClustersResponse{
+		ClusterArns: []string{"arn:aws:ecs:region:account:cluster/default"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteCluster handles the DeleteCluster API endpoint
+func (s *Server) handleDeleteCluster(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteClusterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual cluster deletion logic
+
+	// For now, return a mock response
+	resp := DeleteClusterResponse{
+		Cluster: Cluster{
+			ClusterArn:  "arn:aws:ecs:region:account:cluster/" + req.Cluster,
+			ClusterName: req.Cluster,
+			Status:      "INACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUpdateCluster handles the UpdateCluster API endpoint
+func (s *Server) handleUpdateCluster(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateClusterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual cluster update logic
+
+	// For now, return a mock response
+	resp := UpdateClusterResponse{
+		Cluster: Cluster{
+			ClusterArn:  "arn:aws:ecs:region:account:cluster/" + req.Cluster,
+			ClusterName: req.Cluster,
+			Status:      "ACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/container_instance.go
+++ b/internal/controlplane/api/container_instance.go
@@ -1,0 +1,328 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ContainerInstance represents an ECS container instance
+type ContainerInstance struct {
+	ContainerInstanceArn       string                 `json:"containerInstanceArn,omitempty"`
+	Ec2InstanceId              string                 `json:"ec2InstanceId,omitempty"`
+	Version                    int                    `json:"version,omitempty"`
+	VersionInfo                *VersionInfo           `json:"versionInfo,omitempty"`
+	RemainingResources         []Resource             `json:"remainingResources,omitempty"`
+	RegisteredResources        []Resource             `json:"registeredResources,omitempty"`
+	Status                     string                 `json:"status,omitempty"`
+	StatusReason               string                 `json:"statusReason,omitempty"`
+	AgentConnected             bool                   `json:"agentConnected,omitempty"`
+	RunningTasksCount          int                    `json:"runningTasksCount,omitempty"`
+	PendingTasksCount          int                    `json:"pendingTasksCount,omitempty"`
+	AgentUpdateStatus          string                 `json:"agentUpdateStatus,omitempty"`
+	Attributes                 []Attribute            `json:"attributes,omitempty"`
+	RegisteredAt               string                 `json:"registeredAt,omitempty"`
+	Attachments                []Attachment           `json:"attachments,omitempty"`
+	Tags                       []Tag                  `json:"tags,omitempty"`
+	HealthStatus               string                 `json:"healthStatus,omitempty"`
+	CapacityProviderName       string                 `json:"capacityProviderName,omitempty"`
+}
+
+// VersionInfo represents version information for a container instance
+type VersionInfo struct {
+	AgentVersion  string `json:"agentVersion,omitempty"`
+	AgentHash     string `json:"agentHash,omitempty"`
+	DockerVersion string `json:"dockerVersion,omitempty"`
+}
+
+// Resource represents a resource for a container instance
+type Resource struct {
+	Name           string         `json:"name"`
+	Type           string         `json:"type"`
+	DoubleValue    float64        `json:"doubleValue,omitempty"`
+	LongValue      int64          `json:"longValue,omitempty"`
+	IntegerValue   int            `json:"integerValue,omitempty"`
+	StringSetValue []string       `json:"stringSetValue,omitempty"`
+}
+
+// RegisterContainerInstanceRequest represents the request to register a container instance
+type RegisterContainerInstanceRequest struct {
+	Cluster                       string      `json:"cluster,omitempty"`
+	InstanceIdentityDocumentAndSignature string `json:"instanceIdentityDocumentAndSignature,omitempty"`
+	InstanceIdentityDocument      string      `json:"instanceIdentityDocument,omitempty"`
+	TotalResources                []Resource  `json:"totalResources,omitempty"`
+	VersionInfo                   *VersionInfo `json:"versionInfo,omitempty"`
+	ContainerInstanceArn          string      `json:"containerInstanceArn,omitempty"`
+	Attributes                    []Attribute `json:"attributes,omitempty"`
+	Tags                          []Tag       `json:"tags,omitempty"`
+}
+
+// RegisterContainerInstanceResponse represents the response from registering a container instance
+type RegisterContainerInstanceResponse struct {
+	ContainerInstance ContainerInstance `json:"containerInstance"`
+}
+
+// DeregisterContainerInstanceRequest represents the request to deregister a container instance
+type DeregisterContainerInstanceRequest struct {
+	Cluster           string `json:"cluster,omitempty"`
+	ContainerInstance string `json:"containerInstance"`
+	Force             bool   `json:"force,omitempty"`
+}
+
+// DeregisterContainerInstanceResponse represents the response from deregistering a container instance
+type DeregisterContainerInstanceResponse struct {
+	ContainerInstance ContainerInstance `json:"containerInstance"`
+}
+
+// DescribeContainerInstancesRequest represents the request to describe container instances
+type DescribeContainerInstancesRequest struct {
+	Cluster            string   `json:"cluster,omitempty"`
+	ContainerInstances []string `json:"containerInstances"`
+	Include            []string `json:"include,omitempty"`
+}
+
+// DescribeContainerInstancesResponse represents the response from describing container instances
+type DescribeContainerInstancesResponse struct {
+	ContainerInstances []ContainerInstance `json:"containerInstances"`
+	Failures           []Failure           `json:"failures,omitempty"`
+}
+
+// ListContainerInstancesRequest represents the request to list container instances
+type ListContainerInstancesRequest struct {
+	Cluster    string `json:"cluster,omitempty"`
+	Filter     string `json:"filter,omitempty"`
+	NextToken  string `json:"nextToken,omitempty"`
+	MaxResults int    `json:"maxResults,omitempty"`
+	Status     string `json:"status,omitempty"`
+}
+
+// ListContainerInstancesResponse represents the response from listing container instances
+type ListContainerInstancesResponse struct {
+	ContainerInstanceArns []string `json:"containerInstanceArns"`
+	NextToken             string   `json:"nextToken,omitempty"`
+}
+
+// UpdateContainerInstancesStateRequest represents the request to update container instances state
+type UpdateContainerInstancesStateRequest struct {
+	Cluster            string   `json:"cluster,omitempty"`
+	ContainerInstances []string `json:"containerInstances"`
+	Status             string   `json:"status"`
+}
+
+// UpdateContainerInstancesStateResponse represents the response from updating container instances state
+type UpdateContainerInstancesStateResponse struct {
+	ContainerInstances []ContainerInstance `json:"containerInstances"`
+	Failures           []Failure           `json:"failures,omitempty"`
+}
+
+// UpdateContainerAgentRequest represents the request to update a container agent
+type UpdateContainerAgentRequest struct {
+	Cluster           string `json:"cluster,omitempty"`
+	ContainerInstance string `json:"containerInstance"`
+}
+
+// UpdateContainerAgentResponse represents the response from updating a container agent
+type UpdateContainerAgentResponse struct {
+	ContainerInstance ContainerInstance `json:"containerInstance"`
+}
+
+// registerContainerInstanceEndpoints registers all container instance-related API endpoints
+func (s *Server) registerContainerInstanceEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/registercontainerinstance", s.handleRegisterContainerInstance)
+	mux.HandleFunc("/v1/deregistercontainerinstance", s.handleDeregisterContainerInstance)
+	mux.HandleFunc("/v1/describecontainerinstances", s.handleDescribeContainerInstances)
+	mux.HandleFunc("/v1/listcontainerinstances", s.handleListContainerInstances)
+	mux.HandleFunc("/v1/updatecontainerinstancesstate", s.handleUpdateContainerInstancesState)
+	mux.HandleFunc("/v1/updatecontaineragent", s.handleUpdateContainerAgent)
+}
+
+// handleRegisterContainerInstance handles the RegisterContainerInstance API endpoint
+func (s *Server) handleRegisterContainerInstance(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req RegisterContainerInstanceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual container instance registration logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	containerInstanceArn := req.ContainerInstanceArn
+	if containerInstanceArn == "" {
+		containerInstanceArn = "arn:aws:ecs:region:account:container-instance/" + cluster + "/container-instance-id"
+	}
+
+	resp := RegisterContainerInstanceResponse{
+		ContainerInstance: ContainerInstance{
+			ContainerInstanceArn: containerInstanceArn,
+			Status:              "ACTIVE",
+			AgentConnected:      true,
+			RegisteredAt:        "2025-05-15T00:40:35+09:00",
+			VersionInfo:         req.VersionInfo,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeregisterContainerInstance handles the DeregisterContainerInstance API endpoint
+func (s *Server) handleDeregisterContainerInstance(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeregisterContainerInstanceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual container instance deregistration logic
+
+	// For now, return a mock response
+	// Note: In a real implementation, we would use the cluster information
+
+	resp := DeregisterContainerInstanceResponse{
+		ContainerInstance: ContainerInstance{
+			ContainerInstanceArn: req.ContainerInstance,
+			Status:              "INACTIVE",
+			AgentConnected:      false,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeContainerInstances handles the DescribeContainerInstances API endpoint
+func (s *Server) handleDescribeContainerInstances(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeContainerInstancesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual container instance description logic
+
+	// For now, return a mock response
+	// Note: In a real implementation, we would use the cluster information from the request
+
+	resp := DescribeContainerInstancesResponse{
+		ContainerInstances: []ContainerInstance{
+			{
+				ContainerInstanceArn: req.ContainerInstances[0],
+				Status:              "ACTIVE",
+				AgentConnected:      true,
+				RunningTasksCount:   0,
+				PendingTasksCount:   0,
+				RegisteredAt:        "2025-05-15T00:40:35+09:00",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListContainerInstances handles the ListContainerInstances API endpoint
+func (s *Server) handleListContainerInstances(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListContainerInstancesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual container instance listing logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := ListContainerInstancesResponse{
+		ContainerInstanceArns: []string{"arn:aws:ecs:region:account:container-instance/" + cluster + "/container-instance-id"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUpdateContainerInstancesState handles the UpdateContainerInstancesState API endpoint
+func (s *Server) handleUpdateContainerInstancesState(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateContainerInstancesStateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual container instance state update logic
+
+	// For now, return a mock response
+	resp := UpdateContainerInstancesStateResponse{
+		ContainerInstances: []ContainerInstance{
+			{
+				ContainerInstanceArn: req.ContainerInstances[0],
+				Status:              req.Status,
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUpdateContainerAgent handles the UpdateContainerAgent API endpoint
+func (s *Server) handleUpdateContainerAgent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateContainerAgentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual container agent update logic
+
+	// For now, return a mock response
+	resp := UpdateContainerAgentResponse{
+		ContainerInstance: ContainerInstance{
+			ContainerInstanceArn: req.ContainerInstance,
+			Status:              "ACTIVE",
+			AgentConnected:      true,
+			AgentUpdateStatus:   "UPDATED",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/server.go
+++ b/internal/controlplane/api/server.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Server represents the HTTP API server for KECS Control Plane
+type Server struct {
+	httpServer *http.Server
+	port       int
+	kubeconfig string
+}
+
+// NewServer creates a new API server instance
+func NewServer(port int, kubeconfig string) *Server {
+	return &Server{
+		port:       port,
+		kubeconfig: kubeconfig,
+	}
+}
+
+// Start starts the HTTP server
+func (s *Server) Start() error {
+	router := s.setupRoutes()
+
+	s.httpServer = &http.Server{
+		Addr:         fmt.Sprintf(":%d", s.port),
+		Handler:      router,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	log.Printf("Starting API server on port %d", s.port)
+	return s.httpServer.ListenAndServe()
+}
+
+// Stop gracefully stops the HTTP server
+func (s *Server) Stop(ctx context.Context) error {
+	log.Println("Shutting down API server...")
+	return s.httpServer.Shutdown(ctx)
+}
+
+// setupRoutes configures all the API routes
+func (s *Server) setupRoutes() http.Handler {
+	mux := http.NewServeMux()
+
+	// Register ECS API endpoints
+	s.registerClusterEndpoints(mux)
+	s.registerTaskDefinitionEndpoints(mux)
+	s.registerTaskEndpoints(mux)
+	s.registerServiceEndpoints(mux)
+	s.registerContainerInstanceEndpoints(mux)
+	s.registerCapacityProviderEndpoints(mux)
+	s.registerAccountSettingEndpoints(mux)
+	s.registerTagEndpoints(mux)
+	s.registerAttributeEndpoints(mux)
+	s.registerTaskSetEndpoints(mux)
+
+	// Health check endpoint
+	mux.HandleFunc("/health", s.handleHealthCheck)
+
+	return mux
+}
+
+// handleHealthCheck handles the health check endpoint
+func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}

--- a/internal/controlplane/api/service.go
+++ b/internal/controlplane/api/service.go
@@ -1,0 +1,493 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Service represents an ECS service
+type Service struct {
+	ServiceArn                   string                  `json:"serviceArn,omitempty"`
+	ServiceName                  string                  `json:"serviceName"`
+	ClusterArn                   string                  `json:"clusterArn,omitempty"`
+	LoadBalancers                []LoadBalancer          `json:"loadBalancers,omitempty"`
+	ServiceRegistries            []ServiceRegistry       `json:"serviceRegistries,omitempty"`
+	Status                       string                  `json:"status,omitempty"`
+	DesiredCount                 int                     `json:"desiredCount"`
+	RunningCount                 int                     `json:"runningCount,omitempty"`
+	PendingCount                 int                     `json:"pendingCount,omitempty"`
+	LaunchType                   string                  `json:"launchType,omitempty"`
+	CapacityProviderStrategy     []CapacityStrategy      `json:"capacityProviderStrategy,omitempty"`
+	PlatformVersion              string                  `json:"platformVersion,omitempty"`
+	PlatformFamily               string                  `json:"platformFamily,omitempty"`
+	TaskDefinition               string                  `json:"taskDefinition"`
+	DeploymentConfiguration      *DeploymentConfiguration `json:"deploymentConfiguration,omitempty"`
+	TaskSets                     []TaskSet               `json:"taskSets,omitempty"`
+	Deployments                  []Deployment            `json:"deployments,omitempty"`
+	RoleArn                      string                  `json:"roleArn,omitempty"`
+	Events                       []ServiceEvent          `json:"events,omitempty"`
+	CreatedAt                    string                  `json:"createdAt,omitempty"`
+	PlacementConstraints         []TaskPlacementConstraint `json:"placementConstraints,omitempty"`
+	PlacementStrategy            []PlacementStrategy     `json:"placementStrategy,omitempty"`
+	NetworkConfiguration         *NetworkConfiguration   `json:"networkConfiguration,omitempty"`
+	HealthCheckGracePeriodSeconds int                    `json:"healthCheckGracePeriodSeconds,omitempty"`
+	SchedulingStrategy           string                  `json:"schedulingStrategy,omitempty"`
+	DeploymentController         *DeploymentController   `json:"deploymentController,omitempty"`
+	Tags                         []Tag                   `json:"tags,omitempty"`
+	CreatedBy                    string                  `json:"createdBy,omitempty"`
+	EnableECSManagedTags         bool                    `json:"enableECSManagedTags,omitempty"`
+	PropagateTags                string                  `json:"propagateTags,omitempty"`
+	EnableExecuteCommand         bool                    `json:"enableExecuteCommand,omitempty"`
+}
+
+// LoadBalancer represents a load balancer configuration for a service
+type LoadBalancer struct {
+	TargetGroupArn string `json:"targetGroupArn,omitempty"`
+	LoadBalancerName string `json:"loadBalancerName,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	ContainerPort int `json:"containerPort,omitempty"`
+}
+
+// ServiceRegistry represents a service registry for a service
+type ServiceRegistry struct {
+	RegistryArn string `json:"registryArn,omitempty"`
+	Port int `json:"port,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	ContainerPort int `json:"containerPort,omitempty"`
+}
+
+// DeploymentConfiguration represents a deployment configuration for a service
+type DeploymentConfiguration struct {
+	DeploymentCircuitBreaker *DeploymentCircuitBreaker `json:"deploymentCircuitBreaker,omitempty"`
+	MaximumPercent int `json:"maximumPercent,omitempty"`
+	MinimumHealthyPercent int `json:"minimumHealthyPercent,omitempty"`
+	AlarmConfiguration *AlarmConfiguration `json:"alarmConfiguration,omitempty"`
+}
+
+// DeploymentCircuitBreaker represents a deployment circuit breaker for a service
+type DeploymentCircuitBreaker struct {
+	Enable bool `json:"enable"`
+	Rollback bool `json:"rollback"`
+}
+
+// AlarmConfiguration represents an alarm configuration for a service
+type AlarmConfiguration struct {
+	Alarms []Alarm `json:"alarms"`
+	Enable bool `json:"enable"`
+	RollBack bool `json:"rollBack"`
+}
+
+// Alarm represents an alarm for a service
+type Alarm struct {
+	AlarmName string `json:"alarmName"`
+	AlarmArn string `json:"alarmArn,omitempty"`
+}
+
+// TaskSet represents a task set for a service
+type TaskSet struct {
+	Id string `json:"id,omitempty"`
+	TaskSetArn string `json:"taskSetArn,omitempty"`
+	ServiceArn string `json:"serviceArn,omitempty"`
+	ClusterArn string `json:"clusterArn,omitempty"`
+	StartedBy string `json:"startedBy,omitempty"`
+	ExternalId string `json:"externalId,omitempty"`
+	Status string `json:"status,omitempty"`
+	TaskDefinition string `json:"taskDefinition,omitempty"`
+	ComputedDesiredCount int `json:"computedDesiredCount,omitempty"`
+	PendingCount int `json:"pendingCount,omitempty"`
+	RunningCount int `json:"runningCount,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+	LaunchType string `json:"launchType,omitempty"`
+	CapacityProviderStrategy []CapacityStrategy `json:"capacityProviderStrategy,omitempty"`
+	PlatformVersion string `json:"platformVersion,omitempty"`
+	PlatformFamily string `json:"platformFamily,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	LoadBalancers []LoadBalancer `json:"loadBalancers,omitempty"`
+	ServiceRegistries []ServiceRegistry `json:"serviceRegistries,omitempty"`
+	Scale *Scale `json:"scale,omitempty"`
+	StabilityStatus string `json:"stabilityStatus,omitempty"`
+	StabilityStatusAt string `json:"stabilityStatusAt,omitempty"`
+	Tags []Tag `json:"tags,omitempty"`
+}
+
+// Scale represents a scale configuration for a task set
+type Scale struct {
+	Value float64 `json:"value"`
+	Unit string `json:"unit,omitempty"`
+}
+
+// Deployment represents a deployment for a service
+type Deployment struct {
+	Id string `json:"id,omitempty"`
+	Status string `json:"status,omitempty"`
+	TaskDefinition string `json:"taskDefinition,omitempty"`
+	DesiredCount int `json:"desiredCount,omitempty"`
+	PendingCount int `json:"pendingCount,omitempty"`
+	RunningCount int `json:"runningCount,omitempty"`
+	FailedTasks int `json:"failedTasks,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+	CapacityProviderStrategy []CapacityStrategy `json:"capacityProviderStrategy,omitempty"`
+	LaunchType string `json:"launchType,omitempty"`
+	PlatformVersion string `json:"platformVersion,omitempty"`
+	PlatformFamily string `json:"platformFamily,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	RolloutState string `json:"rolloutState,omitempty"`
+	RolloutStateReason string `json:"rolloutStateReason,omitempty"`
+	ServiceConnectConfiguration *ServiceConnectConfiguration `json:"serviceConnectConfiguration,omitempty"`
+	ServiceConnectResources *ServiceConnectServiceResource `json:"serviceConnectResources,omitempty"`
+}
+
+// ServiceEvent represents an event for a service
+type ServiceEvent struct {
+	Id string `json:"id,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// NetworkConfiguration represents a network configuration for a service
+type NetworkConfiguration struct {
+	AwsvpcConfiguration *AwsVpcConfiguration `json:"awsvpcConfiguration,omitempty"`
+}
+
+// AwsVpcConfiguration represents an AWS VPC configuration for a service
+type AwsVpcConfiguration struct {
+	Subnets []string `json:"subnets"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+	AssignPublicIp string `json:"assignPublicIp,omitempty"`
+}
+
+// DeploymentController represents a deployment controller for a service
+type DeploymentController struct {
+	Type string `json:"type"`
+}
+
+// ServiceConnectConfiguration represents a service connect configuration for a service
+type ServiceConnectConfiguration struct {
+	Enabled bool `json:"enabled"`
+	Namespace string `json:"namespace,omitempty"`
+	Services []ServiceConnectService `json:"services,omitempty"`
+	LogConfiguration *LogConfiguration `json:"logConfiguration,omitempty"`
+}
+
+// ServiceConnectService represents a service connect service
+type ServiceConnectService struct {
+	PortName string `json:"portName"`
+	DiscoveryName string `json:"discoveryName,omitempty"`
+	ClientAliases []ServiceConnectClientAlias `json:"clientAliases,omitempty"`
+	IngressPortOverride int `json:"ingressPortOverride,omitempty"`
+	PortMappingName string `json:"portMappingName,omitempty"`
+	DiscoveryArn string `json:"discoveryArn,omitempty"`
+	Timeout *TimeoutConfiguration `json:"timeout,omitempty"`
+}
+
+// ServiceConnectClientAlias represents a service connect client alias
+type ServiceConnectClientAlias struct {
+	Port int `json:"port"`
+	DnsName string `json:"dnsName,omitempty"`
+}
+
+// TimeoutConfiguration represents a timeout configuration for a service connect service
+type TimeoutConfiguration struct {
+	IdleTimeoutSeconds int `json:"idleTimeoutSeconds,omitempty"`
+	PerRequestTimeoutSeconds int `json:"perRequestTimeoutSeconds,omitempty"`
+}
+
+// ServiceConnectServiceResource represents a service connect service resource
+type ServiceConnectServiceResource struct {
+	DiscoveryName string `json:"discoveryName,omitempty"`
+	DiscoveryArn string `json:"discoveryArn,omitempty"`
+}
+
+// CreateServiceRequest represents the request to create a service
+type CreateServiceRequest struct {
+	ServiceName string `json:"serviceName"`
+	TaskDefinition string `json:"taskDefinition"`
+	Cluster string `json:"cluster,omitempty"`
+	LoadBalancers []LoadBalancer `json:"loadBalancers,omitempty"`
+	ServiceRegistries []ServiceRegistry `json:"serviceRegistries,omitempty"`
+	DesiredCount int `json:"desiredCount,omitempty"`
+	ClientToken string `json:"clientToken,omitempty"`
+	LaunchType string `json:"launchType,omitempty"`
+	CapacityProviderStrategy []CapacityStrategy `json:"capacityProviderStrategy,omitempty"`
+	PlatformVersion string `json:"platformVersion,omitempty"`
+	PlatformFamily string `json:"platformFamily,omitempty"`
+	Role string `json:"role,omitempty"`
+	DeploymentConfiguration *DeploymentConfiguration `json:"deploymentConfiguration,omitempty"`
+	PlacementConstraints []TaskPlacementConstraint `json:"placementConstraints,omitempty"`
+	PlacementStrategy []PlacementStrategy `json:"placementStrategy,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	HealthCheckGracePeriodSeconds int `json:"healthCheckGracePeriodSeconds,omitempty"`
+	SchedulingStrategy string `json:"schedulingStrategy,omitempty"`
+	DeploymentController *DeploymentController `json:"deploymentController,omitempty"`
+	Tags []Tag `json:"tags,omitempty"`
+	EnableECSManagedTags bool `json:"enableECSManagedTags,omitempty"`
+	PropagateTags string `json:"propagateTags,omitempty"`
+	EnableExecuteCommand bool `json:"enableExecuteCommand,omitempty"`
+	ServiceConnectConfiguration *ServiceConnectConfiguration `json:"serviceConnectConfiguration,omitempty"`
+}
+
+// CreateServiceResponse represents the response from creating a service
+type CreateServiceResponse struct {
+	Service Service `json:"service"`
+}
+
+// UpdateServiceRequest represents the request to update a service
+type UpdateServiceRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	Service string `json:"service"`
+	DesiredCount int `json:"desiredCount,omitempty"`
+	TaskDefinition string `json:"taskDefinition,omitempty"`
+	CapacityProviderStrategy []CapacityStrategy `json:"capacityProviderStrategy,omitempty"`
+	DeploymentConfiguration *DeploymentConfiguration `json:"deploymentConfiguration,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	PlacementConstraints []TaskPlacementConstraint `json:"placementConstraints,omitempty"`
+	PlacementStrategy []PlacementStrategy `json:"placementStrategy,omitempty"`
+	PlatformVersion string `json:"platformVersion,omitempty"`
+	ForceNewDeployment bool `json:"forceNewDeployment,omitempty"`
+	HealthCheckGracePeriodSeconds int `json:"healthCheckGracePeriodSeconds,omitempty"`
+	EnableExecuteCommand bool `json:"enableExecuteCommand,omitempty"`
+	EnableECSManagedTags bool `json:"enableECSManagedTags,omitempty"`
+	LoadBalancers []LoadBalancer `json:"loadBalancers,omitempty"`
+	ServiceRegistries []ServiceRegistry `json:"serviceRegistries,omitempty"`
+	ServiceConnectConfiguration *ServiceConnectConfiguration `json:"serviceConnectConfiguration,omitempty"`
+}
+
+// UpdateServiceResponse represents the response from updating a service
+type UpdateServiceResponse struct {
+	Service Service `json:"service"`
+}
+
+// DeleteServiceRequest represents the request to delete a service
+type DeleteServiceRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	Service string `json:"service"`
+	Force bool `json:"force,omitempty"`
+}
+
+// DeleteServiceResponse represents the response from deleting a service
+type DeleteServiceResponse struct {
+	Service Service `json:"service"`
+}
+
+// DescribeServicesRequest represents the request to describe services
+type DescribeServicesRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	Services []string `json:"services"`
+	Include []string `json:"include,omitempty"`
+}
+
+// DescribeServicesResponse represents the response from describing services
+type DescribeServicesResponse struct {
+	Services []Service `json:"services"`
+	Failures []Failure `json:"failures,omitempty"`
+}
+
+// ListServicesRequest represents the request to list services
+type ListServicesRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	NextToken string `json:"nextToken,omitempty"`
+	MaxResults int `json:"maxResults,omitempty"`
+	LaunchType string `json:"launchType,omitempty"`
+	SchedulingStrategy string `json:"schedulingStrategy,omitempty"`
+}
+
+// ListServicesResponse represents the response from listing services
+type ListServicesResponse struct {
+	ServiceArns []string `json:"serviceArns"`
+	NextToken string `json:"nextToken,omitempty"`
+}
+
+// registerServiceEndpoints registers all service-related API endpoints
+func (s *Server) registerServiceEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/createservice", s.handleCreateService)
+	mux.HandleFunc("/v1/updateservice", s.handleUpdateService)
+	mux.HandleFunc("/v1/deleteservice", s.handleDeleteService)
+	mux.HandleFunc("/v1/describeservices", s.handleDescribeServices)
+	mux.HandleFunc("/v1/listservices", s.handleListServices)
+}
+
+// handleCreateService handles the CreateService API endpoint
+func (s *Server) handleCreateService(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req CreateServiceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual service creation logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := CreateServiceResponse{
+		Service: Service{
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.ServiceName,
+			ServiceName:    req.ServiceName,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			Status:         "ACTIVE",
+			DesiredCount:   req.DesiredCount,
+			RunningCount:   0,
+			PendingCount:   req.DesiredCount,
+			TaskDefinition: req.TaskDefinition,
+			CreatedAt:      "2025-05-15T00:40:35+09:00",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUpdateService handles the UpdateService API endpoint
+func (s *Server) handleUpdateService(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateServiceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual service update logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := UpdateServiceResponse{
+		Service: Service{
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+			ServiceName:    req.Service,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			Status:         "ACTIVE",
+			DesiredCount:   req.DesiredCount,
+			RunningCount:   req.DesiredCount,
+			PendingCount:   0,
+			TaskDefinition: req.TaskDefinition,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteService handles the DeleteService API endpoint
+func (s *Server) handleDeleteService(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteServiceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual service deletion logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := DeleteServiceResponse{
+		Service: Service{
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+			ServiceName:    req.Service,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			Status:         "DRAINING",
+			DesiredCount:   0,
+			RunningCount:   0,
+			PendingCount:   0,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeServices handles the DescribeServices API endpoint
+func (s *Server) handleDescribeServices(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeServicesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual service description logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := DescribeServicesResponse{
+		Services: []Service{
+			{
+				ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Services[0],
+				ServiceName:    req.Services[0],
+				ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+				Status:         "ACTIVE",
+				DesiredCount:   1,
+				RunningCount:   1,
+				PendingCount:   0,
+				TaskDefinition: "arn:aws:ecs:region:account:task-definition/family:1",
+				CreatedAt:      "2025-05-15T00:40:35+09:00",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListServices handles the ListServices API endpoint
+func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListServicesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual service listing logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := ListServicesResponse{
+		ServiceArns: []string{"arn:aws:ecs:region:account:service/" + cluster + "/sample-service"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/tag.go
+++ b/internal/controlplane/api/tag.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// TagResourceRequest represents the request to tag a resource
+type TagResourceRequest struct {
+	ResourceArn string `json:"resourceArn"`
+	Tags        []Tag  `json:"tags"`
+}
+
+// TagResourceResponse represents the response from tagging a resource
+type TagResourceResponse struct {
+}
+
+// UntagResourceRequest represents the request to untag a resource
+type UntagResourceRequest struct {
+	ResourceArn string   `json:"resourceArn"`
+	TagKeys     []string `json:"tagKeys"`
+}
+
+// UntagResourceResponse represents the response from untagging a resource
+type UntagResourceResponse struct {
+}
+
+// ListTagsForResourceRequest represents the request to list tags for a resource
+type ListTagsForResourceRequest struct {
+	ResourceArn string `json:"resourceArn"`
+}
+
+// ListTagsForResourceResponse represents the response from listing tags for a resource
+type ListTagsForResourceResponse struct {
+	Tags []Tag `json:"tags"`
+}
+
+// registerTagEndpoints registers all tag-related API endpoints
+func (s *Server) registerTagEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/tagresource", s.handleTagResource)
+	mux.HandleFunc("/v1/untagresource", s.handleUntagResource)
+	mux.HandleFunc("/v1/listtagsforresource", s.handleListTagsForResource)
+}
+
+// handleTagResource handles the TagResource API endpoint
+func (s *Server) handleTagResource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req TagResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual resource tagging logic
+
+	// For now, return a mock response
+	resp := TagResourceResponse{}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUntagResource handles the UntagResource API endpoint
+func (s *Server) handleUntagResource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UntagResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual resource untagging logic
+
+	// For now, return a mock response
+	resp := UntagResourceResponse{}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListTagsForResource handles the ListTagsForResource API endpoint
+func (s *Server) handleListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListTagsForResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual resource tag listing logic
+
+	// For now, return a mock response
+	resp := ListTagsForResourceResponse{
+		Tags: []Tag{
+			{
+				Key:   "Name",
+				Value: "Sample Resource",
+			},
+			{
+				Key:   "Environment",
+				Value: "Development",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/task.go
+++ b/internal/controlplane/api/task.go
@@ -1,0 +1,439 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Task represents an ECS task
+type Task struct {
+	TaskArn           string            `json:"taskArn,omitempty"`
+	ClusterArn        string            `json:"clusterArn,omitempty"`
+	TaskDefinitionArn string            `json:"taskDefinitionArn,omitempty"`
+	ContainerInstanceArn string         `json:"containerInstanceArn,omitempty"`
+	OverrideId        string            `json:"overrideId,omitempty"`
+	LastStatus        string            `json:"lastStatus,omitempty"`
+	DesiredStatus     string            `json:"desiredStatus,omitempty"`
+	Cpu               string            `json:"cpu,omitempty"`
+	Memory            string            `json:"memory,omitempty"`
+	Containers        []Container       `json:"containers,omitempty"`
+	StartedBy         string            `json:"startedBy,omitempty"`
+	Version           int               `json:"version,omitempty"`
+	StoppedReason     string            `json:"stoppedReason,omitempty"`
+	Connectivity      string            `json:"connectivity,omitempty"`
+	ConnectivityAt    string            `json:"connectivityAt,omitempty"`
+	PullStartedAt     string            `json:"pullStartedAt,omitempty"`
+	PullStoppedAt     string            `json:"pullStoppedAt,omitempty"`
+	ExecutionStoppedAt string           `json:"executionStoppedAt,omitempty"`
+	CreatedAt         string            `json:"createdAt,omitempty"`
+	StartedAt         string            `json:"startedAt,omitempty"`
+	StoppingAt        string            `json:"stoppingAt,omitempty"`
+	StoppedAt         string            `json:"stoppedAt,omitempty"`
+	Group             string            `json:"group,omitempty"`
+	LaunchType        string            `json:"launchType,omitempty"`
+	CapacityProviderName string         `json:"capacityProviderName,omitempty"`
+	PlatformVersion   string            `json:"platformVersion,omitempty"`
+	PlatformFamily    string            `json:"platformFamily,omitempty"`
+	Attachments       []Attachment      `json:"attachments,omitempty"`
+	Attributes        []Attribute       `json:"attributes,omitempty"`
+	Tags              []Tag             `json:"tags,omitempty"`
+	EnableExecuteCommand bool           `json:"enableExecuteCommand,omitempty"`
+	Overrides         TaskOverride      `json:"overrides,omitempty"`
+	EphemeralStorage  EphemeralStorage  `json:"ephemeralStorage,omitempty"`
+	HealthStatus      string            `json:"healthStatus,omitempty"`
+}
+
+// Container represents a container in a task
+type Container struct {
+	ContainerArn      string            `json:"containerArn,omitempty"`
+	TaskArn           string            `json:"taskArn,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	Image             string            `json:"image,omitempty"`
+	ImageDigest       string            `json:"imageDigest,omitempty"`
+	RuntimeId         string            `json:"runtimeId,omitempty"`
+	LastStatus        string            `json:"lastStatus,omitempty"`
+	ExitCode          int               `json:"exitCode,omitempty"`
+	Reason            string            `json:"reason,omitempty"`
+	NetworkBindings   []NetworkBinding  `json:"networkBindings,omitempty"`
+	NetworkInterfaces []NetworkInterface `json:"networkInterfaces,omitempty"`
+	HealthStatus      string            `json:"healthStatus,omitempty"`
+	Cpu               string            `json:"cpu,omitempty"`
+	Memory            string            `json:"memory,omitempty"`
+	MemoryReservation string            `json:"memoryReservation,omitempty"`
+	GpuIds            []string          `json:"gpuIds,omitempty"`
+}
+
+// NetworkBinding represents a network binding for a container
+type NetworkBinding struct {
+	BindIP        string `json:"bindIP,omitempty"`
+	ContainerPort int    `json:"containerPort,omitempty"`
+	HostPort      int    `json:"hostPort,omitempty"`
+	Protocol      string `json:"protocol,omitempty"`
+}
+
+// NetworkInterface represents a network interface for a container
+type NetworkInterface struct {
+	AttachmentId       string   `json:"attachmentId,omitempty"`
+	PrivateIpv4Address string   `json:"privateIpv4Address,omitempty"`
+	Ipv6Address        string   `json:"ipv6Address,omitempty"`
+}
+
+// TaskOverride represents overrides for a task
+type TaskOverride struct {
+	ContainerOverrides []ContainerOverride `json:"containerOverrides,omitempty"`
+	TaskRoleArn        string              `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn   string              `json:"executionRoleArn,omitempty"`
+	Cpu                string              `json:"cpu,omitempty"`
+	Memory             string              `json:"memory,omitempty"`
+	EphemeralStorage   *EphemeralStorage   `json:"ephemeralStorage,omitempty"`
+}
+
+// ContainerOverride represents an override for a container
+type ContainerOverride struct {
+	Name              string             `json:"name"`
+	Command           []string           `json:"command,omitempty"`
+	Environment       []KeyValuePair     `json:"environment,omitempty"`
+	EnvironmentFiles  []EnvironmentFile  `json:"environmentFiles,omitempty"`
+	Cpu               int                `json:"cpu,omitempty"`
+	Memory            int                `json:"memory,omitempty"`
+	MemoryReservation int                `json:"memoryReservation,omitempty"`
+	ResourceRequirements []ResourceRequirement `json:"resourceRequirements,omitempty"`
+}
+
+// RunTaskRequest represents the request to run a task
+type RunTaskRequest struct {
+	Cluster                 string        `json:"cluster,omitempty"`
+	TaskDefinition          string        `json:"taskDefinition"`
+	Count                   int           `json:"count,omitempty"`
+	Group                   string        `json:"group,omitempty"`
+	StartedBy               string        `json:"startedBy,omitempty"`
+	LaunchType              string        `json:"launchType,omitempty"`
+	CapacityProviderStrategy []CapacityStrategy `json:"capacityProviderStrategy,omitempty"`
+	PlacementConstraints    []TaskPlacementConstraint `json:"placementConstraints,omitempty"`
+	PlacementStrategy       []PlacementStrategy `json:"placementStrategy,omitempty"`
+	PlatformVersion         string        `json:"platformVersion,omitempty"`
+	EnableECSManagedTags    bool          `json:"enableECSManagedTags,omitempty"`
+	PropagateTags           string        `json:"propagateTags,omitempty"`
+	ReferenceId             string        `json:"referenceId,omitempty"`
+	Tags                    []Tag         `json:"tags,omitempty"`
+	EnableExecuteCommand    bool          `json:"enableExecuteCommand,omitempty"`
+	Overrides               TaskOverride  `json:"overrides,omitempty"`
+}
+
+// PlacementStrategy represents a placement strategy for a task
+type PlacementStrategy struct {
+	Type  string `json:"type"`
+	Field string `json:"field,omitempty"`
+}
+
+// RunTaskResponse represents the response from running a task
+type RunTaskResponse struct {
+	Tasks    []Task    `json:"tasks"`
+	Failures []Failure `json:"failures,omitempty"`
+}
+
+// StartTaskRequest represents the request to start a task
+type StartTaskRequest struct {
+	Cluster              string       `json:"cluster,omitempty"`
+	TaskDefinition       string       `json:"taskDefinition"`
+	ContainerInstances   []string     `json:"containerInstances"`
+	Group                string       `json:"group,omitempty"`
+	StartedBy            string       `json:"startedBy,omitempty"`
+	EnableECSManagedTags bool         `json:"enableECSManagedTags,omitempty"`
+	PropagateTags        string       `json:"propagateTags,omitempty"`
+	ReferenceId          string       `json:"referenceId,omitempty"`
+	Tags                 []Tag        `json:"tags,omitempty"`
+	EnableExecuteCommand bool         `json:"enableExecuteCommand,omitempty"`
+	Overrides            TaskOverride `json:"overrides,omitempty"`
+}
+
+// StartTaskResponse represents the response from starting a task
+type StartTaskResponse struct {
+	Tasks    []Task    `json:"tasks"`
+	Failures []Failure `json:"failures,omitempty"`
+}
+
+// StopTaskRequest represents the request to stop a task
+type StopTaskRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	Task    string `json:"task"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// StopTaskResponse represents the response from stopping a task
+type StopTaskResponse struct {
+	Task Task `json:"task"`
+}
+
+// DescribeTasksRequest represents the request to describe tasks
+type DescribeTasksRequest struct {
+	Cluster string   `json:"cluster,omitempty"`
+	Tasks   []string `json:"tasks"`
+	Include []string `json:"include,omitempty"`
+}
+
+// DescribeTasksResponse represents the response from describing tasks
+type DescribeTasksResponse struct {
+	Tasks    []Task    `json:"tasks"`
+	Failures []Failure `json:"failures,omitempty"`
+}
+
+// ListTasksRequest represents the request to list tasks
+type ListTasksRequest struct {
+	Cluster          string `json:"cluster,omitempty"`
+	ContainerInstance string `json:"containerInstance,omitempty"`
+	Family           string `json:"family,omitempty"`
+	StartedBy        string `json:"startedBy,omitempty"`
+	ServiceName      string `json:"serviceName,omitempty"`
+	DesiredStatus    string `json:"desiredStatus,omitempty"`
+	LaunchType       string `json:"launchType,omitempty"`
+	MaxResults       int    `json:"maxResults,omitempty"`
+	NextToken        string `json:"nextToken,omitempty"`
+}
+
+// ListTasksResponse represents the response from listing tasks
+type ListTasksResponse struct {
+	TaskArns  []string `json:"taskArns"`
+	NextToken string   `json:"nextToken,omitempty"`
+}
+
+// GetTaskProtectionRequest represents the request to get task protection
+type GetTaskProtectionRequest struct {
+	Cluster string   `json:"cluster,omitempty"`
+	Tasks   []string `json:"tasks"`
+}
+
+// ProtectionResult represents a protection result for a task
+type ProtectionResult struct {
+	TaskArn                string `json:"taskArn"`
+	ProtectionEnabled      bool   `json:"protectionEnabled"`
+	ExpirationDate         string `json:"expirationDate,omitempty"`
+	ProtectedFromScaleIn   bool   `json:"protectedFromScaleIn,omitempty"`
+	ProtectedFromScaleOut  bool   `json:"protectedFromScaleOut,omitempty"`
+}
+
+// GetTaskProtectionResponse represents the response from getting task protection
+type GetTaskProtectionResponse struct {
+	ProtectedTasks   []ProtectionResult `json:"protectedTasks"`
+	Failures         []Failure          `json:"failures,omitempty"`
+}
+
+// registerTaskEndpoints registers all task-related API endpoints
+func (s *Server) registerTaskEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/runtask", s.handleRunTask)
+	mux.HandleFunc("/v1/starttask", s.handleStartTask)
+	mux.HandleFunc("/v1/stoptask", s.handleStopTask)
+	mux.HandleFunc("/v1/describetasks", s.handleDescribeTasks)
+	mux.HandleFunc("/v1/listtasks", s.handleListTasks)
+	mux.HandleFunc("/v1/gettaskprotection", s.handleGetTaskProtection)
+}
+
+// handleRunTask handles the RunTask API endpoint
+func (s *Server) handleRunTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req RunTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task running logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := RunTaskResponse{
+		Tasks: []Task{
+			{
+				TaskArn:           "arn:aws:ecs:region:account:task/" + cluster + "/task-id",
+				ClusterArn:        "arn:aws:ecs:region:account:cluster/" + cluster,
+				TaskDefinitionArn: req.TaskDefinition,
+				LastStatus:        "PENDING",
+				DesiredStatus:     "RUNNING",
+				CreatedAt:         "2025-05-15T00:40:35+09:00",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleStartTask handles the StartTask API endpoint
+func (s *Server) handleStartTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req StartTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task starting logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := StartTaskResponse{
+		Tasks: []Task{
+			{
+				TaskArn:              "arn:aws:ecs:region:account:task/" + cluster + "/task-id",
+				ClusterArn:           "arn:aws:ecs:region:account:cluster/" + cluster,
+				TaskDefinitionArn:    req.TaskDefinition,
+				ContainerInstanceArn: "arn:aws:ecs:region:account:container-instance/" + cluster + "/" + req.ContainerInstances[0],
+				LastStatus:           "PENDING",
+				DesiredStatus:        "RUNNING",
+				CreatedAt:            "2025-05-15T00:40:35+09:00",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleStopTask handles the StopTask API endpoint
+func (s *Server) handleStopTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req StopTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task stopping logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := StopTaskResponse{
+		Task: Task{
+			TaskArn:           req.Task,
+			ClusterArn:        "arn:aws:ecs:region:account:cluster/" + cluster,
+			LastStatus:        "STOPPING",
+			DesiredStatus:     "STOPPED",
+			StoppedReason:     req.Reason,
+			StoppingAt:        "2025-05-15T00:40:35+09:00",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeTasks handles the DescribeTasks API endpoint
+func (s *Server) handleDescribeTasks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeTasksRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task description logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := DescribeTasksResponse{
+		Tasks: []Task{
+			{
+				TaskArn:           req.Tasks[0],
+				ClusterArn:        "arn:aws:ecs:region:account:cluster/" + cluster,
+				TaskDefinitionArn: "arn:aws:ecs:region:account:task-definition/family:1",
+				LastStatus:        "RUNNING",
+				DesiredStatus:     "RUNNING",
+				CreatedAt:         "2025-05-15T00:40:35+09:00",
+				StartedAt:         "2025-05-15T00:40:40+09:00",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListTasks handles the ListTasks API endpoint
+func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListTasksRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task listing logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := ListTasksResponse{
+		TaskArns: []string{"arn:aws:ecs:region:account:task/" + cluster + "/task-id"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleGetTaskProtection handles the GetTaskProtection API endpoint
+func (s *Server) handleGetTaskProtection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req GetTaskProtectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task protection logic
+
+	// For now, return a mock response
+	resp := GetTaskProtectionResponse{
+		ProtectedTasks: []ProtectionResult{
+			{
+				TaskArn:            req.Tasks[0],
+				ProtectionEnabled:  false,
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/task_definition.go
+++ b/internal/controlplane/api/task_definition.go
@@ -1,0 +1,502 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// TaskDefinition represents an ECS task definition
+type TaskDefinition struct {
+	TaskDefinitionArn            string                 `json:"taskDefinitionArn,omitempty"`
+	ContainerDefinitions         []ContainerDefinition  `json:"containerDefinitions"`
+	Family                       string                 `json:"family"`
+	TaskRoleArn                  string                 `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn             string                 `json:"executionRoleArn,omitempty"`
+	NetworkMode                  string                 `json:"networkMode,omitempty"`
+	Revision                     int                    `json:"revision,omitempty"`
+	Volumes                      []Volume               `json:"volumes,omitempty"`
+	Status                       string                 `json:"status,omitempty"`
+	RequiresAttributes           []Attribute            `json:"requiresAttributes,omitempty"`
+	PlacementConstraints         []TaskPlacementConstraint `json:"placementConstraints,omitempty"`
+	Compatibilities              []string               `json:"compatibilities,omitempty"`
+	RequiresCompatibilities      []string               `json:"requiresCompatibilities,omitempty"`
+	Cpu                          string                 `json:"cpu,omitempty"`
+	Memory                       string                 `json:"memory,omitempty"`
+	InferenceAccelerators        []InferenceAccelerator `json:"inferenceAccelerators,omitempty"`
+	PidMode                      string                 `json:"pidMode,omitempty"`
+	IpcMode                      string                 `json:"ipcMode,omitempty"`
+	ProxyConfiguration           *ProxyConfiguration    `json:"proxyConfiguration,omitempty"`
+	RegisteredAt                 string                 `json:"registeredAt,omitempty"`
+	DeregisteredAt               string                 `json:"deregisteredAt,omitempty"`
+	RegisteredBy                 string                 `json:"registeredBy,omitempty"`
+	EphemeralStorage             *EphemeralStorage      `json:"ephemeralStorage,omitempty"`
+	RuntimePlatform              *RuntimePlatform       `json:"runtimePlatform,omitempty"`
+}
+
+// ContainerDefinition represents a container definition in a task definition
+type ContainerDefinition struct {
+	Name                   string                `json:"name"`
+	Image                  string                `json:"image"`
+	Cpu                    int                   `json:"cpu,omitempty"`
+	Memory                 int                   `json:"memory,omitempty"`
+	MemoryReservation      int                   `json:"memoryReservation,omitempty"`
+	Links                  []string              `json:"links,omitempty"`
+	PortMappings           []PortMapping         `json:"portMappings,omitempty"`
+	Essential              bool                  `json:"essential,omitempty"`
+	EntryPoint             []string              `json:"entryPoint,omitempty"`
+	Command                []string              `json:"command,omitempty"`
+	Environment            []KeyValuePair        `json:"environment,omitempty"`
+	EnvironmentFiles       []EnvironmentFile     `json:"environmentFiles,omitempty"`
+	MountPoints            []MountPoint          `json:"mountPoints,omitempty"`
+	VolumesFrom            []VolumeFrom          `json:"volumesFrom,omitempty"`
+	LinuxParameters        *LinuxParameters      `json:"linuxParameters,omitempty"`
+	Secrets                []Secret              `json:"secrets,omitempty"`
+	DependsOn              []ContainerDependency `json:"dependsOn,omitempty"`
+	StartTimeout           int                   `json:"startTimeout,omitempty"`
+	StopTimeout            int                   `json:"stopTimeout,omitempty"`
+	Hostname               string                `json:"hostname,omitempty"`
+	User                   string                `json:"user,omitempty"`
+	WorkingDirectory       string                `json:"workingDirectory,omitempty"`
+	DisableNetworking      bool                  `json:"disableNetworking,omitempty"`
+	Privileged             bool                  `json:"privileged,omitempty"`
+	ReadonlyRootFilesystem bool                  `json:"readonlyRootFilesystem,omitempty"`
+	DnsServers             []string              `json:"dnsServers,omitempty"`
+	DnsSearchDomains       []string              `json:"dnsSearchDomains,omitempty"`
+	ExtraHosts             []HostEntry           `json:"extraHosts,omitempty"`
+	DockerSecurityOptions  []string              `json:"dockerSecurityOptions,omitempty"`
+	Interactive            bool                  `json:"interactive,omitempty"`
+	PseudoTerminal         bool                  `json:"pseudoTerminal,omitempty"`
+	DockerLabels           map[string]string     `json:"dockerLabels,omitempty"`
+	Ulimits                []Ulimit              `json:"ulimits,omitempty"`
+	LogConfiguration       *LogConfiguration     `json:"logConfiguration,omitempty"`
+	HealthCheck            *HealthCheck          `json:"healthCheck,omitempty"`
+	SystemControls         []SystemControl       `json:"systemControls,omitempty"`
+	ResourceRequirements   []ResourceRequirement `json:"resourceRequirements,omitempty"`
+	FirelensConfiguration  *FirelensConfiguration `json:"firelensConfiguration,omitempty"`
+}
+
+// PortMapping represents a port mapping for a container
+type PortMapping struct {
+	ContainerPort int    `json:"containerPort"`
+	HostPort      int    `json:"hostPort,omitempty"`
+	Protocol      string `json:"protocol,omitempty"`
+}
+
+// EnvironmentFile represents an environment file for a container
+type EnvironmentFile struct {
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+// MountPoint represents a mount point for a container
+type MountPoint struct {
+	SourceVolume  string `json:"sourceVolume"`
+	ContainerPath string `json:"containerPath"`
+	ReadOnly      bool   `json:"readOnly,omitempty"`
+}
+
+// VolumeFrom represents a volume from another container
+type VolumeFrom struct {
+	SourceContainer string `json:"sourceContainer"`
+	ReadOnly        bool   `json:"readOnly,omitempty"`
+}
+
+// LinuxParameters represents Linux-specific options for a container
+type LinuxParameters struct {
+	Capabilities      *KernelCapabilities `json:"capabilities,omitempty"`
+	Devices           []Device            `json:"devices,omitempty"`
+	InitProcessEnabled bool               `json:"initProcessEnabled,omitempty"`
+	SharedMemorySize  int                 `json:"sharedMemorySize,omitempty"`
+	Tmpfs             []Tmpfs             `json:"tmpfs,omitempty"`
+	MaxSwap           int                 `json:"maxSwap,omitempty"`
+	Swappiness        int                 `json:"swappiness,omitempty"`
+}
+
+// KernelCapabilities represents kernel capabilities for a container
+type KernelCapabilities struct {
+	Add  []string `json:"add,omitempty"`
+	Drop []string `json:"drop,omitempty"`
+}
+
+// Device represents a device mapping for a container
+type Device struct {
+	HostPath      string `json:"hostPath"`
+	ContainerPath string `json:"containerPath,omitempty"`
+	Permissions   []string `json:"permissions,omitempty"`
+}
+
+// Tmpfs represents a tmpfs mount for a container
+type Tmpfs struct {
+	ContainerPath string   `json:"containerPath"`
+	Size          int      `json:"size"`
+	MountOptions  []string `json:"mountOptions,omitempty"`
+}
+
+// Secret represents a secret for a container
+type Secret struct {
+	Name      string `json:"name"`
+	ValueFrom string `json:"valueFrom"`
+}
+
+// ContainerDependency represents a dependency between containers
+type ContainerDependency struct {
+	ContainerName string `json:"containerName"`
+	Condition     string `json:"condition"`
+}
+
+// HostEntry represents a host entry for a container
+type HostEntry struct {
+	Hostname  string `json:"hostname"`
+	IpAddress string `json:"ipAddress"`
+}
+
+// Ulimit represents a ulimit for a container
+type Ulimit struct {
+	Name      string `json:"name"`
+	SoftLimit int    `json:"softLimit"`
+	HardLimit int    `json:"hardLimit"`
+}
+
+// LogConfiguration represents a log configuration for a container
+type LogConfiguration struct {
+	LogDriver string            `json:"logDriver"`
+	Options   map[string]string `json:"options,omitempty"`
+	SecretOptions []Secret      `json:"secretOptions,omitempty"`
+}
+
+// HealthCheck represents a health check for a container
+type HealthCheck struct {
+	Command             []string `json:"command"`
+	Interval            int      `json:"interval,omitempty"`
+	Timeout             int      `json:"timeout,omitempty"`
+	Retries             int      `json:"retries,omitempty"`
+	StartPeriod         int      `json:"startPeriod,omitempty"`
+}
+
+// SystemControl represents a system control for a container
+type SystemControl struct {
+	Namespace string `json:"namespace"`
+	Value     string `json:"value"`
+}
+
+// ResourceRequirement represents a resource requirement for a container
+type ResourceRequirement struct {
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+// FirelensConfiguration represents a firelens configuration for a container
+type FirelensConfiguration struct {
+	Type    string `json:"type"`
+	Options map[string]string `json:"options,omitempty"`
+}
+
+// Volume represents a volume in a task definition
+type Volume struct {
+	Name          string        `json:"name"`
+	Host          *HostVolumeProperties `json:"host,omitempty"`
+	DockerVolumeConfiguration *DockerVolumeConfiguration `json:"dockerVolumeConfiguration,omitempty"`
+	EfsVolumeConfiguration    *EFSVolumeConfiguration    `json:"efsVolumeConfiguration,omitempty"`
+	FsxWindowsFileServerVolumeConfiguration *FSxWindowsFileServerVolumeConfiguration `json:"fsxWindowsFileServerVolumeConfiguration,omitempty"`
+}
+
+// HostVolumeProperties represents host volume properties
+type HostVolumeProperties struct {
+	SourcePath string `json:"sourcePath,omitempty"`
+}
+
+// DockerVolumeConfiguration represents a docker volume configuration
+type DockerVolumeConfiguration struct {
+	Scope         string            `json:"scope,omitempty"`
+	Autoprovision bool              `json:"autoprovision,omitempty"`
+	Driver        string            `json:"driver,omitempty"`
+	DriverOpts    map[string]string `json:"driverOpts,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
+}
+
+// EFSVolumeConfiguration represents an EFS volume configuration
+type EFSVolumeConfiguration struct {
+	FileSystemId          string `json:"fileSystemId"`
+	RootDirectory         string `json:"rootDirectory,omitempty"`
+	TransitEncryption     string `json:"transitEncryption,omitempty"`
+	TransitEncryptionPort int    `json:"transitEncryptionPort,omitempty"`
+	AuthorizationConfig   *EFSAuthorizationConfig `json:"authorizationConfig,omitempty"`
+}
+
+// EFSAuthorizationConfig represents an EFS authorization configuration
+type EFSAuthorizationConfig struct {
+	AccessPointId string `json:"accessPointId,omitempty"`
+	Iam           string `json:"iam,omitempty"`
+}
+
+// FSxWindowsFileServerVolumeConfiguration represents an FSx Windows File Server volume configuration
+type FSxWindowsFileServerVolumeConfiguration struct {
+	FileSystemId  string `json:"fileSystemId"`
+	RootDirectory string `json:"rootDirectory"`
+	AuthorizationConfig *FSxWindowsFileServerAuthorizationConfig `json:"authorizationConfig,omitempty"`
+}
+
+// FSxWindowsFileServerAuthorizationConfig represents an FSx Windows File Server authorization configuration
+type FSxWindowsFileServerAuthorizationConfig struct {
+	CredentialsParameter string `json:"credentialsParameter"`
+	Domain              string `json:"domain"`
+}
+
+// Attribute represents an attribute in a task definition
+type Attribute struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+// TaskPlacementConstraint represents a placement constraint for a task
+type TaskPlacementConstraint struct {
+	Type       string `json:"type"`
+	Expression string `json:"expression,omitempty"`
+}
+
+// InferenceAccelerator represents an inference accelerator for a task
+type InferenceAccelerator struct {
+	DeviceName    string `json:"deviceName"`
+	DeviceType    string `json:"deviceType"`
+}
+
+// ProxyConfiguration represents a proxy configuration for a task
+type ProxyConfiguration struct {
+	Type          string         `json:"type,omitempty"`
+	ContainerName string         `json:"containerName"`
+	Properties    []KeyValuePair `json:"properties,omitempty"`
+}
+
+// EphemeralStorage represents ephemeral storage for a task
+type EphemeralStorage struct {
+	SizeInGiB int `json:"sizeInGiB"`
+}
+
+// RuntimePlatform represents a runtime platform for a task
+type RuntimePlatform struct {
+	CpuArchitecture       string `json:"cpuArchitecture,omitempty"`
+	OperatingSystemFamily string `json:"operatingSystemFamily,omitempty"`
+}
+
+// RegisterTaskDefinitionRequest represents the request to register a task definition
+type RegisterTaskDefinitionRequest struct {
+	ContainerDefinitions    []ContainerDefinition  `json:"containerDefinitions"`
+	Family                  string                 `json:"family"`
+	TaskRoleArn             string                 `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn        string                 `json:"executionRoleArn,omitempty"`
+	NetworkMode             string                 `json:"networkMode,omitempty"`
+	Volumes                 []Volume               `json:"volumes,omitempty"`
+	PlacementConstraints    []TaskPlacementConstraint `json:"placementConstraints,omitempty"`
+	RequiresCompatibilities []string               `json:"requiresCompatibilities,omitempty"`
+	Cpu                     string                 `json:"cpu,omitempty"`
+	Memory                  string                 `json:"memory,omitempty"`
+	Tags                    []Tag                  `json:"tags,omitempty"`
+	PidMode                 string                 `json:"pidMode,omitempty"`
+	IpcMode                 string                 `json:"ipcMode,omitempty"`
+	ProxyConfiguration      *ProxyConfiguration    `json:"proxyConfiguration,omitempty"`
+	InferenceAccelerators   []InferenceAccelerator `json:"inferenceAccelerators,omitempty"`
+	EphemeralStorage        *EphemeralStorage      `json:"ephemeralStorage,omitempty"`
+	RuntimePlatform         *RuntimePlatform       `json:"runtimePlatform,omitempty"`
+}
+
+// RegisterTaskDefinitionResponse represents the response from registering a task definition
+type RegisterTaskDefinitionResponse struct {
+	TaskDefinition TaskDefinition `json:"taskDefinition"`
+	Tags          []Tag          `json:"tags,omitempty"`
+}
+
+// DeregisterTaskDefinitionRequest represents the request to deregister a task definition
+type DeregisterTaskDefinitionRequest struct {
+	TaskDefinition string `json:"taskDefinition"`
+}
+
+// DeregisterTaskDefinitionResponse represents the response from deregistering a task definition
+type DeregisterTaskDefinitionResponse struct {
+	TaskDefinition TaskDefinition `json:"taskDefinition"`
+}
+
+// DescribeTaskDefinitionRequest represents the request to describe a task definition
+type DescribeTaskDefinitionRequest struct {
+	TaskDefinition string   `json:"taskDefinition"`
+	Include        []string `json:"include,omitempty"`
+}
+
+// DescribeTaskDefinitionResponse represents the response from describing a task definition
+type DescribeTaskDefinitionResponse struct {
+	TaskDefinition TaskDefinition `json:"taskDefinition"`
+	Tags           []Tag          `json:"tags,omitempty"`
+}
+
+// ListTaskDefinitionsRequest represents the request to list task definitions
+type ListTaskDefinitionsRequest struct {
+	FamilyPrefix string `json:"familyPrefix,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Sort         string `json:"sort,omitempty"`
+	MaxResults   int    `json:"maxResults,omitempty"`
+	NextToken    string `json:"nextToken,omitempty"`
+}
+
+// ListTaskDefinitionsResponse represents the response from listing task definitions
+type ListTaskDefinitionsResponse struct {
+	TaskDefinitionArns []string `json:"taskDefinitionArns"`
+	NextToken          string   `json:"nextToken,omitempty"`
+}
+
+// DeleteTaskDefinitionsRequest represents the request to delete task definitions
+type DeleteTaskDefinitionsRequest struct {
+	TaskDefinitions []string `json:"taskDefinitions"`
+}
+
+// DeleteTaskDefinitionsResponse represents the response from deleting task definitions
+type DeleteTaskDefinitionsResponse struct {
+	TaskDefinitions []TaskDefinition `json:"taskDefinitions"`
+	Failures        []Failure        `json:"failures,omitempty"`
+}
+
+// registerTaskDefinitionEndpoints registers all task definition-related API endpoints
+func (s *Server) registerTaskDefinitionEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/registertaskdefinition", s.handleRegisterTaskDefinition)
+	mux.HandleFunc("/v1/deregistertaskdefinition", s.handleDeregisterTaskDefinition)
+	mux.HandleFunc("/v1/describetaskdefinition", s.handleDescribeTaskDefinition)
+	mux.HandleFunc("/v1/listtaskdefinitions", s.handleListTaskDefinitions)
+	mux.HandleFunc("/v1/deletetaskdefinitions", s.handleDeleteTaskDefinitions)
+}
+
+// handleRegisterTaskDefinition handles the RegisterTaskDefinition API endpoint
+func (s *Server) handleRegisterTaskDefinition(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req RegisterTaskDefinitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task definition registration logic
+
+	// For now, return a mock response
+	resp := RegisterTaskDefinitionResponse{
+		TaskDefinition: TaskDefinition{
+			TaskDefinitionArn:    "arn:aws:ecs:region:account:task-definition/" + req.Family + ":1",
+			Family:               req.Family,
+			ContainerDefinitions: req.ContainerDefinitions,
+			Revision:             1,
+			Status:               "ACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeregisterTaskDefinition handles the DeregisterTaskDefinition API endpoint
+func (s *Server) handleDeregisterTaskDefinition(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeregisterTaskDefinitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task definition deregistration logic
+
+	// For now, return a mock response
+	resp := DeregisterTaskDefinitionResponse{
+		TaskDefinition: TaskDefinition{
+			TaskDefinitionArn: req.TaskDefinition,
+			Status:            "INACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeTaskDefinition handles the DescribeTaskDefinition API endpoint
+func (s *Server) handleDescribeTaskDefinition(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeTaskDefinitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task definition description logic
+
+	// For now, return a mock response
+	resp := DescribeTaskDefinitionResponse{
+		TaskDefinition: TaskDefinition{
+			TaskDefinitionArn: req.TaskDefinition,
+			Family:            "sample-family",
+			Revision:          1,
+			Status:            "ACTIVE",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListTaskDefinitions handles the ListTaskDefinitions API endpoint
+func (s *Server) handleListTaskDefinitions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ListTaskDefinitionsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task definition listing logic
+
+	// For now, return a mock response
+	resp := ListTaskDefinitionsResponse{
+		TaskDefinitionArns: []string{"arn:aws:ecs:region:account:task-definition/sample-family:1"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteTaskDefinitions handles the DeleteTaskDefinitions API endpoint
+func (s *Server) handleDeleteTaskDefinitions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteTaskDefinitionsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task definition deletion logic
+
+	// For now, return a mock response
+	resp := DeleteTaskDefinitionsResponse{
+		TaskDefinitions: []TaskDefinition{
+			{
+				TaskDefinitionArn: req.TaskDefinitions[0],
+				Status:            "DELETE_IN_PROGRESS",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/api/task_set.go
+++ b/internal/controlplane/api/task_set.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// CreateTaskSetRequest represents the request to create a task set
+type CreateTaskSetRequest struct {
+	Service           string                `json:"service"`
+	Cluster           string                `json:"cluster,omitempty"`
+	ExternalId        string                `json:"externalId,omitempty"`
+	TaskDefinition    string                `json:"taskDefinition"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	LoadBalancers     []LoadBalancer        `json:"loadBalancers,omitempty"`
+	ServiceRegistries []ServiceRegistry     `json:"serviceRegistries,omitempty"`
+	LaunchType        string                `json:"launchType,omitempty"`
+	CapacityProviderStrategy []CapacityStrategy `json:"capacityProviderStrategy,omitempty"`
+	PlatformVersion   string                `json:"platformVersion,omitempty"`
+	Scale             *Scale                `json:"scale,omitempty"`
+	ClientToken       string                `json:"clientToken,omitempty"`
+	Tags              []Tag                 `json:"tags,omitempty"`
+}
+
+// CreateTaskSetResponse represents the response from creating a task set
+type CreateTaskSetResponse struct {
+	TaskSet TaskSet `json:"taskSet"`
+}
+
+// DeleteTaskSetRequest represents the request to delete a task set
+type DeleteTaskSetRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	Service string `json:"service"`
+	TaskSet string `json:"taskSet"`
+	Force   bool   `json:"force,omitempty"`
+}
+
+// DeleteTaskSetResponse represents the response from deleting a task set
+type DeleteTaskSetResponse struct {
+	TaskSet TaskSet `json:"taskSet"`
+}
+
+// DescribeTaskSetsRequest represents the request to describe task sets
+type DescribeTaskSetsRequest struct {
+	Cluster  string   `json:"cluster,omitempty"`
+	Service  string   `json:"service"`
+	TaskSets []string `json:"taskSets,omitempty"`
+	Include  []string `json:"include,omitempty"`
+}
+
+// DescribeTaskSetsResponse represents the response from describing task sets
+type DescribeTaskSetsResponse struct {
+	TaskSets []TaskSet `json:"taskSets"`
+	Failures []Failure `json:"failures,omitempty"`
+}
+
+// UpdateTaskSetRequest represents the request to update a task set
+type UpdateTaskSetRequest struct {
+	Cluster string `json:"cluster,omitempty"`
+	Service string `json:"service"`
+	TaskSet string `json:"taskSet"`
+	Scale   *Scale `json:"scale"`
+}
+
+// UpdateTaskSetResponse represents the response from updating a task set
+type UpdateTaskSetResponse struct {
+	TaskSet TaskSet `json:"taskSet"`
+}
+
+// registerTaskSetEndpoints registers all task set-related API endpoints
+func (s *Server) registerTaskSetEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/createtaskset", s.handleCreateTaskSet)
+	mux.HandleFunc("/v1/deletetaskset", s.handleDeleteTaskSet)
+	mux.HandleFunc("/v1/describetasksets", s.handleDescribeTaskSets)
+	mux.HandleFunc("/v1/updatetaskset", s.handleUpdateTaskSet)
+}
+
+// handleCreateTaskSet handles the CreateTaskSet API endpoint
+func (s *Server) handleCreateTaskSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req CreateTaskSetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task set creation logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := CreateTaskSetResponse{
+		TaskSet: TaskSet{
+			Id:             "ts-1234567890",
+			TaskSetArn:     "arn:aws:ecs:region:account:task-set/" + cluster + "/" + req.Service + "/ts-1234567890",
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			ExternalId:     req.ExternalId,
+			Status:         "ACTIVE",
+			TaskDefinition: req.TaskDefinition,
+			Scale: &Scale{
+				Value: 100.0,
+				Unit:  "PERCENT",
+			},
+			StabilityStatus: "STEADY_STATE",
+			CreatedAt:       "2025-05-15T00:50:29+09:00",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDeleteTaskSet handles the DeleteTaskSet API endpoint
+func (s *Server) handleDeleteTaskSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeleteTaskSetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task set deletion logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := DeleteTaskSetResponse{
+		TaskSet: TaskSet{
+			Id:             req.TaskSet,
+			TaskSetArn:     "arn:aws:ecs:region:account:task-set/" + cluster + "/" + req.Service + "/" + req.TaskSet,
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			Status:         "DRAINING",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleDescribeTaskSets handles the DescribeTaskSets API endpoint
+func (s *Server) handleDescribeTaskSets(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DescribeTaskSetsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task set description logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	taskSets := []TaskSet{}
+	if len(req.TaskSets) > 0 {
+		for _, taskSetId := range req.TaskSets {
+			taskSets = append(taskSets, TaskSet{
+				Id:             taskSetId,
+				TaskSetArn:     "arn:aws:ecs:region:account:task-set/" + cluster + "/" + req.Service + "/" + taskSetId,
+				ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+				ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+				Status:         "ACTIVE",
+				TaskDefinition: "arn:aws:ecs:region:account:task-definition/family:1",
+				Scale: &Scale{
+					Value: 100.0,
+					Unit:  "PERCENT",
+				},
+				StabilityStatus: "STEADY_STATE",
+				CreatedAt:       "2025-05-15T00:50:29+09:00",
+			})
+		}
+	} else {
+		// Return default task set if none specified
+		taskSets = append(taskSets, TaskSet{
+			Id:             "ts-1234567890",
+			TaskSetArn:     "arn:aws:ecs:region:account:task-set/" + cluster + "/" + req.Service + "/ts-1234567890",
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			Status:         "ACTIVE",
+			TaskDefinition: "arn:aws:ecs:region:account:task-definition/family:1",
+			Scale: &Scale{
+				Value: 100.0,
+				Unit:  "PERCENT",
+			},
+			StabilityStatus: "STEADY_STATE",
+			CreatedAt:       "2025-05-15T00:50:29+09:00",
+		})
+	}
+
+	resp := DescribeTaskSetsResponse{
+		TaskSets: taskSets,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleUpdateTaskSet handles the UpdateTaskSet API endpoint
+func (s *Server) handleUpdateTaskSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req UpdateTaskSetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual task set update logic
+
+	// For now, return a mock response
+	cluster := "default"
+	if req.Cluster != "" {
+		cluster = req.Cluster
+	}
+
+	resp := UpdateTaskSetResponse{
+		TaskSet: TaskSet{
+			Id:             req.TaskSet,
+			TaskSetArn:     "arn:aws:ecs:region:account:task-set/" + cluster + "/" + req.Service + "/" + req.TaskSet,
+			ServiceArn:     "arn:aws:ecs:region:account:service/" + cluster + "/" + req.Service,
+			ClusterArn:     "arn:aws:ecs:region:account:cluster/" + cluster,
+			Status:         "ACTIVE",
+			Scale:          req.Scale,
+			StabilityStatus: "UPDATING",
+			UpdatedAt:       "2025-05-15T00:50:29+09:00",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/controlplane/cmd/server.go
+++ b/internal/controlplane/cmd/server.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
+	"github.com/nandemo-ya/kecs/internal/controlplane/api"
 	"github.com/spf13/cobra"
 )
 
@@ -34,5 +41,35 @@ func runServer() {
 	} else {
 		fmt.Println("Using in-cluster configuration or default kubeconfig")
 	}
-	// TODO: Implement actual server startup logic
+
+	// Initialize and start the API server
+	apiServer := api.NewServer(port, kubeconfig)
+	
+	// Set up graceful shutdown
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	
+	// Handle signals for graceful shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	
+	go func() {
+		sig := <-sigCh
+		fmt.Printf("Received signal %s, shutting down...\n", sig)
+		cancel()
+		
+		// Allow some time for graceful shutdown
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		
+		if err := apiServer.Stop(shutdownCtx); err != nil {
+			fmt.Printf("Error during server shutdown: %v\n", err)
+		}
+	}()
+	
+	// Start the server
+	if err := apiServer.Start(); err != nil && err != http.ErrServerClosed {
+		fmt.Printf("Server error: %v\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This PR implements HTTP-based API server endpoints for the Control Plane component. The implementation provides a skeleton structure for AWS ECS compatible APIs running on Kubernetes.

## Changes
- Added API server implementation with HTTP endpoints
- Implemented skeleton handlers for all major ECS API operations:
  - Cluster management
  - Task definition management
  - Task execution and management
  - Service management
  - Container instance management
  - Capacity provider management
  - Account settings management
  - Tag management
  - Attribute management
  - Task set management
- Updated server command to initialize and start the API server
- Added graceful shutdown handling

Note: This is a skeleton implementation that returns mock responses. The actual integration with Kubernetes resources will be implemented in future PRs.