### PR TITLE
fix: Improve Phase 2 test compatibility

### DIFF
--- a/controlplane/internal/controlplane/api/ecs_handler.go
+++ b/controlplane/internal/controlplane/api/ecs_handler.go
@@ -117,6 +117,8 @@ func (s *Server) handleECSRequest(w http.ResponseWriter, r *http.Request) {
 		s.handleECSUntagResource(w, body)
 	case "ListTagsForResource":
 		s.handleECSListTagsForResource(w, body)
+	case "ListTaskDefinitionFamilies":
+		s.handleECSListTaskDefinitionFamilies(w, body)
 	default:
 		// Return a basic empty response for unsupported operations
 		s.handleUnsupportedOperation(w, operation)

--- a/controlplane/internal/controlplane/api/service_handler.go
+++ b/controlplane/internal/controlplane/api/service_handler.go
@@ -20,7 +20,12 @@ import (
 func (s *Server) handleECSCreateService(w http.ResponseWriter, body []byte) {
 	var req CreateServiceRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		errorResponse := map[string]interface{}{
+			"__type": "InvalidParameterException",
+			"message": "Invalid request body",
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -28,7 +33,12 @@ func (s *Server) handleECSCreateService(w http.ResponseWriter, body []byte) {
 	resp, err := s.CreateServiceWithStorage(ctx, req)
 	if err != nil {
 		log.Printf("Error creating service: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		errorResponse := map[string]interface{}{
+			"__type": "ServiceException",
+			"message": err.Error(),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -41,7 +51,12 @@ func (s *Server) handleECSCreateService(w http.ResponseWriter, body []byte) {
 func (s *Server) handleECSDescribeServices(w http.ResponseWriter, body []byte) {
 	var req DescribeServicesRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		errorResponse := map[string]interface{}{
+			"__type": "InvalidParameterException",
+			"message": "Invalid request body",
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -49,7 +64,12 @@ func (s *Server) handleECSDescribeServices(w http.ResponseWriter, body []byte) {
 	resp, err := s.DescribeServicesWithStorage(ctx, req)
 	if err != nil {
 		log.Printf("Error describing services: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		errorResponse := map[string]interface{}{
+			"__type": "ServiceException",
+			"message": err.Error(),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -62,7 +82,12 @@ func (s *Server) handleECSDescribeServices(w http.ResponseWriter, body []byte) {
 func (s *Server) handleECSListServices(w http.ResponseWriter, body []byte) {
 	var req ListServicesRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		errorResponse := map[string]interface{}{
+			"__type": "InvalidParameterException",
+			"message": "Invalid request body",
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -70,7 +95,12 @@ func (s *Server) handleECSListServices(w http.ResponseWriter, body []byte) {
 	resp, err := s.ListServicesWithStorage(ctx, req)
 	if err != nil {
 		log.Printf("Error listing services: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		errorResponse := map[string]interface{}{
+			"__type": "ServiceException",
+			"message": err.Error(),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -83,7 +113,12 @@ func (s *Server) handleECSListServices(w http.ResponseWriter, body []byte) {
 func (s *Server) handleECSUpdateService(w http.ResponseWriter, body []byte) {
 	var req UpdateServiceRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		errorResponse := map[string]interface{}{
+			"__type": "InvalidParameterException",
+			"message": "Invalid request body",
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -91,7 +126,12 @@ func (s *Server) handleECSUpdateService(w http.ResponseWriter, body []byte) {
 	resp, err := s.UpdateServiceWithStorage(ctx, req)
 	if err != nil {
 		log.Printf("Error updating service: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		errorResponse := map[string]interface{}{
+			"__type": "ServiceException",
+			"message": err.Error(),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -104,7 +144,12 @@ func (s *Server) handleECSUpdateService(w http.ResponseWriter, body []byte) {
 func (s *Server) handleECSDeleteService(w http.ResponseWriter, body []byte) {
 	var req DeleteServiceRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		errorResponse := map[string]interface{}{
+			"__type": "InvalidParameterException",
+			"message": "Invalid request body",
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 
@@ -112,7 +157,12 @@ func (s *Server) handleECSDeleteService(w http.ResponseWriter, body []byte) {
 	resp, err := s.DeleteServiceWithStorage(ctx, req)
 	if err != nil {
 		log.Printf("Error deleting service: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		errorResponse := map[string]interface{}{
+			"__type": "ServiceException",
+			"message": err.Error(),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errorResponse)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Fix Phase 2 test failures by implementing missing functionality and improving error handling
- Add workaround for DuckDB constraint checking bug

## Changes
1. **API Improvements**
   - Add `ListTaskDefinitionFamilies` endpoint implementation
   - Convert all error responses to JSON format for AWS ECS compatibility
   - Fix error response format in service handlers

2. **Validation Enhancements**
   - Add validation for required fields (`family`, `containerDefinitions`)
   - Add validation for container memory values (must be > 0)
   - Improve error messages to match test expectations

3. **DuckDB Workaround**
   - Implement workaround for known DuckDB UPDATE constraint bug
   - Add error detection and recovery logic for constraint violations
   - Document the issue with references to DuckDB GitHub issues

## Known Issues
- DuckDB has a known bug where UPDATE operations on tables with primary key constraints can incorrectly trigger "Duplicate key" errors even when not modifying the primary key
- This affects the `DeregisterTaskDefinition` operation
- Added workaround code to detect and handle this specific error
- See: https://github.com/duckdb/duckdb/issues/8764

## Test Results
- Fixed several Phase 2 test failures
- Validation tests now pass
- ListTaskDefinitionFamilies test passes
- DeregisterTaskDefinition still has issues due to DuckDB bug (workaround implemented)

🤖 Generated with [Claude Code](https://claude.ai/code)