### PR TITLE
feat: Reuse kind clusters for the same ECS cluster

### DIFF
--- a/test-kind-reuse-existing.sh
+++ b/test-kind-reuse-existing.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Test script for kind cluster reuse with existing cluster
+
+echo "=== Testing kind cluster reuse with pre-existing ECS cluster ==="
+
+CLUSTER_NAME="test-existing-cluster"
+
+# First, create a cluster
+echo -e "\n1. Creating ECS cluster '$CLUSTER_NAME'..."
+curl -s -X POST http://localhost:8080/v1/CreateCluster \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.CreateCluster" \
+  -d '{
+    "clusterName": "'$CLUSTER_NAME'",
+    "tags": [{"key": "Test", "value": "existing"}]
+  }' | jq -r '.cluster.clusterName // "Created"'
+
+# Wait for kind cluster to be created
+echo -e "\n2. Waiting for kind cluster creation..."
+sleep 15
+
+# Check kind clusters
+echo -e "\n3. Current kind clusters:"
+docker ps --filter "name=kecs-$CLUSTER_NAME" --format "table {{.Names}}\t{{.Status}}"
+
+# Delete the kind cluster manually (simulate manual deletion)
+echo -e "\n4. Deleting kind cluster manually (simulating accidental deletion)..."
+docker rm -f "kecs-$CLUSTER_NAME-control-plane" 2>/dev/null
+
+# Verify it's gone
+echo -e "\n5. Kind clusters after manual deletion:"
+docker ps --filter "name=kecs-$CLUSTER_NAME" --format "table {{.Names}}\t{{.Status}}"
+
+# Try to use the cluster again - should recreate the kind cluster
+echo -e "\n6. Trying to use the ECS cluster again (should recreate kind cluster)..."
+DESCRIBE_RESPONSE=$(curl -s -X POST http://localhost:8080/v1/DescribeClusters \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.DescribeClusters" \
+  -d '{"clusters": ["'$CLUSTER_NAME'"]}')
+
+echo "Describe response:"
+echo "$DESCRIBE_RESPONSE" | jq -r '.clusters[0].clusterName // "Not found"'
+
+# Wait for potential recreation
+echo -e "\n7. Waiting for potential kind cluster recreation..."
+sleep 10
+
+# Check if kind cluster was recreated
+echo -e "\n8. Kind clusters after describe operation:"
+docker ps --filter "name=kecs-$CLUSTER_NAME" --format "table {{.Names}}\t{{.Status}}"
+
+# Count kind clusters with this name
+COUNT=$(docker ps --filter "name=kecs-$CLUSTER_NAME" -q | wc -l)
+echo -e "\nNumber of kind clusters for '$CLUSTER_NAME': $COUNT"
+
+# Cleanup - delete the test cluster
+echo -e "\n9. Cleaning up - deleting ECS cluster..."
+curl -s -X POST http://localhost:8080/v1/DeleteCluster \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.DeleteCluster" \
+  -d '{"cluster": "'$CLUSTER_NAME'"}' > /dev/null
+
+echo "Done."

--- a/test-kind-reuse.sh
+++ b/test-kind-reuse.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Test script for kind cluster reuse feature
+
+echo "=== Testing kind cluster reuse ==="
+
+CLUSTER_NAME="test-reuse-cluster"
+
+# First, create a cluster
+echo -e "\n1. Creating ECS cluster '$CLUSTER_NAME'..."
+RESPONSE1=$(curl -s -X POST http://localhost:8080/v1/CreateCluster \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.CreateCluster" \
+  -d '{
+    "clusterName": "'$CLUSTER_NAME'",
+    "tags": [{"key": "Test", "value": "reuse"}]
+  }')
+
+echo "Response:"
+echo "$RESPONSE1" | jq -r '.cluster.clusterName // empty'
+
+# Wait for kind cluster to be created
+echo -e "\n2. Waiting for kind cluster creation..."
+sleep 10
+
+# Check kind clusters
+echo -e "\n3. Current kind clusters:"
+docker ps --filter "name=kecs-$CLUSTER_NAME" --format "table {{.Names}}\t{{.Status}}"
+
+# Create the same cluster again
+echo -e "\n4. Creating the same ECS cluster again..."
+RESPONSE2=$(curl -s -X POST http://localhost:8080/v1/CreateCluster \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.CreateCluster" \
+  -d '{
+    "clusterName": "'$CLUSTER_NAME'",
+    "tags": [{"key": "Test", "value": "reuse"}]
+  }')
+
+echo "Response:"
+if [ -z "$RESPONSE2" ]; then
+  echo "(Empty response - cluster already exists)"
+else
+  echo "$RESPONSE2" | jq -r '.cluster.clusterName // empty'
+fi
+
+# Wait a bit
+sleep 5
+
+# Check kind clusters again
+echo -e "\n5. Kind clusters after second create (should be the same):"
+docker ps --filter "name=kecs-$CLUSTER_NAME" --format "table {{.Names}}\t{{.Status}}"
+
+# Count kind clusters with this name
+COUNT=$(docker ps --filter "name=kecs-$CLUSTER_NAME" -q | wc -l)
+echo -e "\nNumber of kind clusters for '$CLUSTER_NAME': $COUNT"
+
+if [ "$COUNT" -eq 1 ]; then
+  echo "✓ SUCCESS: Only one kind cluster exists (reused successfully)"
+else
+  echo "✗ FAIL: Expected 1 kind cluster, found $COUNT"
+fi
+
+# Cleanup - delete the test cluster
+echo -e "\n6. Cleaning up - deleting ECS cluster..."
+curl -s -X POST http://localhost:8080/v1/DeleteCluster \
+  -H "Content-Type: application/x-amz-json-1.1" \
+  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.DeleteCluster" \
+  -d '{"cluster": "'$CLUSTER_NAME'"}' > /dev/null
+
+echo "Done."


### PR DESCRIPTION
## Summary
- Prevent creating multiple kind clusters for the same ECS cluster
- Generate deterministic kind cluster names based on ECS cluster name
- Reuse existing kind clusters when possible

## Problem
Previously, every `CreateCluster` call would generate a new random kind cluster name, leading to:
- Multiple kind containers for the same ECS cluster
- Wasted resources
- Confusion about which kind cluster belongs to which ECS cluster

## Solution
1. **Deterministic naming**: Kind cluster names are now generated deterministically as `kecs-<ecs-cluster-name>`
2. **Existence check**: Before creating a new kind cluster, check if one already exists
3. **Automatic recreation**: If an existing ECS cluster's kind cluster is missing (e.g., manually deleted), it's automatically recreated

## Test Results
```
✓ SUCCESS: Only one kind cluster exists (reused successfully)
```

The test script confirms that:
- First CreateCluster creates a new kind cluster
- Second CreateCluster reuses the existing kind cluster
- No duplicate kind clusters are created

## Benefits
- 🔄 Resource efficiency: No duplicate kind clusters
- ⚡ Faster cluster operations: Skip creation if cluster exists
- 🎯 Clear mapping: One ECS cluster = One kind cluster
- 🔧 Self-healing: Automatically recreates missing kind clusters

🤖 Generated with [Claude Code](https://claude.ai/code)