### PR TITLE
feat: Complete CloudWatch Logs integration

### DIFF
--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/cloudwatch"
 	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/iam"
 	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
@@ -9,11 +10,12 @@ import (
 
 // DefaultECSAPI provides the default implementation of ECS API operations
 type DefaultECSAPI struct {
-	storage        storage.Storage
-	kindManager    *kubernetes.KindManager
-	region         string
-	accountID      string
-	iamIntegration iam.Integration
+	storage               storage.Storage
+	kindManager           *kubernetes.KindManager
+	region                string
+	accountID             string
+	iamIntegration        iam.Integration
+	cloudWatchIntegration cloudwatch.Integration
 }
 
 // NewDefaultECSAPI creates a new default ECS API implementation with storage and kubernetes manager
@@ -29,6 +31,11 @@ func NewDefaultECSAPI(storage storage.Storage, kindManager *kubernetes.KindManag
 // SetIAMIntegration sets the IAM integration for the ECS API
 func (api *DefaultECSAPI) SetIAMIntegration(iamIntegration iam.Integration) {
 	api.iamIntegration = iamIntegration
+}
+
+// SetCloudWatchIntegration sets the CloudWatch integration for the ECS API
+func (api *DefaultECSAPI) SetCloudWatchIntegration(cloudWatchIntegration cloudwatch.Integration) {
+	api.cloudWatchIntegration = cloudWatchIntegration
 }
 
 // NewDefaultECSAPIWithConfig creates a new default ECS API implementation with custom region and accountID

--- a/controlplane/internal/controlplane/api/task_ecs_api.go
+++ b/controlplane/internal/controlplane/api/task_ecs_api.go
@@ -75,8 +75,8 @@ func (api *DefaultECSAPI) RunTask(ctx context.Context, req *generated.RunTaskReq
 		taskManager = &mockTaskManager{storage: api.storage}
 	}
 
-	// Create task converter
-	taskConverter := converters.NewTaskConverter(api.region, api.accountID)
+	// Create task converter with CloudWatch integration
+	taskConverter := converters.NewTaskConverterWithCloudWatch(api.region, api.accountID, api.cloudWatchIntegration)
 
 	// Marshal the request for the converter
 	reqJSON, err := json.Marshal(req)

--- a/controlplane/internal/integrations/cloudwatch/integration_complete_test.go
+++ b/controlplane/internal/integrations/cloudwatch/integration_complete_test.go
@@ -1,0 +1,175 @@
+package cloudwatch_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/cloudwatch"
+)
+
+var _ = Describe("CloudWatch Integration Complete", func() {
+	var (
+		integration cloudwatch.Integration
+		mockClient  *mockCloudWatchLogsTestClient
+	)
+
+	BeforeEach(func() {
+		mockClient = &mockCloudWatchLogsTestClient{
+			createLogGroupCalls:  []*cloudwatchlogs.CreateLogGroupInput{},
+			createLogStreamCalls: []*cloudwatchlogs.CreateLogStreamInput{},
+		}
+		
+		integration = cloudwatch.NewIntegrationWithClient(
+			nil, // kubeClient not needed for these tests
+			nil, // localstack manager not needed
+			&cloudwatch.Config{
+				LogGroupPrefix: "/ecs/",
+				RetentionDays:  7,
+				KubeNamespace:  "default",
+			},
+			mockClient,
+		)
+	})
+
+	Describe("Task Logging Configuration", func() {
+		It("should configure CloudWatch logging for a task", func() {
+			taskArn := "arn:aws:ecs:us-east-1:123456789012:task/default/task-123"
+			containerName := "my-app"
+			logDriver := "awslogs"
+			options := map[string]string{
+				"awslogs-group":         "/ecs/my-app",
+				"awslogs-region":        "us-east-1",
+				"awslogs-stream-prefix": "my-app",
+			}
+
+			logConfig, err := integration.ConfigureContainerLogging(taskArn, containerName, logDriver, options)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logConfig).NotTo(BeNil())
+			
+			// Verify configuration
+			Expect(logConfig.LogGroupName).To(Equal("/ecs/my-app"))
+			Expect(logConfig.LogStreamName).To(Equal("my-app"))
+			Expect(logConfig.LogDriver).To(Equal("awslogs"))
+			
+			// Verify FluentBit config was generated
+			Expect(logConfig.FluentBitConfig).To(ContainSubstring("[OUTPUT]"))
+			Expect(logConfig.FluentBitConfig).To(ContainSubstring("cloudwatch_logs"))
+			Expect(logConfig.FluentBitConfig).To(ContainSubstring("/ecs/my-app"))
+		})
+
+		It("should create log group if not specified", func() {
+			taskArn := "arn:aws:ecs:us-east-1:123456789012:task/default/task-456"
+			containerName := "nginx"
+			logDriver := "awslogs"
+			options := map[string]string{} // No group specified
+
+			logConfig, err := integration.ConfigureContainerLogging(taskArn, containerName, logDriver, options)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logConfig).NotTo(BeNil())
+			
+			// Should use default group
+			Expect(logConfig.LogGroupName).To(Equal("/ecs/kecs-tasks"))
+			
+			// Verify log group creation was called
+			Expect(mockClient.createLogGroupCalls).To(HaveLen(1))
+			Expect(*mockClient.createLogGroupCalls[0].LogGroupName).To(Equal("/ecs/kecs-tasks"))
+		})
+
+		It("should reject non-awslogs drivers", func() {
+			taskArn := "arn:aws:ecs:us-east-1:123456789012:task/default/task-789"
+			containerName := "app"
+			logDriver := "json-file"
+			options := map[string]string{}
+
+			logConfig, err := integration.ConfigureContainerLogging(taskArn, containerName, logDriver, options)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported log driver"))
+			Expect(logConfig).To(BeNil())
+		})
+	})
+
+	Describe("Log Stream Management", func() {
+		It("should create unique log streams for containers", func() {
+			taskArn := "arn:aws:ecs:us-east-1:123456789012:task/default/task-abc123"
+			
+			// Get stream names for different containers
+			stream1 := integration.GetLogStreamForContainer(taskArn, "web")
+			stream2 := integration.GetLogStreamForContainer(taskArn, "app")
+			
+			Expect(stream1).To(Equal("web/task-abc123"))
+			Expect(stream2).To(Equal("app/task-abc123"))
+			Expect(stream1).NotTo(Equal(stream2))
+		})
+
+		It("should handle log group creation with retention", func() {
+			groupName := "test-group"
+			
+			err := integration.CreateLogGroup(groupName)
+			Expect(err).NotTo(HaveOccurred())
+			
+			// Verify calls
+			Expect(mockClient.createLogGroupCalls).To(HaveLen(1))
+			Expect(*mockClient.createLogGroupCalls[0].LogGroupName).To(Equal("/ecs/test-group"))
+			
+			// Verify retention policy was set
+			Expect(mockClient.putRetentionPolicyCalls).To(HaveLen(1))
+			Expect(*mockClient.putRetentionPolicyCalls[0].LogGroupName).To(Equal("/ecs/test-group"))
+			Expect(*mockClient.putRetentionPolicyCalls[0].RetentionInDays).To(Equal(int32(7)))
+		})
+	})
+
+	Describe("FluentBit Configuration", func() {
+		It("should generate valid FluentBit configuration", func() {
+			taskArn := "arn:aws:ecs:us-east-1:123456789012:task/default/task-xyz"
+			containerName := "app"
+			options := map[string]string{
+				"awslogs-group":  "/ecs/my-service",
+				"awslogs-region": "us-west-2",
+			}
+
+			logConfig, err := integration.ConfigureContainerLogging(taskArn, containerName, "awslogs", options)
+			Expect(err).NotTo(HaveOccurred())
+			
+			// Verify FluentBit config contains required sections
+			config := logConfig.FluentBitConfig
+			Expect(config).To(ContainSubstring("[SERVICE]"))
+			Expect(config).To(ContainSubstring("[INPUT]"))
+			Expect(config).To(ContainSubstring("[FILTER]"))
+			Expect(config).To(ContainSubstring("[OUTPUT]"))
+			
+			// Verify specific settings
+			Expect(config).To(ContainSubstring("region              us-west-2"))
+			Expect(config).To(ContainSubstring("log_group_name      /ecs/my-service"))
+			Expect(config).To(ContainSubstring("endpoint            http://localstack.aws-services.svc.cluster.local:4566"))
+		})
+	})
+})
+
+// mockCloudWatchLogsTestClient for testing
+type mockCloudWatchLogsTestClient struct {
+	createLogGroupCalls      []*cloudwatchlogs.CreateLogGroupInput
+	createLogStreamCalls     []*cloudwatchlogs.CreateLogStreamInput
+	putRetentionPolicyCalls  []*cloudwatchlogs.PutRetentionPolicyInput
+}
+
+func (m *mockCloudWatchLogsTestClient) CreateLogGroup(ctx context.Context, params *cloudwatchlogs.CreateLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+	m.createLogGroupCalls = append(m.createLogGroupCalls, params)
+	return &cloudwatchlogs.CreateLogGroupOutput{}, nil
+}
+
+func (m *mockCloudWatchLogsTestClient) DeleteLogGroup(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
+	return &cloudwatchlogs.DeleteLogGroupOutput{}, nil
+}
+
+func (m *mockCloudWatchLogsTestClient) CreateLogStream(ctx context.Context, params *cloudwatchlogs.CreateLogStreamInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+	m.createLogStreamCalls = append(m.createLogStreamCalls, params)
+	return &cloudwatchlogs.CreateLogStreamOutput{}, nil
+}
+
+func (m *mockCloudWatchLogsTestClient) PutRetentionPolicy(ctx context.Context, params *cloudwatchlogs.PutRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
+	m.putRetentionPolicyCalls = append(m.putRetentionPolicyCalls, params)
+	return &cloudwatchlogs.PutRetentionPolicyOutput{}, nil
+}


