### PR TITLE
feat: Add LocalStack configuration support to main server

### DIFF
--- a/configs/development.yaml
+++ b/configs/development.yaml
@@ -1,0 +1,40 @@
+# KECS Development Configuration
+
+server:
+  port: 8080
+  adminPort: 8081
+  dataDir: ~/.kecs/data
+  logLevel: debug
+
+localstack:
+  enabled: true
+  services:
+    - iam
+    - cloudwatchlogs
+    - ssm
+    - secretsmanager
+    - elbv2
+    - s3
+    - dynamodb
+  persistence: true
+  image: localstack/localstack
+  version: latest
+  namespace: kecs-system
+  port: 4566
+  edgePort: 4566
+  resources:
+    memory: 2Gi
+    cpu: 1000m
+    storageSize: 10Gi
+  environment:
+    DEFAULT_REGION: us-east-1
+    DOCKER_HOST: unix:///var/run/docker.sock
+    LAMBDA_EXECUTOR: local
+    DISABLE_CORS_CHECKS: "1"
+    DISABLE_CUSTOM_CORS_S3: "1"
+    EXTRA_CORS_ALLOWED_ORIGINS: "*"
+    EXTRA_CORS_ALLOWED_HEADERS: "x-amz-*"
+    DEBUG: "1"
+  debug: true
+  dataDir: /var/lib/localstack
+  customEndpoints: {}

