### PR TITLE
Add ADR-0010: Docker Proxy Support for Kind Containers

### DIFF
--- a/docs/adr/records/0010-docker-proxy-support.md
+++ b/docs/adr/records/0010-docker-proxy-support.md
@@ -1,0 +1,100 @@
+# ADR-0010: Docker Proxy Support for Kind Containers
+
+Date: 2025-06-07
+
+## Status
+
+Proposed
+
+## Context
+
+Users familiar with Docker but not Kubernetes need a way to view and manage containers running inside Kind clusters. Currently, they must:
+- Use `kubectl` commands (requires Kubernetes knowledge)
+- Execute `crictl` commands inside Kind nodes
+- Cannot use familiar `docker ps`, `docker logs`, etc.
+
+## Decision
+
+Implement Docker command proxy functionality in KECS that:
+
+1. **Docker API Compatibility Layer**
+   - Expose Docker Engine API-compatible endpoints
+   - Translate Docker API calls to Kind/crictl operations
+   - Support common Docker commands (ps, logs, exec, inspect)
+
+2. **Implementation Approaches**
+
+   ### Option A: Docker CLI Plugin
+   - Create `docker-kecs` plugin for Docker CLI
+   - Users can run: `docker kecs ps`, `docker kecs logs <container>`
+   - Leverages existing Docker CLI infrastructure
+
+   ### Option B: Standalone CLI with Docker-like Interface
+   - Create `kecs docker` subcommand
+   - Mimics Docker CLI syntax: `kecs docker ps`, `kecs docker logs`
+   - Full control over implementation
+
+   ### Option C: Docker Engine API Proxy
+   - Implement Docker Engine API endpoints in KECS
+   - Users can set `DOCKER_HOST=tcp://localhost:2375`
+   - Existing Docker tools work transparently
+
+## Proposed Solution
+
+Implement a hybrid approach:
+
+1. **Phase 1**: Standalone CLI (`kecs docker` subcommand)
+   - Quick to implement
+   - No Docker CLI modifications needed
+   - Good for testing the concept
+
+2. **Phase 2**: Docker Engine API subset
+   - Implement key Docker API endpoints
+   - Enable `DOCKER_HOST` compatibility
+   - Support for Docker ecosystem tools
+
+3. **Phase 3**: Docker CLI plugin (optional)
+   - Native Docker CLI integration
+   - Best user experience
+
+## Implementation Details
+
+### API Endpoints (Phase 2)
+```
+GET  /containers/json                 # docker ps
+GET  /containers/{id}/logs           # docker logs
+POST /containers/{id}/exec           # docker exec
+GET  /containers/{id}/json           # docker inspect
+```
+
+### Command Mapping
+```
+docker ps     -> crictl ps
+docker logs   -> crictl logs
+docker exec   -> crictl exec
+docker inspect -> crictl inspect
+```
+
+### Cluster Selection
+- Environment variable: `KECS_CLUSTER=<cluster-name>`
+- CLI flag: `--cluster <cluster-name>`
+- Default: active Kind cluster
+
+## Consequences
+
+### Positive
+- Familiar interface for Docker users
+- No Kubernetes knowledge required
+- Leverages existing Docker ecosystem
+- Gradual migration path to Kubernetes
+
+### Negative
+- Additional complexity in KECS
+- Not all Docker commands map cleanly
+- Potential confusion about container runtime differences
+- Maintenance burden for API compatibility
+
+## References
+- [Docker Engine API](https://docs.docker.com/engine/api/)
+- [CRI-tools (crictl)](https://github.com/kubernetes-sigs/cri-tools)
+- [Docker CLI Plugins](https://docs.docker.com/engine/extend/plugin_api/)

--- a/scripts/docker-ps-kind.sh
+++ b/scripts/docker-ps-kind.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Helper script to show containers running inside kind clusters
+# Similar to "docker ps" but for containers inside kind
+
+set -e
+
+# Function to show usage
+usage() {
+    echo "Usage: $0 [OPTIONS] [CLUSTER_NAME]"
+    echo ""
+    echo "Show containers running inside kind clusters (similar to docker ps)"
+    echo ""
+    echo "Options:"
+    echo "  -a, --all       Show all containers (default shows only running)"
+    echo "  -h, --help      Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0                    # Show containers in all kind clusters"
+    echo "  $0 my-cluster         # Show containers in specific cluster"
+    echo "  $0 -a my-cluster      # Show all containers including stopped ones"
+}
+
+# Parse arguments
+SHOW_ALL=""
+CLUSTER_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -a|--all)
+            SHOW_ALL="-a"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            CLUSTER_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
+# Function to format container info
+format_container_info() {
+    local cluster=$1
+    echo "=== Cluster: $cluster ==="
+    echo "CONTAINER ID    IMAGE                                               COMMAND                  CREATED         STATUS          NAMES"
+    docker exec "$cluster-control-plane" crictl ps $SHOW_ALL --no-trunc | tail -n +2 | while IFS= read -r line; do
+        # Extract fields from crictl output
+        container_id=$(echo "$line" | awk '{print substr($1, 1, 12)}')
+        image=$(echo "$line" | awk '{print $2}' | awk -F'/' '{print $NF}' | sed 's/:.*$//')
+        created=$(echo "$line" | awk '{print $3, $4, $5}')
+        state=$(echo "$line" | awk '{print $6}')
+        name=$(echo "$line" | awk '{print $7}')
+        
+        # Format similar to docker ps
+        printf "%-15s %-50s %-24s %-15s %-15s %s\n" \
+            "$container_id" "$image" "" "$created" "$state" "$name"
+    done
+    echo ""
+}
+
+# Get list of kind clusters
+if [ -n "$CLUSTER_NAME" ]; then
+    # Check if specified cluster exists
+    if ! kind get clusters | grep -q "^$CLUSTER_NAME$"; then
+        echo "Error: Cluster '$CLUSTER_NAME' not found"
+        echo "Available clusters:"
+        kind get clusters
+        exit 1
+    fi
+    clusters="$CLUSTER_NAME"
+else
+    # Get all clusters
+    clusters=$(kind get clusters)
+    if [ -z "$clusters" ]; then
+        echo "No kind clusters found"
+        exit 0
+    fi
+fi
+
+# Show containers for each cluster
+for cluster in $clusters; do
+    format_container_info "$cluster"
+done


### PR DESCRIPTION
## Summary
- Add architectural decision record for Docker command proxy functionality
- Include initial implementation of docker-ps-kind.sh helper script
- Enable Docker-familiar users to manage containers in Kind clusters

## Details
This PR introduces ADR-0010 which documents the design decision to add Docker command proxy functionality to KECS. This feature addresses the need for users who are familiar with Docker but not Kubernetes to easily view and manage containers running inside Kind clusters.

### Key Points:
- Proposes a phased approach starting with CLI commands
- Plans for Docker Engine API compatibility in later phases
- Includes a helper script `docker-ps-kind.sh` that demonstrates the concept

## Test plan
- [x] Review ADR for clarity and completeness
- [x] Test docker-ps-kind.sh script functionality
- [ ] Gather feedback on proposed approach

🤖 Generated with [Claude Code](https://claude.ai/code)