### PR TITLE
feat: Add Web UI custom slash commands and improve build commands

### DIFF
--- a/.claude/commands/kecs-docker-start-with-ui.md
+++ b/.claude/commands/kecs-docker-start-with-ui.md
@@ -1,0 +1,35 @@
+Build KECS Docker image with embedded Web UI and run it as a container. The container will expose ports 8080 (API with Web UI) and 8081 (Admin).
+
+Execute:
+```bash
+# Find project root
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+echo "Building Web UI..."
+(cd "$PROJECT_ROOT" && make build-webui) || { echo "Web UI build failed"; exit 1; }
+
+echo "Building KECS Docker image with Web UI..."
+(cd "$PROJECT_ROOT" && docker build -f controlplane/Dockerfile.production -t ghcr.io/nandemo-ya/kecs:latest-ui .) || { echo "Docker build failed"; exit 1; }
+
+echo "Starting KECS container with Web UI..."
+docker run -d \
+  --name kecs-ui \
+  -p 8080:8080 \
+  -p 8081:8081 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $HOME/.kube:/home/nonroot/.kube:ro \
+  -e KUBECONFIG=/home/nonroot/.kube/config \
+  ghcr.io/nandemo-ya/kecs:latest-ui
+
+if [ $? -eq 0 ]; then
+  echo "KECS container with Web UI started successfully"
+  echo "Container ID: $(docker ps -q -f name=kecs-ui)"
+  echo "Web UI: http://localhost:8080"
+  echo "API Server: http://localhost:8080"
+  echo "Admin Server: http://localhost:8081"
+  echo "Logs: docker logs -f kecs-ui"
+else
+  echo "Failed to start KECS container"
+  exit 1
+fi
+```

--- a/.claude/commands/kecs-docker-start.md
+++ b/.claude/commands/kecs-docker-start.md
@@ -2,8 +2,11 @@ Build KECS Docker image and run it as a container. The container will expose por
 
 Execute:
 ```bash
+# Find project root
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
 echo "Building KECS Docker image..."
-cd .. && make docker-build || { echo "Docker build failed"; exit 1; }
+(cd "$PROJECT_ROOT" && make docker-build) || { echo "Docker build failed"; exit 1; }
 
 echo "Starting KECS container..."
 docker run -d \

--- a/.claude/commands/kecs-docker-stop-with-ui.md
+++ b/.claude/commands/kecs-docker-stop-with-ui.md
@@ -1,0 +1,26 @@
+Stop and remove the running KECS container with Web UI.
+
+Execute:
+```bash
+if docker ps -q -f name=kecs-ui | grep -q .; then
+    echo "Stopping KECS container with Web UI..."
+    docker stop kecs-ui
+    
+    if [ $? -eq 0 ]; then
+        echo "Removing KECS container..."
+        docker rm kecs-ui
+        echo "KECS container with Web UI stopped and removed successfully"
+    else
+        echo "Failed to stop KECS container"
+        exit 1
+    fi
+else
+    echo "KECS container with Web UI is not running"
+    
+    # Check if container exists but is stopped
+    if docker ps -aq -f name=kecs-ui | grep -q .; then
+        echo "Removing stopped KECS container..."
+        docker rm kecs-ui
+    fi
+fi
+```

--- a/.claude/commands/kecs-start-with-ui.md
+++ b/.claude/commands/kecs-start-with-ui.md
@@ -1,0 +1,23 @@
+Build KECS with embedded Web UI and start it running in the background. The server will run on port 8080 (API with Web UI) and 8081 (Admin).
+
+Execute:
+```bash
+# Find project root by looking for go.mod
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+echo "Building Web UI..."
+(cd "$PROJECT_ROOT" && make build-webui) || { echo "Web UI build failed"; exit 1; }
+
+echo "Building KECS with embedded Web UI..."
+(cd "$PROJECT_ROOT" && make build-with-ui) || { echo "Build failed"; exit 1; }
+
+echo "Starting KECS with Web UI in background..."
+nohup "$PROJECT_ROOT/bin/kecs" server > kecs.log 2>&1 &
+echo $! > kecs.pid
+
+echo "KECS with Web UI started with PID: $(cat kecs.pid)"
+echo "Web UI: http://localhost:8080"
+echo "API Server: http://localhost:8080"
+echo "Admin Server: http://localhost:8081"
+echo "Logs: tail -f kecs.log"
+```

--- a/.claude/commands/kecs-start.md
+++ b/.claude/commands/kecs-start.md
@@ -2,11 +2,14 @@ Build KECS and start it running in the background. The server will run on port 8
 
 Execute:
 ```bash
+# Find project root
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
 echo "Building KECS..."
-cd .. && make build || { echo "Build failed"; exit 1; }
+(cd "$PROJECT_ROOT" && make build) || { echo "Build failed"; exit 1; }
 
 echo "Starting KECS in background..."
-cd controlplane && nohup ../bin/kecs server > kecs.log 2>&1 &
+nohup "$PROJECT_ROOT/bin/kecs" server > kecs.log 2>&1 &
 echo $! > kecs.pid
 
 echo "KECS started with PID: $(cat kecs.pid)"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # Build output
 bin/
 
+# Web UI build output
+controlplane/internal/controlplane/api/webui_dist/
+
 # Coverage reports
 coverage.txt
 


### PR DESCRIPTION
## Summary
- Added custom slash commands for building and running KECS with embedded Web UI
- Improved all build commands to use dynamic project root detection
- Added webui_dist to .gitignore as it's a build artifact

## New Commands
- `/project:kecs-start-with-ui` - Build and start KECS with embedded Web UI locally
- `/project:kecs-docker-start-with-ui` - Build and run KECS with Web UI in Docker container
- `/project:kecs-docker-stop-with-ui` - Stop and remove the Web UI container

## Improvements
- All commands now use `git rev-parse --show-toplevel` to find project root dynamically
- Removed hardcoded user-specific paths
- Commands work from any directory within the project
- Added webui_dist to .gitignore to keep build artifacts out of version control

## Technical Details
- Web UI is built using `make build-webui` which runs npm build
- KECS is compiled with `-tags embed_webui` to include the Web UI
- Web UI is served at http://localhost:8080/ui/
- Uses Go's embed directive to include static files in the binary

## Test Plan
- [x] Test `/project:kecs-start-with-ui` - Builds and embeds Web UI successfully
- [x] Test Web UI accessibility at http://localhost:8080/ui/
- [x] Verify WebSocket connections work
- [x] Confirm API calls from UI work correctly
- [ ] Test Docker commands with UI

🤖 Generated with [Claude Code](https://claude.ai/code)