### PR TITLE
Update Go version to 1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.3 AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI/CD Pipeline](https://github.com/nandemo-ya/kecs/actions/workflows/ci.yml/badge.svg)](https://github.com/nandemo-ya/kecs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/nandemo-ya/kecs/branch/main/graph/badge.svg)](https://codecov.io/gh/nandemo-ya/kecs)
-[![Go Version](https://img.shields.io/badge/Go-1.24-blue.svg)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/Go-1.24.3-blue.svg)](https://golang.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release](https://img.shields.io/github/release/nandemo-ya/kecs.svg)](https://github.com/nandemo-ya/kecs/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nandemo-ya/kecs)](https://goreportcard.com/report/github.com/nandemo-ya/kecs)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nandemo-ya/kecs
 
-go 1.23.0
+go 1.24.3
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect


### PR DESCRIPTION
## Summary
- Update Go version from 1.24 to 1.24.3 across the project

## Changes
- ✅ Updated `go.mod` to specify Go 1.24.3
- ✅ Updated Dockerfile to use `golang:1.24.3` base image
- ✅ Updated README.md badge to show Go 1.24.3
- ✅ GitHub Actions workflow automatically uses version from go.mod
- ✅ Tested build and all tests pass with Go 1.24.3

## Test plan
- [x] Build succeeds with `make build`
- [x] All tests pass with `make test`
- [x] Clean build with `make clean && make all`

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)