--- a/configs/production.yaml
+++ b/configs/production.yaml
@@ -1,0 +1,37 @@
+# KECS Production Configuration
+
+server:
+  port: 8080
+  adminPort: 8081
+  dataDir: ~/.kecs/data
+  logLevel: info
+
+localstack:
+  enabled: false
+  services:
+    - iam
+    - cloudwatchlogs
+    - ssm
+    - secretsmanager
+    - elbv2
+  persistence: true
+  image: localstack/localstack
+  version: latest
+  namespace: kecs-system
+  port: 4566
+  edgePort: 4566
+  resources:
+    memory: 2Gi
+    cpu: 1000m
+    storageSize: 10Gi
+  environment:
+    DEFAULT_REGION: us-east-1
+    DOCKER_HOST: unix:///var/run/docker.sock
+    LAMBDA_EXECUTOR: local
+    DISABLE_CORS_CHECKS: "1"
+    DISABLE_CUSTOM_CORS_S3: "1"
+    EXTRA_CORS_ALLOWED_ORIGINS: "*"
+    EXTRA_CORS_ALLOWED_HEADERS: "x-amz-*"
+  debug: false
+  dataDir: /var/lib/localstack
+  customEndpoints: {}

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/localstack"
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the KECS configuration
+type Config struct {
+	Server     ServerConfig     `yaml:"server"`
+	LocalStack localstack.Config `yaml:"localstack"`
+}
+
+// ServerConfig represents server-specific configuration
+type ServerConfig struct {
+	Port      int    `yaml:"port"`
+	AdminPort int    `yaml:"adminPort"`
+	DataDir   string `yaml:"dataDir"`
+	LogLevel  string `yaml:"logLevel"`
+}
+
+// DefaultConfig returns the default configuration
+func DefaultConfig() *Config {
+	homeDir, _ := os.UserHomeDir()
+	defaultDataDir := filepath.Join(homeDir, ".kecs", "data")
+
+	return &Config{
+		Server: ServerConfig{
+			Port:      8080,
+			AdminPort: 8081,
+			DataDir:   defaultDataDir,
+			LogLevel:  "info",
+		},
+		LocalStack: *localstack.DefaultConfig(),
+	}
+}
+
+// LoadConfig loads configuration from a file
+func LoadConfig(configPath string) (*Config, error) {
+	config := DefaultConfig()
+
+	if configPath == "" {
+		return config, nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// If config file doesn't exist, return default config
+			return config, nil
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return config, nil
+}
+
+// Validate validates the configuration
+func (c *Config) Validate() error {
+	// Validate server config
+	if c.Server.Port <= 0 || c.Server.Port > 65535 {
+		return fmt.Errorf("invalid server port: %d", c.Server.Port)
+	}
+	if c.Server.AdminPort <= 0 || c.Server.AdminPort > 65535 {
+		return fmt.Errorf("invalid admin port: %d", c.Server.AdminPort)
+	}
+
+	// Validate LocalStack config if enabled
+	if c.LocalStack.Enabled {
+		if err := c.LocalStack.Validate(); err != nil {
+			return fmt.Errorf("invalid LocalStack config: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/controlplane/internal/config/config_suite_test.go
+++ b/controlplane/internal/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/controlplane/internal/config/config_test.go
+++ b/controlplane/internal/config/config_test.go
@@ -1,0 +1,138 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
+)
+
+var _ = Describe("Config", func() {
+	var (
+		tempDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "kecs-config-test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("DefaultConfig", func() {
+		It("should return valid default configuration", func() {
+			cfg := config.DefaultConfig()
+			Expect(cfg).NotTo(BeNil())
+			Expect(cfg.Server.Port).To(Equal(8080))
+			Expect(cfg.Server.AdminPort).To(Equal(8081))
+			Expect(cfg.LocalStack.Enabled).To(BeFalse())
+		})
+	})
+
+	Describe("LoadConfig", func() {
+		Context("when config file does not exist", func() {
+			It("should return default configuration", func() {
+				cfg, err := config.LoadConfig(filepath.Join(tempDir, "nonexistent.yaml"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+				Expect(cfg.Server.Port).To(Equal(8080))
+			})
+		})
+
+		Context("when config file is empty", func() {
+			It("should return default configuration with empty path", func() {
+				cfg, err := config.LoadConfig("")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+				Expect(cfg.Server.Port).To(Equal(8080))
+			})
+		})
+
+		Context("when config file exists", func() {
+			It("should load configuration from file", func() {
+				configPath := filepath.Join(tempDir, "test.yaml")
+				configContent := `
+server:
+  port: 9090
+  adminPort: 9091
+  dataDir: /custom/data
+  logLevel: debug
+
+localstack:
+  enabled: true
+  services:
+    - s3
+    - dynamodb
+  version: 2.0.0
+`
+				err := os.WriteFile(configPath, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				cfg, err := config.LoadConfig(configPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+				Expect(cfg.Server.Port).To(Equal(9090))
+				Expect(cfg.Server.AdminPort).To(Equal(9091))
+				Expect(cfg.Server.DataDir).To(Equal("/custom/data"))
+				Expect(cfg.Server.LogLevel).To(Equal("debug"))
+				Expect(cfg.LocalStack.Enabled).To(BeTrue())
+				Expect(cfg.LocalStack.Services).To(ContainElements("s3", "dynamodb"))
+				Expect(cfg.LocalStack.Version).To(Equal("2.0.0"))
+			})
+		})
+
+		Context("when config file has invalid YAML", func() {
+			It("should return error", func() {
+				configPath := filepath.Join(tempDir, "invalid.yaml")
+				configContent := `
+server:
+  port: invalid
+`
+				err := os.WriteFile(configPath, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = config.LoadConfig(configPath)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Validate", func() {
+		It("should validate valid configuration", func() {
+			cfg := config.DefaultConfig()
+			err := cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject invalid server port", func() {
+			cfg := config.DefaultConfig()
+			cfg.Server.Port = 0
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid server port"))
+		})
+
+		It("should reject invalid admin port", func() {
+			cfg := config.DefaultConfig()
+			cfg.Server.AdminPort = 70000
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid admin port"))
+		})
+
+		It("should validate LocalStack config when enabled", func() {
+			cfg := config.DefaultConfig()
+			cfg.LocalStack.Enabled = true
+			cfg.LocalStack.Services = []string{"invalid-service"}
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid LocalStack config"))
+		})
+	})
+})

--- a/docs/localstack-integration.md
+++ b/docs/localstack-integration.md
@@ -13,12 +13,12 @@ LocalStack integration in KECS provides:
 
 ## Configuration
 
-### Basic Configuration
+### Using Configuration File
 
 LocalStack integration is configured in the KECS configuration file:
 
 ```yaml
-# LocalStack configuration
+# LocalStack configuration in production.yaml or development.yaml
 localstack:
   enabled: true  # Enable LocalStack integration
   services:
@@ -39,6 +39,46 @@ localstack:
   debug: false
   dataDir: "/var/lib/localstack"
 ```
+
+### Using Command Line Options
+
+You can also enable LocalStack using command line flags:
+
+```bash
+# Start KECS with LocalStack enabled
+kecs server --localstack-enabled --config configs/production.yaml
+
+# Or without a config file (uses defaults)
+kecs server --localstack-enabled
+```
+
+### Configuration Precedence
+
+1. Command line flags override config file settings
+2. Config file settings override defaults
+3. Default configuration is used if no config is specified
+
+### Server Startup with LocalStack
+
+When starting the KECS server with LocalStack enabled:
+
+```bash
+# Using config file
+kecs server --config configs/development.yaml
+
+# Using command line flag
+kecs server --localstack-enabled
+
+# Specify custom ports
+kecs server --localstack-enabled --port 8080 --admin-port 8081
+```
+
+The server will:
+1. Initialize LocalStack manager
+2. Create LocalStack deployment in Kubernetes
+3. Wait for LocalStack to be healthy
+4. Configure AWS proxy routing
+5. Start accepting requests
 
 ### Proxy Configuration
 


### PR DESCRIPTION
## Summary
- Add configuration file support for LocalStack integration
- Implement command line flags for enabling LocalStack
- Integrate LocalStack manager initialization in server startup

## Changes
- Added `configs/production.yaml` and `configs/development.yaml` with LocalStack configuration
- Added `--localstack-enabled` and `--config` command line flags to server command
- Created `internal/config` package for configuration management
- Modified server startup to load configuration and initialize LocalStack when enabled
- Updated LocalStack documentation with new configuration options

## Test Plan
- [x] Unit tests for configuration loading and validation
- [x] Manual testing of server startup with LocalStack enabled
- [ ] Integration tests with LocalStack (Phase 2)

## Related
- Implements part of #135 (LocalStack integration)
- Follows ADR-0012 and ADR-0013

🤖 Generated with [Claude Code](https://claude.ai/code)