### PR TITLE
fix: Make LocalStack event time marshaling test more robust

### DIFF
--- a/controlplane/internal/localstack/events_test.go
+++ b/controlplane/internal/localstack/events_test.go
@@ -152,12 +152,14 @@ var _ = Describe("LocalStack Events", func() {
 
 	Describe("Event Marshaling", func() {
 		It("should marshal and unmarshal events correctly", func() {
+			// Use UTC time to avoid timezone issues
+			testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 			originalEvent := &localstack.Event{
 				Service:   "ecs",
 				EventType: localstack.EventTypeTaskStateChange,
 				Region:    "us-east-1",
 				Account:   "123456789012",
-				Time:      time.Now().Truncate(time.Second), // Truncate for comparison
+				Time:      testTime,
 				Detail: map[string]interface{}{
 					"clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/test",
 					"taskArn":    "arn:aws:ecs:us-east-1:123456789012:task/test/abc123",
@@ -169,6 +171,7 @@ var _ = Describe("LocalStack Events", func() {
 			jsonData, err := originalEvent.MarshalJSON()
 			Expect(err).NotTo(HaveOccurred())
 
+
 			// Unmarshal from JSON
 			var unmarshaledEvent localstack.Event
 			err = unmarshaledEvent.UnmarshalJSON(jsonData)
@@ -179,7 +182,8 @@ var _ = Describe("LocalStack Events", func() {
 			Expect(unmarshaledEvent.EventType).To(Equal(originalEvent.EventType))
 			Expect(unmarshaledEvent.Region).To(Equal(originalEvent.Region))
 			Expect(unmarshaledEvent.Account).To(Equal(originalEvent.Account))
-			Expect(unmarshaledEvent.Time.Truncate(time.Second)).To(Equal(originalEvent.Time))
+			// Compare times with second precision
+			Expect(unmarshaledEvent.Time.Unix()).To(Equal(originalEvent.Time.Unix()))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
Fix flaky LocalStack event marshaling test that was failing in CI at line 182.

## Problem
The test was using `time.Now()` and comparing times after JSON marshaling/unmarshaling. This could fail due to:
- Timezone differences between test environments
- Nanosecond precision issues
- RFC3339 format variations

## Solution
1. Use a fixed UTC time instead of `time.Now()`
2. Compare times using `Unix()` timestamp instead of `Truncate(time.Second)`
3. This ensures consistent behavior across different environments

## Test Plan
- [x] All LocalStack tests pass locally
- [ ] CI tests should pass consistently

🤖 Generated with [Claude Code](https://claude.ai/code)