### PR TITLE
fix: Update cluster list tests to expect ARN format

### DIFF
--- a/tests/scenarios/cluster/cluster_list_test.go
+++ b/tests/scenarios/cluster/cluster_list_test.go
@@ -72,9 +72,12 @@ var _ = Describe("Cluster List Operations", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to list clusters")
 
 				// Verify all created clusters are in the list
+				// ListClusters returns ARNs, so we need to check for ARN format
 				for _, expectedName := range clusterNames {
-					Expect(clusters).To(ContainElement(expectedName),
-						"Cluster %s not found in list", expectedName)
+					// Convert cluster name to expected ARN format
+					expectedArn := fmt.Sprintf("arn:aws:ecs:ap-northeast-1:123456789012:cluster/%s", expectedName)
+					Expect(clusters).To(ContainElement(expectedArn),
+						"Cluster ARN for %s not found in list", expectedName)
 				}
 
 				logger.Info("Successfully listed %d clusters", len(clusters))
@@ -92,13 +95,15 @@ var _ = Describe("Cluster List Operations", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to list clusters")
 
 				// Verify deleted cluster is not in the list
-				Expect(clusters).NotTo(ContainElement(deletedCluster),
-					"Deleted cluster should not appear in list")
+				deletedArn := fmt.Sprintf("arn:aws:ecs:ap-northeast-1:123456789012:cluster/%s", deletedCluster)
+				Expect(clusters).NotTo(ContainElement(deletedArn),
+					"Deleted cluster ARN should not appear in list")
 
 				// Verify remaining clusters are still in the list
 				for i := 1; i < len(clusterNames); i++ {
-					Expect(clusters).To(ContainElement(clusterNames[i]),
-						"Cluster %s not found in list", clusterNames[i])
+					expectedArn := fmt.Sprintf("arn:aws:ecs:ap-northeast-1:123456789012:cluster/%s", clusterNames[i])
+					Expect(clusters).To(ContainElement(expectedArn),
+						"Cluster ARN for %s not found in list", clusterNames[i])
 				}
 			})
 		})
@@ -145,9 +150,10 @@ var _ = Describe("Cluster List Operations", func() {
 
 					// Count our test clusters
 					foundCount := 0
-					for _, cluster := range clusters {
-						for _, expected := range clusterNames {
-							if cluster == expected {
+					for _, clusterArn := range clusters {
+						for _, expectedName := range clusterNames {
+							expectedArn := fmt.Sprintf("arn:aws:ecs:ap-northeast-1:123456789012:cluster/%s", expectedName)
+							if clusterArn == expectedArn {
 								foundCount++
 								break
 							}


### PR DESCRIPTION
## Summary
- Fix failing Phase 1 scenario tests by updating test expectations
- Tests now correctly expect ARN format from ListClusters API
- All Phase 1 tests now pass successfully

## Background
The scenario tests were failing because they expected the ListClusters API to return cluster names, but the API actually returns ARNs in the format `arn:aws:ecs:region:account:cluster/name`. This is consistent with AWS ECS API behavior.

## Changes
- Updated `cluster_list_test.go` to expect ARN format in test assertions
- Added comments explaining why ARN format is expected
- No changes to the API implementation were needed

## Test Results
Before fix:
- 8 tests: 5 passed, 3 failed

After fix:
- 8 tests: 8 passed, 0 failed

```
Ran 8 of 9 Specs in 20.179 seconds
SUCCESS\! -- 8 Passed | 0 Failed | 1 Pending | 0 Skipped
```

🤖 Generated with [Claude Code](https://claude.ai/code)