### PR TITLE
feat: Implement Kubernetes secret management for ECS task conversion

### DIFF
--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -4,11 +4,14 @@ go 1.24.3
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/marcboeker/go-duckdb v1.8.5
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/kind v0.29.0
 )
 
@@ -30,7 +33,6 @@ require (
 	github.com/google/flatbuffers v25.1.24+incompatible // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
@@ -64,7 +67,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect

--- a/controlplane/internal/controlplane/api/server.go
+++ b/controlplane/internal/controlplane/api/server.go
@@ -22,6 +22,7 @@ type Server struct {
 	ecsService    generated.ECSServiceInterface
 	storage       storage.Storage
 	kindManager   *kubernetes.KindManager
+	taskManager   *kubernetes.TaskManager
 	region        string
 	accountID     string
 	webSocketHub  *WebSocketHub
@@ -39,6 +40,15 @@ func NewServer(port int, kubeconfig string, storage storage.Storage) *Server {
 		storage:      storage,
 		kindManager:  kubernetes.NewKindManager(),
 		webSocketHub: NewWebSocketHub(),
+	}
+
+	// Initialize task manager
+	taskManager, err := kubernetes.NewTaskManager(storage)
+	if err != nil {
+		log.Printf("Warning: Failed to initialize task manager: %v", err)
+		// Continue without task manager - some features may not work
+	} else {
+		s.taskManager = taskManager
 	}
 
 	// Initialize Web UI handler if enabled

--- a/controlplane/internal/converters/task_converter_test.go
+++ b/controlplane/internal/converters/task_converter_test.go
@@ -1,0 +1,278 @@
+package converters
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	"github.com/nandemo-ya/kecs/controlplane/internal/types"
+)
+
+func TestParseSecretARN(t *testing.T) {
+	converter := NewTaskConverter("ap-northeast-1", "123456789012")
+
+	tests := []struct {
+		name     string
+		arn      string
+		expected *SecretInfo
+	}{
+		{
+			name: "Secrets Manager ARN with JSON key",
+			arn:  "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf:username::",
+			expected: &SecretInfo{
+				SecretName: "kecs-secret-my-secret",
+				Key:        "username",
+				Source:     "secretsmanager",
+			},
+		},
+		{
+			name: "Secrets Manager ARN without JSON key",
+			arn:  "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
+			expected: &SecretInfo{
+				SecretName: "kecs-secret-my-secret",
+				Key:        "value",
+				Source:     "secretsmanager",
+			},
+		},
+		{
+			name: "SSM Parameter Store ARN",
+			arn:  "arn:aws:ssm:us-east-1:123456789012:parameter/app/database/password",
+			expected: &SecretInfo{
+				SecretName: "kecs-secret-app-database-password",
+				Key:        "value",
+				Source:     "ssm",
+			},
+		},
+		{
+			name:     "Invalid ARN",
+			arn:      "invalid-arn",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := converter.parseSecretARN(tt.arn)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expected.SecretName, result.SecretName)
+				assert.Equal(t, tt.expected.Key, result.Key)
+				assert.Equal(t, tt.expected.Source, result.Source)
+			}
+		})
+	}
+}
+
+func TestCollectSecrets(t *testing.T) {
+	converter := NewTaskConverter("ap-northeast-1", "123456789012")
+
+	containerDefs := []types.ContainerDefinition{
+		{
+			Name:  ptr.To("web"),
+			Image: ptr.To("nginx:latest"),
+			Secrets: []types.Secret{
+				{
+					Name:      ptr.To("DB_PASSWORD"),
+					ValueFrom: ptr.To("arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass-XyZ123"),
+				},
+				{
+					Name:      ptr.To("API_KEY"),
+					ValueFrom: ptr.To("arn:aws:ssm:us-east-1:123456789012:parameter/api/key"),
+				},
+			},
+		},
+		{
+			Name:  ptr.To("app"),
+			Image: ptr.To("myapp:latest"),
+			Secrets: []types.Secret{
+				{
+					Name:      ptr.To("DB_PASSWORD2"),
+					ValueFrom: ptr.To("arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass-XyZ123"), // Same secret
+				},
+			},
+		},
+	}
+
+	secrets := converter.CollectSecrets(containerDefs)
+
+	// Should have 2 unique secrets (db-pass and api/key)
+	assert.Len(t, secrets, 2)
+
+	// Check that the secrets were parsed correctly
+	dbSecretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass-XyZ123"
+	dbSecret, exists := secrets[dbSecretARN]
+	require.True(t, exists)
+	assert.Equal(t, "kecs-secret-db-pass", dbSecret.SecretName)
+	assert.Equal(t, "secretsmanager", dbSecret.Source)
+
+	apiKeyARN := "arn:aws:ssm:us-east-1:123456789012:parameter/api/key"
+	apiSecret, exists := secrets[apiKeyARN]
+	require.True(t, exists)
+	assert.Equal(t, "kecs-secret-api-key", apiSecret.SecretName)
+	assert.Equal(t, "ssm", apiSecret.Source)
+}
+
+func TestConvertSecrets(t *testing.T) {
+	converter := NewTaskConverter("ap-northeast-1", "123456789012")
+
+	secrets := []types.Secret{
+		{
+			Name:      ptr.To("DB_PASSWORD"),
+			ValueFrom: ptr.To("arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass-XyZ123:password::"),
+		},
+		{
+			Name:      ptr.To("API_KEY"),
+			ValueFrom: ptr.To("arn:aws:ssm:us-east-1:123456789012:parameter/api/key"),
+		},
+		{
+			Name:      ptr.To("INVALID"),
+			ValueFrom: ptr.To("invalid-arn"),
+		},
+	}
+
+	envVars := converter.convertSecrets(secrets)
+
+	// Should have 2 env vars (invalid ARN is skipped)
+	assert.Len(t, envVars, 2)
+
+	// Check DB_PASSWORD
+	dbEnv := envVars[0]
+	assert.Equal(t, "DB_PASSWORD", dbEnv.Name)
+	require.NotNil(t, dbEnv.ValueFrom)
+	require.NotNil(t, dbEnv.ValueFrom.SecretKeyRef)
+	assert.Equal(t, "kecs-secret-db-pass", dbEnv.ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "password", dbEnv.ValueFrom.SecretKeyRef.Key)
+
+	// Check API_KEY
+	apiEnv := envVars[1]
+	assert.Equal(t, "API_KEY", apiEnv.Name)
+	require.NotNil(t, apiEnv.ValueFrom)
+	require.NotNil(t, apiEnv.ValueFrom.SecretKeyRef)
+	assert.Equal(t, "kecs-secret-api-key", apiEnv.ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "value", apiEnv.ValueFrom.SecretKeyRef.Key)
+}
+
+func TestSanitizeSecretName(t *testing.T) {
+	converter := NewTaskConverter("ap-northeast-1", "123456789012")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple name",
+			input:    "my-secret",
+			expected: "kecs-secret-my-secret",
+		},
+		{
+			name:     "Name with special characters",
+			input:    "my_secret@123",
+			expected: "kecs-secret-my-secret-123",
+		},
+		{
+			name:     "Name with uppercase",
+			input:    "MySecret",
+			expected: "kecs-secret-mysecret",
+		},
+		{
+			name:     "Name with slashes",
+			input:    "/app/db/password",
+			expected: "kecs-secret-app-db-password",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := converter.sanitizeSecretName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTaskConverterWithSecrets(t *testing.T) {
+	converter := NewTaskConverter("ap-northeast-1", "123456789012")
+
+	// Create a task definition with secrets
+	containerDefs := []types.ContainerDefinition{
+		{
+			Name:  ptr.To("app"),
+			Image: ptr.To("myapp:latest"),
+			Environment: []types.KeyValuePair{
+				{Name: ptr.To("ENV"), Value: ptr.To("production")},
+			},
+			Secrets: []types.Secret{
+				{
+					Name:      ptr.To("DB_PASSWORD"),
+					ValueFrom: ptr.To("arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass-XyZ123"),
+				},
+			},
+			PortMappings: []types.PortMapping{
+				{ContainerPort: ptr.To(8080), Protocol: ptr.To("tcp")},
+			},
+		},
+	}
+
+	containerDefsJSON, err := json.Marshal(containerDefs)
+	require.NoError(t, err)
+
+	taskDef := &storage.TaskDefinition{
+		ARN:                  "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/app:1",
+		Family:               "app",
+		Revision:             1,
+		ContainerDefinitions: string(containerDefsJSON),
+		NetworkMode:          "bridge",
+		CPU:                  "256",
+		Memory:               "512",
+	}
+
+	runTaskReq := types.RunTaskRequest{
+		TaskDefinition: ptr.To("app:1"),
+		Cluster:        ptr.To("default"),
+		Count:          ptr.To(1),
+		LaunchType:     ptr.To("FARGATE"),
+	}
+	runTaskReqJSON, err := json.Marshal(runTaskReq)
+	require.NoError(t, err)
+
+	cluster := &storage.Cluster{
+		Name:   "default",
+		ARN:    "arn:aws:ecs:ap-northeast-1:123456789012:cluster/default",
+		Region: "ap-northeast-1",
+	}
+
+	// Convert to pod
+	pod, err := converter.ConvertTaskToPod(taskDef, runTaskReqJSON, cluster, "task-123")
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+
+	// Check pod basics
+	assert.Equal(t, "ecs-task-task-123", pod.Name)
+	assert.Equal(t, "default-ap-northeast-1", pod.Namespace)
+
+	// Check container
+	require.Len(t, pod.Spec.Containers, 1)
+	container := pod.Spec.Containers[0]
+	assert.Equal(t, "app", container.Name)
+	assert.Equal(t, "myapp:latest", container.Image)
+
+	// Check environment variables
+	require.Len(t, container.Env, 2) // 1 regular env + 1 secret
+	
+	// Regular env var
+	assert.Equal(t, "ENV", container.Env[0].Name)
+	assert.Equal(t, "production", container.Env[0].Value)
+	
+	// Secret env var
+	assert.Equal(t, "DB_PASSWORD", container.Env[1].Name)
+	require.NotNil(t, container.Env[1].ValueFrom)
+	require.NotNil(t, container.Env[1].ValueFrom.SecretKeyRef)
+	assert.Equal(t, "kecs-secret-db-pass", container.Env[1].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "value", container.Env[1].ValueFrom.SecretKeyRef.Key)
+}


### PR DESCRIPTION
## Summary
- Implement secret management for ECS task to Kubernetes pod conversion
- Support AWS Secrets Manager and SSM Parameter Store ARN formats
- Create Kubernetes secrets and proper environment variable references

## Changes
- **Task Converter Enhancements**:
  - Add `SecretInfo` struct to hold parsed secret information
  - Implement `parseSecretARN()` to parse AWS secret ARNs
  - Update `convertSecrets()` to create K8s env vars with secret references
  - Add `CollectSecrets()` to gather unique secrets from containers
  - Add `sanitizeSecretName()` for K8s-compatible names

- **Task Manager Updates**:
  - Modify `CreateTask()` to accept secrets parameter
  - Add `createSecrets()` method to create K8s secrets
  - Currently uses placeholder values (real AWS integration TODO)

- **API Integration**:
  - Update `handleRunTaskECS()` to use task converter
  - Add secret collection and creation logic
  - Integrate with existing pod deployment flow

## Test plan
- [x] Unit tests for ARN parsing (Secrets Manager and SSM)
- [x] Tests for secret collection from multiple containers
- [x] Tests for environment variable conversion
- [x] Tests for secret name sanitization
- [x] Integration test for full task conversion with secrets
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)