### PR TITLE
feat: Optimize GitHub Actions with Docker layer caching

### DIFF
--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -30,6 +30,11 @@ jobs:
           go mod download
           go mod tidy
 
+      - name: Install ginkgo
+        run: |
+          cd tests/scenarios
+          go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
       - name: Install AWS CLI v2
         uses: unfor19/install-aws-cli-action@v1
         with:
@@ -37,17 +42,24 @@ jobs:
           verbose: false
           arch: amd64
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build KECS Docker image
-        run: |
-          cd controlplane
-          docker build -t kecs:test .
+        uses: docker/build-push-action@v5
+        with:
+          context: ./controlplane
+          tags: kecs:test
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run Phase 1 tests (Foundation)
         id: test-phase1
         run: |
           cd tests/scenarios
           echo "## Running Phase 1: Foundation tests ##"
-          go run github.com/onsi/ginkgo/v2/ginkgo -v -timeout 30m \
+          ginkgo -v -timeout 30m \
             --no-color \
             --junit-report=junit-phase1.xml \
             --output-dir=. \
@@ -64,7 +76,7 @@ jobs:
         run: |
           cd tests/scenarios
           echo "## Running Phase 2: Core Operations tests ##"
-          go run github.com/onsi/ginkgo/v2/ginkgo -v -timeout 30m \
+          ginkgo -v -timeout 30m \
             --no-color \
             --junit-report=junit-phase2.xml \
             --output-dir=. \
@@ -81,7 +93,7 @@ jobs:
         run: |
           cd tests/scenarios
           echo "## Running Phase 3: Task Lifecycle & Status tests ##"
-          go run github.com/onsi/ginkgo/v2/ginkgo -v -timeout 30m \
+          ginkgo -v -timeout 30m \
             --no-color \
             --junit-report=junit-phase3.xml \
             --output-dir=. \
@@ -98,7 +110,7 @@ jobs:
         run: |
           cd tests/scenarios
           echo "## Running Phase 4: Advanced Service Operations tests ##"
-          go run github.com/onsi/ginkgo/v2/ginkgo -v -timeout 30m \
+          ginkgo -v -timeout 30m \
             --no-color \
             --junit-report=junit-phase4.xml \
             --output-dir=. \


### PR DESCRIPTION
## Summary
- Optimize scenario tests execution time in GitHub Actions
- Add Docker layer caching to reduce build time
- Pre-install ginkgo to avoid repeated compilation

## Changes

### 1. Docker Layer Caching
- Added `docker/setup-buildx-action@v3` for buildx support
- Changed to `docker/build-push-action@v5` with cache configuration
- Uses GitHub Actions cache (`type=gha`) to persist layers between runs

### 2. Ginkgo Installation
- Pre-install ginkgo binary once after downloading dependencies
- Replace `go run github.com/onsi/ginkgo/v2/ginkgo` with direct `ginkgo` command
- Saves ~10-15 seconds per test phase

## Expected Improvements

1. **Docker build time**: 
   - First run: Same as before (full build)
   - Subsequent runs: Reduced from ~2-3 minutes to ~30 seconds

2. **Test execution**:
   - Each phase saves ~10-15 seconds from ginkgo compilation
   - Total savings: ~40-60 seconds across 4 phases

3. **Overall CI time reduction**: 30-50% expected

## Test Plan
The PR itself will demonstrate the improvement as the scenario tests will run with these optimizations.

🤖 Generated with [Claude Code](https://claude.ai/code)