### PR DESCRIPTION
## Summary
- Completes CloudWatch Logs integration between LocalStack and Kubernetes
- Enables ECS tasks to send container logs to CloudWatch Logs

## Changes

### Server Integration
- Added CloudWatch integration to Server struct
- Initialize CloudWatch integration when LocalStack is available
- Pass CloudWatch integration to DefaultECSAPI

### Log Group and Stream Management
- Auto-create log groups when tasks start
- Create log streams for each container
- Support custom log group names from task definitions
- Set retention policy for log groups

### FluentBit Sidecar
- Add FluentBit sidecar container for log forwarding
- Generate FluentBit configuration for LocalStack endpoint
- Mount host paths for container log access
- Configure CloudWatch Logs output plugin

### Task Definition Support
- Process `awslogs` driver configuration from container definitions
- Support all awslogs options (group, region, stream-prefix)
- Add annotations to track log configuration per container

## Testing
- [x] Code compiles without errors
- [x] Unit tests pass
- [x] Added comprehensive test coverage
- [ ] Manual testing with LocalStack required

## Impact
This completes Phase 2 item 3 from ADR-0012:
- ✅ CloudWatch logs integration

Tasks can now send logs to CloudWatch Logs when configured with the `awslogs` driver in their task definitions. KECS will automatically:
1. Create log groups and streams in LocalStack when tasks start
2. Add FluentBit sidecar to pods for log forwarding
3. Configure FluentBit to send logs to LocalStack CloudWatch endpoint

Example task definition log configuration:
```json
{
  "logConfiguration": {
    "logDriver": "awslogs",
    "options": {
      "awslogs-group": "/ecs/my-app",
      "awslogs-region": "us-east-1",
      "awslogs-stream-prefix": "my-app"
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)