### PR TITLE
feat: Complete IAM integration for task execution

### DIFF
--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -2,16 +2,18 @@ package api
 
 import (
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/iam"
 	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
 )
 
 // DefaultECSAPI provides the default implementation of ECS API operations
 type DefaultECSAPI struct {
-	storage     storage.Storage
-	kindManager *kubernetes.KindManager
-	region      string
-	accountID   string
+	storage        storage.Storage
+	kindManager    *kubernetes.KindManager
+	region         string
+	accountID      string
+	iamIntegration iam.Integration
 }
 
 // NewDefaultECSAPI creates a new default ECS API implementation with storage and kubernetes manager
@@ -22,6 +24,11 @@ func NewDefaultECSAPI(storage storage.Storage, kindManager *kubernetes.KindManag
 		region:      "ap-northeast-1", // Default region
 		accountID:   "123456789012",   // Default account ID
 	}
+}
+
+// SetIAMIntegration sets the IAM integration for the ECS API
+func (api *DefaultECSAPI) SetIAMIntegration(iamIntegration iam.Integration) {
+	api.iamIntegration = iamIntegration
 }
 
 // NewDefaultECSAPIWithConfig creates a new default ECS API implementation with custom region and accountID


### PR DESCRIPTION
## Summary
- Completes IAM integration between LocalStack and Kubernetes
- Enables ECS tasks to use IAM roles via ServiceAccounts

## Changes

### Server Integration
- Added IAM integration to Server struct
- Initialize IAM integration when LocalStack is available
- Pass IAM integration to DefaultECSAPI

### Task Definition Registration
- Auto-create IAM roles when registering task definitions
- Create task role with proper trust policy for ECS tasks
- Create execution role with necessary permissions
- Log warnings if role creation fails (non-blocking)

### Task Execution
- Apply ServiceAccount to pods based on task role ARN
- Extract role name from ARN and set corresponding ServiceAccount
- Add annotations to track IAM role usage

### Utilities
- Added `extractRoleNameFromARN` function to both API and converter
- Handles various ARN formats and fallback to plain role names

## Testing
- [x] Code compiles without errors
- [x] Existing tests pass
- [ ] Manual testing with LocalStack required

## Impact
This completes Phase 2 item 1 from ADR-0012:
- ✅ IAM role integration with ServiceAccounts

Tasks can now use IAM roles defined in task definitions, and KECS will automatically:
1. Create the IAM role in LocalStack when task definition is registered
2. Create corresponding ServiceAccount in Kubernetes
3. Assign the ServiceAccount to pods when tasks are run

🤖 Generated with [Claude Code](https://claude.ai/code)