### PR TITLE
fix: Handle branch names with slashes in VS Code workspace files

### DIFF
--- a/docs/development/worktree-workflow.md
+++ b/docs/development/worktree-workflow.md
@@ -141,6 +141,8 @@ Open a workspace:
 code ../kecs-worktrees/feat/proxy-modes/kecs-feat-proxy-modes.code-workspace
 ```
 
+Note: For branch names with slashes (e.g., `feat/proxy-modes`), the workspace filename will have dashes instead (e.g., `kecs-feat-proxy-modes.code-workspace`).
+
 ## AI Agent Development
 
 When using AI agents (like Claude) for development:

--- a/scripts/setup-dev-worktrees.sh
+++ b/scripts/setup-dev-worktrees.sh
@@ -133,7 +133,9 @@ setup_dependencies() {
 create_vscode_workspace() {
     local branch_name=$1
     local worktree_path="${WORKTREE_DIR}/${branch_name}"
-    local workspace_file="${worktree_path}/kecs-${branch_name}.code-workspace"
+    # Replace slashes with dashes for filename
+    local safe_branch_name=$(echo "$branch_name" | tr '/' '-')
+    local workspace_file="${worktree_path}/kecs-${safe_branch_name}.code-workspace"
     
     print_info "Creating VS Code workspace file for ${branch_name}"
     
@@ -320,7 +322,7 @@ main() {
     echo ""
     echo "To work on a feature:"
     echo "  cd ${WORKTREE_DIR}/<branch-name>"
-    echo "  code kecs-<branch-name>.code-workspace"
+    echo "  code kecs-<branch-name>.code-workspace  # Note: slashes in branch names are replaced with dashes"
     echo ""
     echo "To run tests in a worktree:"
     echo "  cd ${WORKTREE_DIR}/<branch-name>/controlplane"


### PR DESCRIPTION
## Summary
- Fix 'No such file or directory' error when creating worktrees for branches with slashes

## Problem
When running `./scripts/setup-dev-worktrees.sh fix/scenario-test-phase1`, the script failed with:
```
./scripts/setup-dev-worktrees.sh: line 140: .../kecs-fix/scenario-test-phase1.code-workspace: No such file or directory
```

## Solution
- Replace slashes with dashes in VS Code workspace filenames
- Update documentation to explain the naming convention
- For branch `fix/scenario-test-phase1`, the workspace file will be `kecs-fix-scenario-test-phase1.code-workspace`

## Testing
```bash
./scripts/setup-dev-worktrees.sh fix/scenario-test-phase1
# Should create workspace file: kecs-fix-scenario-test-phase1.code-workspace
```

🤖 Generated with [Claude Code](https://claude.ai/code)