### PR TITLE
Fix issue #78: Add missing cluster attributes to CreateCluster response

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_handler.go
+++ b/controlplane/internal/controlplane/api/cluster_handler.go
@@ -142,7 +142,7 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 
 	// Extract settings and configuration from request
 	if req != nil {
-		if settings, ok := (*req)["settings"].(map[string]interface{}); ok {
+		if settings, ok := (*req)["settings"].([]interface{}); ok {
 			settingsJSON, _ := json.Marshal(settings)
 			cluster.Settings = string(settingsJSON)
 		}
@@ -153,6 +153,14 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 		if tags, ok := (*req)["tags"].([]interface{}); ok {
 			tagsJSON, _ := json.Marshal(tags)
 			cluster.Tags = string(tagsJSON)
+		}
+		if capacityProviders, ok := (*req)["capacityProviders"].([]interface{}); ok {
+			capacityProvidersJSON, _ := json.Marshal(capacityProviders)
+			cluster.CapacityProviders = string(capacityProvidersJSON)
+		}
+		if defaultCapacityProviderStrategy, ok := (*req)["defaultCapacityProviderStrategy"].([]interface{}); ok {
+			strategyJSON, _ := json.Marshal(defaultCapacityProviderStrategy)
+			cluster.DefaultCapacityProviderStrategy = string(strategyJSON)
 		}
 	}
 
@@ -174,6 +182,13 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 					"runningTasksCount":                 existingCluster.RunningTasksCount,
 					"pendingTasksCount":                 existingCluster.PendingTasksCount,
 					"activeServicesCount":               existingCluster.ActiveServicesCount,
+					// Add statistics sub-object
+					"statistics": map[string]interface{}{
+						"registeredContainerInstancesCount": existingCluster.RegisteredContainerInstancesCount,
+						"runningTasksCount":                 existingCluster.RunningTasksCount,
+						"pendingTasksCount":                 existingCluster.PendingTasksCount,
+						"activeServicesCount":               existingCluster.ActiveServicesCount,
+					},
 				},
 			}
 
@@ -192,6 +207,16 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 				var tags interface{}
 				json.Unmarshal([]byte(existingCluster.Tags), &tags)
 				(*response)["cluster"].(map[string]interface{})["tags"] = tags
+			}
+			if existingCluster.CapacityProviders != "" {
+				var capacityProviders interface{}
+				json.Unmarshal([]byte(existingCluster.CapacityProviders), &capacityProviders)
+				(*response)["cluster"].(map[string]interface{})["capacityProviders"] = capacityProviders
+			}
+			if existingCluster.DefaultCapacityProviderStrategy != "" {
+				var defaultCapacityProviderStrategy interface{}
+				json.Unmarshal([]byte(existingCluster.DefaultCapacityProviderStrategy), &defaultCapacityProviderStrategy)
+				(*response)["cluster"].(map[string]interface{})["defaultCapacityProviderStrategy"] = defaultCapacityProviderStrategy
 			}
 			
 			return response, nil
@@ -245,6 +270,13 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 			"runningTasksCount":                 cluster.RunningTasksCount,
 			"pendingTasksCount":                 cluster.PendingTasksCount,
 			"activeServicesCount":               cluster.ActiveServicesCount,
+			// Add statistics sub-object
+			"statistics": map[string]interface{}{
+				"registeredContainerInstancesCount": cluster.RegisteredContainerInstancesCount,
+				"runningTasksCount":                 cluster.RunningTasksCount,
+				"pendingTasksCount":                 cluster.PendingTasksCount,
+				"activeServicesCount":               cluster.ActiveServicesCount,
+			},
 		},
 	}
 
@@ -263,6 +295,16 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 		var tags interface{}
 		json.Unmarshal([]byte(cluster.Tags), &tags)
 		(*response)["cluster"].(map[string]interface{})["tags"] = tags
+	}
+	if cluster.CapacityProviders != "" {
+		var capacityProviders interface{}
+		json.Unmarshal([]byte(cluster.CapacityProviders), &capacityProviders)
+		(*response)["cluster"].(map[string]interface{})["capacityProviders"] = capacityProviders
+	}
+	if cluster.DefaultCapacityProviderStrategy != "" {
+		var defaultCapacityProviderStrategy interface{}
+		json.Unmarshal([]byte(cluster.DefaultCapacityProviderStrategy), &defaultCapacityProviderStrategy)
+		(*response)["cluster"].(map[string]interface{})["defaultCapacityProviderStrategy"] = defaultCapacityProviderStrategy
 	}
 
 	return response, nil
