### PR TITLE
Implement StopTask API with Kubernetes pod deletion

### DIFF
--- a/controlplane/internal/controlplane/api/ecs_handler.go
+++ b/controlplane/internal/controlplane/api/ecs_handler.go
@@ -77,6 +77,8 @@ func (s *Server) handleECSRequest(w http.ResponseWriter, r *http.Request) {
 		s.handleECSDescribeServices(w, body)
 	case "ListServices":
 		s.handleECSListServices(w, body)
+	case "StopTask":
+		s.handleStopTaskECS(w, body)
 	default:
 		// Return a basic empty response for unsupported operations
 		s.handleUnsupportedOperation(w, operation)


### PR DESCRIPTION
## Summary
- Implements the ECS StopTask API to stop running tasks by deleting their Kubernetes pods
- Replaces mock implementations with real storage and Kubernetes integration
- Adds proper task state management and lifecycle tracking

## Implementation Details

### StopTask API Implementation
- Added `StopTaskWithStorage` method that manages the complete task stopping lifecycle
- Task transitions through states: RUNNING → STOPPING → STOPPED
- Properly updates storage at each state transition with version incrementing
- Handles error cases gracefully (e.g., pod already deleted)

### Pod Deletion
- Implemented `deleteTaskPod` helper method for safe Kubernetes pod deletion
- Uses `DeletePropagationForeground` policy to ensure dependent resources are cleaned up
- Handles "not found" errors gracefully when pods are already deleted
- Logs successful deletions and warnings for debugging

### Enhanced DescribeTasks
- Replaced mock DescribeTasks implementation with `DescribeTasksWithStorage`
- Added `updateTaskStatusFromKubernetes` to sync task status with actual pod state
- Maps Kubernetes pod phases to ECS task statuses:
  - PodPending → PENDING
  - PodRunning → RUNNING
  - PodSucceeded/PodFailed → STOPPED
- Updates storage when status changes are detected

### Helper Methods
- Created `storageTaskToAPITask` converter for consistent task representation
- Properly handles JSON parsing for containers and overrides
- Formats timestamps according to RFC3339 standard

## Testing
The implementation has been tested and confirmed working:
- Tasks can be stopped using `aws ecs stop-task`
- Kubernetes pods are properly deleted when tasks are stopped
- Task status transitions are correctly reflected in storage
- DescribeTasks returns accurate real-time pod status

## Integration
- Added StopTask case to the ECS handler switch statement
- Created `handleStopTaskECS` method for the /v1/StopTask endpoint
- Both REST and ECS API endpoints are fully functional

🤖 Generated with [Claude Code](https://claude.ai/code)