### PR TITLE
fix: Fix AWS CLI 'str' object has no attribute 'get' error

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_handler.go
+++ b/controlplane/internal/controlplane/api/cluster_handler.go
@@ -210,12 +210,12 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 					"runningTasksCount":                 existingCluster.RunningTasksCount,
 					"pendingTasksCount":                 existingCluster.PendingTasksCount,
 					"activeServicesCount":               existingCluster.ActiveServicesCount,
-					// Add statistics sub-object
-					"statistics": map[string]interface{}{
-						"registeredContainerInstancesCount": existingCluster.RegisteredContainerInstancesCount,
-						"runningTasksCount":                 existingCluster.RunningTasksCount,
-						"pendingTasksCount":                 existingCluster.PendingTasksCount,
-						"activeServicesCount":               existingCluster.ActiveServicesCount,
+					// Add statistics as array of key-value pairs
+					"statistics": []map[string]interface{}{
+						{"name": "registeredContainerInstancesCount", "value": fmt.Sprintf("%d", existingCluster.RegisteredContainerInstancesCount)},
+						{"name": "runningTasksCount", "value": fmt.Sprintf("%d", existingCluster.RunningTasksCount)},
+						{"name": "pendingTasksCount", "value": fmt.Sprintf("%d", existingCluster.PendingTasksCount)},
+						{"name": "activeServicesCount", "value": fmt.Sprintf("%d", existingCluster.ActiveServicesCount)},
 					},
 				},
 			}
@@ -305,12 +305,12 @@ func (s *Server) CreateClusterWithStorage(ctx context.Context, req *generated.Cr
 			"runningTasksCount":                 cluster.RunningTasksCount,
 			"pendingTasksCount":                 cluster.PendingTasksCount,
 			"activeServicesCount":               cluster.ActiveServicesCount,
-			// Add statistics sub-object
-			"statistics": map[string]interface{}{
-				"registeredContainerInstancesCount": cluster.RegisteredContainerInstancesCount,
-				"runningTasksCount":                 cluster.RunningTasksCount,
-				"pendingTasksCount":                 cluster.PendingTasksCount,
-				"activeServicesCount":               cluster.ActiveServicesCount,
+			// Add statistics as array of key-value pairs
+			"statistics": []map[string]interface{}{
+				{"name": "registeredContainerInstancesCount", "value": fmt.Sprintf("%d", cluster.RegisteredContainerInstancesCount)},
+				{"name": "runningTasksCount", "value": fmt.Sprintf("%d", cluster.RunningTasksCount)},
+				{"name": "pendingTasksCount", "value": fmt.Sprintf("%d", cluster.PendingTasksCount)},
+				{"name": "activeServicesCount", "value": fmt.Sprintf("%d", cluster.ActiveServicesCount)},
 			},
 		},
 	}
@@ -547,12 +547,12 @@ func buildDescribeClustersResponse(clusters []*storage.Cluster, failures []map[s
 			"runningTasksCount":                 cluster.RunningTasksCount,
 			"pendingTasksCount":                 cluster.PendingTasksCount,
 			"activeServicesCount":               cluster.ActiveServicesCount,
-			// Add statistics sub-object
-			"statistics": map[string]interface{}{
-				"registeredContainerInstancesCount": cluster.RegisteredContainerInstancesCount,
-				"runningTasksCount":                 cluster.RunningTasksCount,
-				"pendingTasksCount":                 cluster.PendingTasksCount,
-				"activeServicesCount":               cluster.ActiveServicesCount,
+			// Add statistics as array of key-value pairs
+			"statistics": []map[string]interface{}{
+				{"name": "registeredContainerInstancesCount", "value": fmt.Sprintf("%d", cluster.RegisteredContainerInstancesCount)},
+				{"name": "runningTasksCount", "value": fmt.Sprintf("%d", cluster.RunningTasksCount)},
+				{"name": "pendingTasksCount", "value": fmt.Sprintf("%d", cluster.PendingTasksCount)},
+				{"name": "activeServicesCount", "value": fmt.Sprintf("%d", cluster.ActiveServicesCount)},
 			},
 		}
 


### PR DESCRIPTION
## Summary
- Fixed statistics field format in cluster responses to match AWS ECS API specification
- Changed from object to array of key-value pairs

## Problem
When using AWS CLI with KECS profile (`aws ecs create-cluster --cluster-name my-cluster --profile kecs`), it failed with:
```
'str' object has no attribute 'get'
```

This occurred because AWS CLI expected the `statistics` field to be an array of key-value pairs, but KECS was returning it as an object.

## Solution
Changed the statistics format from:
```json
"statistics": {
  "registeredContainerInstancesCount": 0,
  "runningTasksCount": 0,
  "pendingTasksCount": 0,
  "activeServicesCount": 0
}
```

To the correct format:
```json
"statistics": [
  {"name": "registeredContainerInstancesCount", "value": "0"},
  {"name": "runningTasksCount", "value": "0"},
  {"name": "pendingTasksCount", "value": "0"},
  {"name": "activeServicesCount", "value": "0"}
]
```

This matches the `Cluster` struct definition where `Statistics` is `[]KeyValuePair`.

## Test Plan
Tested with AWS CLI:
```bash
aws ecs create-cluster --cluster-name my-cluster --profile kecs
aws ecs list-clusters --profile kecs
```

Both commands now work correctly without errors.

🤖 Generated with [Claude Code](https://claude.ai/code)