### PR TITLE
fix: Fix kubeconfig path generation in KindManager

### DIFF
--- a/controlplane/internal/kubernetes/kind_manager.go
+++ b/controlplane/internal/kubernetes/kind_manager.go
@@ -125,7 +125,7 @@ func (k *KindManager) GetClusterNodes(clusterName string) ([]nodes.Node, error) 
 
 func (k *KindManager) getKubeconfigPath(kecsClusterName string) string {
 	homeDir, _ := os.UserHomeDir()
-	return filepath.Join(homeDir, ".kube", fmt.Sprintf("kecs-%s.config", kecsClusterName))
+	return filepath.Join(homeDir, ".kube", fmt.Sprintf("%s.config", kecsClusterName))
 }
 
 // GetKubeConfig returns a kubernetes config for the current context


### PR DESCRIPTION
## Summary

This PR fixes an issue where kubeconfig files were being created with duplicate 'kecs-' prefixes in their filenames.

## Problem
When creating a Kind cluster for KECS, the kubeconfig file was being saved with names like:
-  
- 

This happened because the  parameter already contains the 'kecs-' prefix, but the  method was adding it again.

## Solution
Remove the duplicate prefix from the  method:

```go
// Before
return filepath.Join(homeDir, ".kube", fmt.Sprintf("kecs-%s.config", kecsClusterName))

// After  
return filepath.Join(homeDir, ".kube", fmt.Sprintf("%s.config", kecsClusterName))
```

## Testing
- Started KECS server with Starting KECS Control Plane server on port 8080 with log level info
Starting KECS Admin server on port 8081
Using in-cluster configuration or default kubeconfig
Using database: /Users/stormcat/.kecs/data/kecs.db
- Created cluster with {
    "cluster": {
        "clusterArn": "arn:aws:ecs:ap-northeast-1:123456789012:cluster/test-cluster",
        "clusterName": "test-cluster",
        "status": "ACTIVE"
    }
}
- Verified Kind cluster was created successfully
- Confirmed kubeconfig file has correct name without duplicate prefix

🤖 Generated with [Claude Code](https://claude.ai/code)