### PR TITLE
Optimize CI/CD pipeline and improve .gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     name: Build and Push Docker image
     needs: test
     runs-on: ubuntu-latest
+    # Only run on main branch pushes and tags, not on PRs
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     permissions:
       contents: read
       packages: write
@@ -62,7 +64,7 @@ jobs:
         with:
           context: ./controlplane
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.git_tag.outputs.TAG }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bin/
 # Coverage reports
 coverage.txt
 
+# Database files
+*.db
+
 # IDE files
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
- Optimize GitHub Actions workflow to run Docker build only on main branch
- Add database files (*.db) to .gitignore

## Changes Made

### CI/CD Optimization
- **Conditional Docker Build**: Added `if` condition to `build-and-push` job to run only on:
  - Main branch pushes (`refs/heads/main`)
  - Tag pushes (`refs/tags/*`)
- **Skip PR Builds**: Docker build will no longer run on pull request branches
- **Maintain Testing**: All branches continue to run the full test suite
- **Resource Efficiency**: Reduces CI execution time and resource usage for feature branches

### .gitignore Improvements
- **Database Files**: Added `*.db` pattern to exclude test database files
- **Clean Repository**: Prevents accidental commit of temporary test databases

## Benefits
- ⚡ **Faster CI for PRs**: Eliminates expensive Docker build step for feature branches
- 🧪 **Full Test Coverage**: Maintains complete testing on all branches
- 🔒 **Secure Builds**: Docker images still built and pushed for all main branch changes
- 🗂️ **Cleaner Repo**: Automatic exclusion of temporary database files

## Technical Details

### Before
- Docker build ran on every push and PR (including feature branches)
- Test database files could be accidentally committed

### After
- Docker build only runs when code is merged to main or tags are created
- Test database files automatically ignored
- Estimated CI time reduction: 3-5 minutes per PR

🤖 Generated with [Claude Code](https://claude.ai/code)