### PR TITLE
fix: Fix LocalStack API test routing issue

### DIFF
--- a/controlplane/internal/controlplane/api/localstack_test.go
+++ b/controlplane/internal/controlplane/api/localstack_test.go
@@ -23,10 +23,14 @@ var _ = Describe("LocalStack API", func() {
 		server, err = api.NewServer(8080, "", nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		
-		// Create a dummy handler for testing since setupRoutes is private
+		// Create a handler that properly routes the request
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Just delegate to the server's health check for testing
-			server.GetLocalStackStatus(w, r)
+			// Route based on path
+			if r.URL.Path == "/api/localstack/status" {
+				server.GetLocalStackStatus(w, r)
+			} else {
+				http.NotFound(w, r)
+			}
 		})
 		testServer = httptest.NewServer(handler)
 	})


### PR DESCRIPTION
## Summary
Fixes the LocalStack API test failure in CI by correcting the test handler routing logic.

## Problem
The test `should reject non-GET requests` was failing because the test handler was routing all requests to `GetLocalStackStatus` regardless of the URL path. This meant that even requests to non-existent paths were being handled by the LocalStack status endpoint.

## Solution
Updated the test handler to:
- Only route requests to `/api/localstack/status` to the `GetLocalStackStatus` method
- Return 404 for all other paths
- This matches the behavior of the real server routing

## Testing
- All LocalStack tests now pass locally
- The specific test `should reject non-GET requests` correctly receives HTTP 405 status

Fixes #160

🤖 Generated with [Claude Code](https://claude.ai/code)