### PR TITLE
Add Control Plane Dockerfile with multi-architecture support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -o controlplane ./cmd/controlplane
+
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:nonroot
+COPY --from=builder /app/controlplane /controlplane
+
+ENV PORT=8080
+ENV ADMIN_PORT=8081
+
+EXPOSE 8080 8081
+ENTRYPOINT ["/controlplane", "server"]


### PR DESCRIPTION
## Overview
- Add Dockerfile for Control Plane
- Support multi-architecture builds (AMD64/ARM64) using BuildKit
- Secure and lightweight runtime environment based on distroless

## Technical Details
- Efficient image building with multi-stage builds
- Faster builds using cache mount feature
- Enhanced security with nonroot user execution

## Usage
```bash
# Enable BuildKit
export DOCKER_BUILDKIT=1

# Multi-architecture build
docker buildx build --platform=linux/amd64,linux/arm64 -t kecs-controlplane:latest .