@@ -470,6 +512,13 @@ func buildDescribeClustersResponse(clusters []*storage.Cluster, failures []map[s
 			"runningTasksCount":                 cluster.RunningTasksCount,
 			"pendingTasksCount":                 cluster.PendingTasksCount,
 			"activeServicesCount":               cluster.ActiveServicesCount,
+			// Add statistics sub-object
+			"statistics": map[string]interface{}{
+				"registeredContainerInstancesCount": cluster.RegisteredContainerInstancesCount,
+				"runningTasksCount":                 cluster.RunningTasksCount,
+				"pendingTasksCount":                 cluster.PendingTasksCount,
+				"activeServicesCount":               cluster.ActiveServicesCount,
+			},
 		}
 
 		// Add optional fields
@@ -487,6 +536,16 @@ func buildDescribeClustersResponse(clusters []*storage.Cluster, failures []map[s
 			var tags interface{}
 			json.Unmarshal([]byte(cluster.Tags), &tags)
 			clusterMap["tags"] = tags
+		}
+		if cluster.CapacityProviders != "" {
+			var capacityProviders interface{}
+			json.Unmarshal([]byte(cluster.CapacityProviders), &capacityProviders)
+			clusterMap["capacityProviders"] = capacityProviders
+		}
+		if cluster.DefaultCapacityProviderStrategy != "" {
+			var defaultCapacityProviderStrategy interface{}
+			json.Unmarshal([]byte(cluster.DefaultCapacityProviderStrategy), &defaultCapacityProviderStrategy)
+			clusterMap["defaultCapacityProviderStrategy"] = defaultCapacityProviderStrategy
 		}
 
 		clusterList[i] = clusterMap

--- a/controlplane/internal/storage/duckdb/cluster_store.go
+++ b/controlplane/internal/storage/duckdb/cluster_store.go
@@ -34,14 +34,17 @@ func (s *clusterStore) Create(ctx context.Context, cluster *storage.Cluster) err
 			configuration, settings, tags, kind_cluster_name,
 			registered_container_instances_count, running_tasks_count,
 			pending_tasks_count, active_services_count,
+			capacity_providers, default_capacity_provider_strategy,
 			created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	// Convert empty strings to NULL for JSON fields
 	configuration := sql.NullString{String: cluster.Configuration, Valid: cluster.Configuration != ""}
 	settings := sql.NullString{String: cluster.Settings, Valid: cluster.Settings != ""}
 	tags := sql.NullString{String: cluster.Tags, Valid: cluster.Tags != ""}
 	kindClusterName := sql.NullString{String: cluster.KindClusterName, Valid: cluster.KindClusterName != ""}
+	capacityProviders := sql.NullString{String: cluster.CapacityProviders, Valid: cluster.CapacityProviders != ""}
+	defaultCapacityProviderStrategy := sql.NullString{String: cluster.DefaultCapacityProviderStrategy, Valid: cluster.DefaultCapacityProviderStrategy != ""}
 
 	_, err := s.db.ExecContext(ctx, query,
 		cluster.ID,
@@ -58,6 +61,8 @@ func (s *clusterStore) Create(ctx context.Context, cluster *storage.Cluster) err
 		cluster.RunningTasksCount,
 		cluster.PendingTasksCount,
 		cluster.ActiveServicesCount,
+		capacityProviders,
+		defaultCapacityProviderStrategy,
 		cluster.CreatedAt,
 		cluster.UpdatedAt,
 	)
@@ -77,12 +82,13 @@ func (s *clusterStore) Get(ctx context.Context, name string) (*storage.Cluster, 
 			configuration, settings, tags, kind_cluster_name,
 			registered_container_instances_count, running_tasks_count,
 			pending_tasks_count, active_services_count,
+			capacity_providers, default_capacity_provider_strategy,
 			created_at, updated_at
 		FROM clusters
 		WHERE name = ?`
 
 	cluster := &storage.Cluster{}
-	var configuration, settings, tags, kindClusterName sql.NullString
+	var configuration, settings, tags, kindClusterName, capacityProviders, defaultCapacityProviderStrategy sql.NullString
 
 	err := s.db.QueryRowContext(ctx, query, name).Scan(
 		&cluster.ID,
@@ -99,6 +105,8 @@ func (s *clusterStore) Get(ctx context.Context, name string) (*storage.Cluster, 
 		&cluster.RunningTasksCount,
 		&cluster.PendingTasksCount,
 		&cluster.ActiveServicesCount,
+		&capacityProviders,
+		&defaultCapacityProviderStrategy,
 		&cluster.CreatedAt,
 		&cluster.UpdatedAt,
 	)
@@ -115,6 +123,8 @@ func (s *clusterStore) Get(ctx context.Context, name string) (*storage.Cluster, 
 	cluster.Settings = settings.String
 	cluster.Tags = tags.String
 	cluster.KindClusterName = kindClusterName.String
+	cluster.CapacityProviders = capacityProviders.String
+	cluster.DefaultCapacityProviderStrategy = defaultCapacityProviderStrategy.String
 
 	return cluster, nil
 }
@@ -127,6 +137,7 @@ func (s *clusterStore) List(ctx context.Context) ([]*storage.Cluster, error) {
 			configuration, settings, tags, kind_cluster_name,
 			registered_container_instances_count, running_tasks_count,
 			pending_tasks_count, active_services_count,
+			capacity_providers, default_capacity_provider_strategy,
 			created_at, updated_at
 		FROM clusters
 		ORDER BY created_at DESC`
@@ -141,7 +152,7 @@ func (s *clusterStore) List(ctx context.Context) ([]*storage.Cluster, error) {
 
 	for rows.Next() {
 		cluster := &storage.Cluster{}
-		var configuration, settings, tags, kindClusterName sql.NullString
+		var configuration, settings, tags, kindClusterName, capacityProviders, defaultCapacityProviderStrategy sql.NullString
 
 		err := rows.Scan(
 			&cluster.ID,
@@ -158,6 +169,8 @@ func (s *clusterStore) List(ctx context.Context) ([]*storage.Cluster, error) {
 			&cluster.RunningTasksCount,
 			&cluster.PendingTasksCount,
 			&cluster.ActiveServicesCount,
+			&capacityProviders,
+			&defaultCapacityProviderStrategy,
 			&cluster.CreatedAt,
 			&cluster.UpdatedAt,
 		)
@@ -170,6 +183,8 @@ func (s *clusterStore) List(ctx context.Context) ([]*storage.Cluster, error) {
 		cluster.Settings = settings.String
 		cluster.Tags = tags.String
 		cluster.KindClusterName = kindClusterName.String
+		cluster.CapacityProviders = capacityProviders.String
+		cluster.DefaultCapacityProviderStrategy = defaultCapacityProviderStrategy.String
 
 		clusters = append(clusters, cluster)
 	}
@@ -200,6 +215,8 @@ func (s *clusterStore) Update(ctx context.Context, cluster *storage.Cluster) err
 			running_tasks_count = ?,
 			pending_tasks_count = ?,
 			active_services_count = ?,
+			capacity_providers = ?,
+			default_capacity_provider_strategy = ?,
 			updated_at = ?
 		WHERE name = ?`
 
@@ -208,6 +225,8 @@ func (s *clusterStore) Update(ctx context.Context, cluster *storage.Cluster) err
 	settings := sql.NullString{String: cluster.Settings, Valid: cluster.Settings != ""}
 	tags := sql.NullString{String: cluster.Tags, Valid: cluster.Tags != ""}
 	kindClusterName := sql.NullString{String: cluster.KindClusterName, Valid: cluster.KindClusterName != ""}
+	capacityProviders := sql.NullString{String: cluster.CapacityProviders, Valid: cluster.CapacityProviders != ""}
+	defaultCapacityProviderStrategy := sql.NullString{String: cluster.DefaultCapacityProviderStrategy, Valid: cluster.DefaultCapacityProviderStrategy != ""}
 
 	result, err := s.db.ExecContext(ctx, query,
 		cluster.ARN,
@@ -222,6 +241,8 @@ func (s *clusterStore) Update(ctx context.Context, cluster *storage.Cluster) err
 		cluster.RunningTasksCount,
 		cluster.PendingTasksCount,
 		cluster.ActiveServicesCount,
+		capacityProviders,
+		defaultCapacityProviderStrategy,
 		cluster.UpdatedAt,
 		cluster.Name,
 	)

--- a/controlplane/internal/storage/duckdb/duckdb.go
+++ b/controlplane/internal/storage/duckdb/duckdb.go
@@ -150,6 +150,8 @@ func (s *DuckDBStorage) createClustersTable(ctx context.Context) error {
 		running_tasks_count INTEGER DEFAULT 0,
 		pending_tasks_count INTEGER DEFAULT 0,
 		active_services_count INTEGER DEFAULT 0,
+		capacity_providers JSON,
+		default_capacity_provider_strategy JSON,
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL
 	)`

--- a/controlplane/internal/storage/interfaces.go
+++ b/controlplane/internal/storage/interfaces.go
@@ -94,6 +94,12 @@ type Cluster struct {
 	PendingTasksCount                 int `json:"pendingTasksCount"`
 	ActiveServicesCount               int `json:"activeServicesCount"`
 	
+	// Capacity providers as JSON
+	CapacityProviders string `json:"capacityProviders,omitempty"`
+	
+	// Default capacity provider strategy as JSON
+	DefaultCapacityProviderStrategy string `json:"defaultCapacityProviderStrategy,omitempty"`
+	
 	// Timestamps
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`

--- a/test-db-query.sh
+++ b/test-db-query.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Direct database query test
+echo "Checking database content for cluster..."
+
+# Find the database file
+DB_FILE=$(find ~/.kecs -name "kecs.db" 2>/dev/null | head -1)
+
+if [ -z "$DB_FILE" ]; then
+  echo "Database file not found"
+  exit 1
+fi
+
+echo "Found database: $DB_FILE"
+
+# Query the clusters table
+echo -e "\nQuerying clusters table..."
+echo "SELECT name, settings, capacity_providers, default_capacity_provider_strategy FROM clusters WHERE name = 'test-issue-78-complete';" | sqlite3 "$DB_FILE" 2>/dev/null || \
+echo "SELECT name, settings, capacity_providers, default_capacity_provider_strategy FROM clusters WHERE name = 'test-issue-78-complete';" | duckdb "$DB_FILE" 2>/dev/null || \
+echo "Could not query database (neither sqlite3 nor duckdb command available)"

--- a/test-issue-78.sh
+++ b/test-issue-78.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Test script for issue #78 - CreateCluster missing attributes
+
+echo "Testing CreateCluster with all attributes..."
+
+# Generate unique cluster name
+CLUSTER_NAME="test-issue-78-$(date +%s)"
+
+# Create a cluster with all attributes
+RESPONSE=$(curl -s -X POST http://localhost:8080/v1/CreateCluster \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.CreateCluster" \
+  -d '{
+    "clusterName": "'$CLUSTER_NAME'",
+    "tags": [
+      {"key": "Environment", "value": "test"},
+      {"key": "Team", "value": "backend"}
+    ],
+    "settings": [
+      {"name": "containerInsights", "value": "enabled"}
+    ],
+    "capacityProviders": ["FARGATE", "FARGATE_SPOT"],
+    "defaultCapacityProviderStrategy": [
+      {"capacityProvider": "FARGATE", "weight": 1, "base": 0}
+    ]
+  }')
+
+echo "Response:"
+if [ -z "$RESPONSE" ]; then
+  echo "Empty response - cluster might already exist"
+else
+  echo "$RESPONSE" | jq .
+fi
+
+echo -e "\nChecking for required fields..."
+
+# Check for statistics
+if echo "$RESPONSE" | jq -e '.cluster.statistics' > /dev/null; then
+  echo "✓ statistics field present"
+else
+  echo "✗ statistics field missing"
+fi
+
+# Check for tags
+if echo "$RESPONSE" | jq -e '.cluster.tags' > /dev/null; then
+  echo "✓ tags field present"
+else
+  echo "✗ tags field missing"
+fi
+
+# Check for settings
+if echo "$RESPONSE" | jq -e '.cluster.settings' > /dev/null; then
+  echo "✓ settings field present"
+else
+  echo "✗ settings field missing"
+fi
+
+# Check for capacityProviders
+if echo "$RESPONSE" | jq -e '.cluster.capacityProviders' > /dev/null; then
+  echo "✓ capacityProviders field present"
+else
+  echo "✗ capacityProviders field missing"
+fi
+
+# Check for defaultCapacityProviderStrategy
+if echo "$RESPONSE" | jq -e '.cluster.defaultCapacityProviderStrategy' > /dev/null; then
+  echo "✓ defaultCapacityProviderStrategy field present"
+else
+  echo "✗ defaultCapacityProviderStrategy field missing"
+fi


### PR DESCRIPTION
## Summary
- Add all missing fields (statistics, tags, settings, capacityProviders, defaultCapacityProviderStrategy) to CreateCluster response
- Update storage layer to support new cluster attributes
- Fix settings field parsing issue

## Changes
1. **Storage Interface Updates**:
   - Added `CapacityProviders` and `DefaultCapacityProviderStrategy` fields to Cluster struct
   - Updated database schema to include new JSON columns

2. **API Handler Updates**:
   - Fixed settings field extraction to expect array instead of map (matching AWS ECS API)
   - Added statistics sub-object to CreateCluster response
   - Added proper handling for all optional fields in response

3. **Database Updates**:
   - Added capacity_providers and default_capacity_provider_strategy columns
   - Updated all CRUD operations to handle new fields with proper NULL handling

## Test Results
All required fields are now present in the CreateCluster response:
```
✓ statistics field present
✓ tags field present
✓ settings field present
✓ capacityProviders field present
✓ defaultCapacityProviderStrategy field present
```

## Test Script
A comprehensive test script (`test-issue-78.sh`) has been added to verify the implementation.

Fixes #78

🤖 Generated with [Claude Code](https://claude.ai/code)