### PR TITLE
Fix: Rename Web UI ADR from 0004 to 0005

### DIFF
--- a/docs/adr/records/0005-web-ui.md
+++ b/docs/adr/records/0005-web-ui.md
@@ -1,4 +1,4 @@
-# Web UI Integration
+# ADR-0005: Web UI Integration
 
 **Date:** 2025-06-01
 


### PR DESCRIPTION
## Summary
- Renamed Web UI ADR from 0004 to 0005 to fix duplicate ADR numbering
- Updated the ADR title to include the ADR number prefix

## Context
There were two ADRs numbered 0004:
- API code generation ADR (0004-api-code-generation.md)
- Web UI ADR (0004-web-ui.md)

This PR fixes the numbering conflict by renaming the Web UI ADR to 0005.

## Test plan
- [x] Verify file renamed correctly
- [x] Verify ADR title updated to include ADR-0005 prefix
- [x] Confirm no other references to ADR-0004 Web UI exist in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)