### PR TITLE
fix: Fix flaky LocalStack API tests in GitHub Actions

### DIFF
--- a/controlplane/internal/controlplane/api/localstack_test.go
+++ b/controlplane/internal/controlplane/api/localstack_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,9 +16,14 @@ var _ = Describe("LocalStack API", func() {
 	var (
 		server      *api.Server
 		testServer  *httptest.Server
+		originalTestMode string
 	)
 
 	BeforeEach(func() {
+		// Set test mode to avoid Kubernetes initialization issues
+		originalTestMode = os.Getenv("KECS_TEST_MODE")
+		os.Setenv("KECS_TEST_MODE", "true")
+		
 		// Create server without LocalStack manager to test disabled state
 		var err error
 		server, err = api.NewServer(8080, "", nil, nil)
@@ -37,6 +43,13 @@ var _ = Describe("LocalStack API", func() {
 
 	AfterEach(func() {
 		testServer.Close()
+		
+		// Restore original test mode setting
+		if originalTestMode == "" {
+			os.Unsetenv("KECS_TEST_MODE")
+		} else {
+			os.Setenv("KECS_TEST_MODE", originalTestMode)
+		}
 	})
 
 	Describe("LocalStack Status Endpoint", func() {


### PR DESCRIPTION
## Summary
- Fixed intermittent test failures in LocalStack API tests that were occurring in GitHub Actions
- The issue was caused by `NewServer` attempting to initialize Kubernetes clients when `KECS_TEST_MODE` was not set
- Tests now properly set `KECS_TEST_MODE=true` to skip Kubernetes initialization in test environments

## Problem
The LocalStack API tests were failing in GitHub Actions with the following error:
```
[FAIL] LocalStack API [BeforeEach] LocalStack Status Endpoint should return disabled status when LocalStack is not configured
[FAIL] LocalStack API [BeforeEach] LocalStack Status Endpoint should reject non-GET requests
```

The root cause was that `api.NewServer()` was trying to initialize a Kubernetes client through `NewTaskManager()`, but the Kubernetes configuration is not available in the CI environment.

## Solution
- Added `KECS_TEST_MODE=true` environment variable in the `BeforeEach` hook
- Properly restore the original environment variable value in `AfterEach`
- This ensures the server skips Kubernetes-related initialization during tests

## Test plan
- [x] Ran the LocalStack API tests locally multiple times to verify they pass consistently
- [x] Verified no side effects from environment variable changes
- [ ] CI will validate the fix in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)