### PR TITLE
feat: Add test support for generated types

### DIFF
--- a/controlplane/internal/controlplane/api/generated_integration_test.go
+++ b/controlplane/internal/controlplane/api/generated_integration_test.go
@@ -1,0 +1,241 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api"
+	generated_v2 "github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated_v2"
+	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage/duckdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedTypesIntegration tests that generated types work correctly with the API
+func TestGeneratedTypesIntegration(t *testing.T) {
+	// Create storage
+	storage, err := duckdb.NewDuckDBStorage(":memory:")
+	require.NoError(t, err)
+	defer storage.Close()
+
+	err = storage.Initialize(context.Background())
+	require.NoError(t, err)
+
+	// Create Kind manager
+	kindManager := kubernetes.NewKindManager()
+
+	// Create ECS API with generated types
+	ecsAPI := api.NewDefaultECSAPIGenerated(storage, kindManager)
+
+	// Create mux and register routes
+	mux := http.NewServeMux()
+	api.RegisterECSRoutesGenerated(mux, ecsAPI)
+
+	// Create test server
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	t.Run("CreateCluster", func(t *testing.T) {
+		// Create request using generated types
+		req := &generated_v2.CreateClusterRequest{
+			ClusterName: stringPtr("test-cluster"),
+			Settings: []generated_v2.ClusterSetting{
+				{
+					Name:  interfacePtr("containerInsights"),
+					Value: stringPtr("enabled"),
+				},
+			},
+			Tags: []generated_v2.Tag{
+				{
+					Key:   stringPtr("Environment"),
+					Value: stringPtr("test"),
+				},
+			},
+		}
+
+		// Make HTTP request
+		resp, err := makeRequest(server.URL, "CreateCluster", req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Parse response
+		var createResp generated_v2.CreateClusterResponse
+		err = json.NewDecoder(resp.Body).Decode(&createResp)
+		require.NoError(t, err)
+
+		// Verify response
+		assert.NotNil(t, createResp.Cluster)
+		assert.Equal(t, "test-cluster", *createResp.Cluster.ClusterName)
+		assert.Equal(t, "ACTIVE", *createResp.Cluster.Status)
+		assert.Contains(t, *createResp.Cluster.ClusterArn, "arn:aws:ecs:")
+	})
+
+	t.Run("ListClusters", func(t *testing.T) {
+		// Create request
+		req := &generated_v2.ListClustersRequest{}
+
+		// Make HTTP request
+		resp, err := makeRequest(server.URL, "ListClusters", req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Parse response
+		var listResp generated_v2.ListClustersResponse
+		err = json.NewDecoder(resp.Body).Decode(&listResp)
+		require.NoError(t, err)
+
+		// Verify response
+		assert.NotNil(t, listResp.ClusterArns)
+		assert.Contains(t, listResp.ClusterArns, "arn:aws:ecs:ap-northeast-1:123456789012:cluster/test-cluster")
+	})
+
+	t.Run("DescribeClusters", func(t *testing.T) {
+		// Create request
+		req := &generated_v2.DescribeClustersRequest{
+			Clusters: []string{"test-cluster"},
+		}
+
+		// Make HTTP request
+		resp, err := makeRequest(server.URL, "DescribeClusters", req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Parse response
+		var describeResp generated_v2.DescribeClustersResponse
+		err = json.NewDecoder(resp.Body).Decode(&describeResp)
+		require.NoError(t, err)
+
+		// Verify response
+		assert.Len(t, describeResp.Clusters, 1)
+		cluster := describeResp.Clusters[0]
+		assert.Equal(t, "test-cluster", *cluster.ClusterName)
+		assert.Equal(t, "ACTIVE", *cluster.Status)
+
+		// Verify settings were saved
+		assert.NotNil(t, cluster.Settings)
+		assert.Len(t, cluster.Settings, 1)
+		// Name is *interface{}, so we need to dereference and cast
+		if cluster.Settings[0].Name != nil {
+			nameInterface := *cluster.Settings[0].Name
+			assert.Equal(t, "containerInsights", nameInterface)
+		}
+		assert.Equal(t, "enabled", *cluster.Settings[0].Value)
+
+		// Verify tags were saved
+		assert.NotNil(t, cluster.Tags)
+		assert.Len(t, cluster.Tags, 1)
+		assert.Equal(t, "Environment", *cluster.Tags[0].Key)
+		assert.Equal(t, "test", *cluster.Tags[0].Value)
+	})
+
+	t.Run("DeleteCluster", func(t *testing.T) {
+		// Create request
+		req := &generated_v2.DeleteClusterRequest{
+			Cluster: "test-cluster",
+		}
+
+		// Make HTTP request
+		resp, err := makeRequest(server.URL, "DeleteCluster", req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Parse response
+		var deleteResp generated_v2.DeleteClusterResponse
+		err = json.NewDecoder(resp.Body).Decode(&deleteResp)
+		require.NoError(t, err)
+
+		// Verify response
+		assert.NotNil(t, deleteResp.Cluster)
+		assert.Equal(t, "test-cluster", *deleteResp.Cluster.ClusterName)
+		assert.Equal(t, "INACTIVE", *deleteResp.Cluster.Status)
+	})
+}
+
+// TestGeneratedTypesJSONCompatibility tests JSON marshaling/unmarshaling
+func TestGeneratedTypesJSONCompatibility(t *testing.T) {
+	t.Run("CreateClusterRequest", func(t *testing.T) {
+		req := &generated_v2.CreateClusterRequest{
+			ClusterName: stringPtr("test-cluster"),
+			Settings: []generated_v2.ClusterSetting{
+				{
+					Name:  interfacePtr("containerInsights"),
+					Value: stringPtr("enabled"),
+				},
+			},
+		}
+
+		// Marshal to JSON
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		// Verify JSON has camelCase fields
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(data, &jsonMap)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-cluster", jsonMap["clusterName"])
+		settings := jsonMap["settings"].([]interface{})
+		assert.Len(t, settings, 1)
+		setting := settings[0].(map[string]interface{})
+		assert.Equal(t, "containerInsights", setting["name"])
+		assert.Equal(t, "enabled", setting["value"])
+	})
+
+	t.Run("ClusterResponse", func(t *testing.T) {
+		cluster := &generated_v2.Cluster{
+			ClusterArn:  stringPtr("arn:aws:ecs:us-east-1:123456789012:cluster/test"),
+			ClusterName: stringPtr("test"),
+			Status:      stringPtr("ACTIVE"),
+		}
+
+		// Marshal to JSON
+		data, err := json.Marshal(cluster)
+		require.NoError(t, err)
+
+		// Verify JSON has camelCase fields
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(data, &jsonMap)
+		require.NoError(t, err)
+
+		assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:cluster/test", jsonMap["clusterArn"])
+		assert.Equal(t, "test", jsonMap["clusterName"])
+		assert.Equal(t, "ACTIVE", jsonMap["status"])
+	})
+}
+
+// Helper function to make HTTP requests
+func makeRequest(baseURL, action string, body interface{}) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", baseURL+"/", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AmazonEC2ContainerServiceV20141113."+action)
+
+	client := &http.Client{}
+	return client.Do(req)
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func interfacePtr(i interface{}) *interface{} {
+	return &i
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}

--- a/tests/scenarios/README_GENERATED_TYPES.md
+++ b/tests/scenarios/README_GENERATED_TYPES.md
@@ -1,0 +1,77 @@
+# Testing with Generated Types
+
+This document describes how to use the generated types mode in test scenarios.
+
+## Overview
+
+KECS test scenarios support three client modes:
+1. **CurlMode** (default) - Uses curl commands for direct HTTP API calls
+2. **AWSCLIMode** - Uses AWS CLI commands  
+3. **GeneratedMode** - Uses generated types with custom AWS client (NEW)
+
+## Using Generated Mode
+
+To use generated types in your tests:
+
+```go
+// Create client with generated mode
+client := utils.NewECSClientInterface(kecs.Endpoint(), utils.GeneratedMode)
+
+// Use the client normally
+err := client.CreateCluster("test-cluster")
+```
+
+## Example Test
+
+See `cluster/cluster_generated_test.go` for a complete example of testing with generated types.
+
+## Benefits
+
+1. **Type Safety**: Generated types provide compile-time type checking
+2. **AWS CLI Compatibility**: Generated types use camelCase JSON tags
+3. **No SDK Dependencies**: Removes dependency on aws-sdk-go-v2
+
+## Current Implementation Status
+
+### Implemented Operations
+- ✅ CreateCluster
+- ✅ DescribeCluster  
+- ✅ ListClusters
+- ✅ DeleteCluster
+
+### TODO Operations
+- ⏳ RegisterTaskDefinition
+- ⏳ DescribeTaskDefinition
+- ⏳ ListTaskDefinitions
+- ⏳ CreateService
+- ⏳ DescribeService
+- ⏳ UpdateService
+- ⏳ DeleteService
+- ⏳ RunTask
+- ⏳ DescribeTasks
+- ⏳ StopTask
+- ⏳ TagResource
+- ⏳ UntagResource
+
+## Migration Guide
+
+To migrate existing tests to use generated types:
+
+1. Change client creation:
+```go
+// Before
+client := utils.NewECSClient(endpoint)
+
+// After  
+client := utils.NewECSClientInterface(endpoint, utils.GeneratedMode)
+```
+
+2. Update type assertions if needed (most operations return the same interface)
+
+3. Run tests to ensure compatibility
+
+## Integration Tests
+
+The generated types are tested in:
+- `controlplane/internal/controlplane/api/generated_integration_test.go` - Unit tests
+- `tests/scenarios/cluster/cluster_generated_test.go` - E2E tests with real KECS container

--- a/tests/scenarios/cluster/cluster_generated_test.go
+++ b/tests/scenarios/cluster/cluster_generated_test.go
@@ -1,0 +1,135 @@
+package cluster_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nandemo-ya/kecs/tests/scenarios/utils"
+)
+
+var _ = Describe("Cluster Operations with Generated Types", func() {
+	var (
+		kecs   *utils.KECSContainer
+		client utils.ECSClientInterface
+		logger *utils.TestLogger
+	)
+
+	BeforeEach(func() {
+		// Start KECS container
+		kecs = utils.StartKECS(GinkgoT())
+		DeferCleanup(kecs.Cleanup)
+
+		// Create ECS client using generated types
+		client = utils.NewECSClientInterface(kecs.Endpoint(), utils.GeneratedMode)
+		logger = utils.NewTestLogger(GinkgoT())
+	})
+
+	Describe("Cluster CRUD Operations", func() {
+		Context("when using generated types", func() {
+			var clusterName string
+
+			BeforeEach(func() {
+				clusterName = utils.GenerateTestName("gen-cluster")
+				DeferCleanup(func() {
+					// Clean up cluster if it exists
+					_ = client.DeleteCluster(clusterName)
+				})
+			})
+
+			It("should create and describe cluster with generated types", func() {
+				logger.Info("Creating cluster with generated types: %s", clusterName)
+
+				// Create cluster
+				err := client.CreateCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create cluster")
+
+				// Describe cluster
+				cluster, err := client.DescribeCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred(), "Failed to describe cluster")
+
+				// Verify cluster properties
+				Expect(cluster.ClusterName).To(Equal(clusterName))
+				Expect(cluster.Status).To(Equal("ACTIVE"))
+				Expect(cluster.ClusterArn).To(ContainSubstring("arn:aws:ecs:"))
+				Expect(cluster.ClusterArn).To(ContainSubstring("cluster/" + clusterName))
+
+				// Initial counts should be zero
+				Expect(cluster.RegisteredContainerInstancesCount).To(Equal(0))
+				Expect(cluster.RunningTasksCount).To(Equal(0))
+				Expect(cluster.PendingTasksCount).To(Equal(0))
+				Expect(cluster.ActiveServicesCount).To(Equal(0))
+			})
+
+			It("should list clusters with generated types", func() {
+				// Create cluster first
+				err := client.CreateCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred())
+
+				// List clusters
+				clusterArns, err := client.ListClusters()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clusterArns).To(ContainElement(ContainSubstring(clusterName)))
+			})
+
+			It("should delete cluster with generated types", func() {
+				// Create cluster first
+				err := client.CreateCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Delete cluster
+				err = client.DeleteCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify cluster is deleted
+				_, err = client.DescribeCluster(clusterName)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not found"))
+			})
+		})
+
+		Context("when testing JSON marshaling compatibility", func() {
+			It("should handle cluster settings correctly", func() {
+				clusterName := utils.GenerateTestName("settings-cluster")
+				DeferCleanup(func() {
+					_ = client.DeleteCluster(clusterName)
+				})
+
+				// Create cluster (settings would be set via API if supported)
+				err := client.CreateCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Describe cluster to check settings
+				cluster, err := client.DescribeCluster(clusterName)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Settings should be parsed correctly (even if empty)
+				Expect(cluster.Settings).NotTo(BeNil())
+			})
+		})
+	})
+
+	Describe("Error Handling with Generated Types", func() {
+		It("should handle cluster not found error", func() {
+			nonExistentCluster := "non-existent-cluster"
+			
+			_, err := client.DescribeCluster(nonExistentCluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("should handle duplicate cluster creation", func() {
+			clusterName := utils.GenerateTestName("dup-cluster")
+			DeferCleanup(func() {
+				_ = client.DeleteCluster(clusterName)
+			})
+
+			// Create cluster
+			err := client.CreateCluster(clusterName)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Try to create again - should not error (idempotent)
+			err = client.CreateCluster(clusterName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/tests/scenarios/utils/client_interface.go
+++ b/tests/scenarios/utils/client_interface.go
@@ -8,6 +8,8 @@ const (
 	CurlMode ClientMode = "curl"
 	// AWSCLIMode uses AWS CLI for API calls
 	AWSCLIMode ClientMode = "awscli"
+	// GeneratedMode uses generated types and custom AWS client
+	GeneratedMode ClientMode = "generated"
 )
 
 // ECSClientInterface defines the interface for ECS operations

--- a/tests/scenarios/utils/factory.go
+++ b/tests/scenarios/utils/factory.go
@@ -9,6 +9,8 @@ func NewECSClientInterface(endpoint string, mode ...ClientMode) ECSClientInterfa
 			return NewAWSCLIClient(endpoint)
 		case CurlMode:
 			return NewCurlClient(endpoint)
+		case GeneratedMode:
+			return NewGeneratedClient(endpoint)
 		}
 	}
 	// Default to curl mode for backward compatibility

--- a/tests/scenarios/utils/generated_client.go
+++ b/tests/scenarios/utils/generated_client.go
@@ -1,0 +1,316 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	generated_v2 "github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated_v2"
+)
+
+// GeneratedClient uses generated types for ECS operations
+type GeneratedClient struct {
+	endpoint string
+	region   string
+}
+
+// NewGeneratedClient creates a new client using generated types
+func NewGeneratedClient(endpoint string) *GeneratedClient {
+	return &GeneratedClient{
+		endpoint: endpoint,
+		region:   "us-east-1",
+	}
+}
+
+// doRequest performs a request to KECS API
+func (c *GeneratedClient) doRequest(action string, request interface{}) ([]byte, error) {
+	// Marshal request using generated types
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request
+	url := fmt.Sprintf("%s/", c.endpoint)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", fmt.Sprintf("AmazonEC2ContainerServiceV20141113.%s", action))
+
+	// Execute request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Read response
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for errors
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API error: status=%d, body=%s", resp.StatusCode, respBody)
+	}
+
+	return respBody, nil
+}
+
+// CreateCluster creates a new ECS cluster
+func (c *GeneratedClient) CreateCluster(name string) error {
+	req := generated_v2.CreateClusterRequest{
+		ClusterName: &name,
+	}
+	
+	_, err := c.doRequest("CreateCluster", req)
+	return err
+}
+
+// DescribeCluster describes an ECS cluster
+func (c *GeneratedClient) DescribeCluster(name string) (*Cluster, error) {
+	req := generated_v2.DescribeClustersRequest{
+		Clusters: []string{name},
+	}
+	
+	output, err := c.doRequest("DescribeClusters", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp generated_v2.DescribeClustersResponse
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(resp.Failures) > 0 {
+		return nil, fmt.Errorf("cluster not found: %s", *resp.Failures[0].Reason)
+	}
+
+	if len(resp.Clusters) == 0 {
+		return nil, fmt.Errorf("no clusters returned")
+	}
+
+	// Convert generated type to test type
+	genCluster := resp.Clusters[0]
+	cluster := &Cluster{
+		ClusterArn:                        derefString(genCluster.ClusterArn),
+		ClusterName:                       derefString(genCluster.ClusterName),
+		Status:                            derefString(genCluster.Status),
+		RegisteredContainerInstancesCount: int(derefInt32(genCluster.RegisteredContainerInstancesCount)),
+		RunningTasksCount:                 int(derefInt32(genCluster.RunningTasksCount)),
+		PendingTasksCount:                 int(derefInt32(genCluster.PendingTasksCount)),
+		ActiveServicesCount:               int(derefInt32(genCluster.ActiveServicesCount)),
+	}
+
+	// Convert settings
+	if genCluster.Settings != nil {
+		cluster.Settings = make([]ClusterSetting, len(genCluster.Settings))
+		for i, s := range genCluster.Settings {
+			cluster.Settings[i] = ClusterSetting{
+				Name:  fmt.Sprintf("%v", derefInterface(s.Name)),
+				Value: derefString(s.Value),
+			}
+		}
+	}
+
+	// Convert tags
+	if genCluster.Tags != nil {
+		cluster.Tags = make(map[string]string)
+		for _, tag := range genCluster.Tags {
+			if tag.Key != nil && tag.Value != nil {
+				cluster.Tags[*tag.Key] = *tag.Value
+			}
+		}
+	}
+
+	return cluster, nil
+}
+
+// ListClusters lists all ECS clusters
+func (c *GeneratedClient) ListClusters() ([]string, error) {
+	req := generated_v2.ListClustersRequest{}
+	
+	output, err := c.doRequest("ListClusters", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp generated_v2.ListClustersResponse
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return resp.ClusterArns, nil
+}
+
+// DeleteCluster deletes an ECS cluster
+func (c *GeneratedClient) DeleteCluster(name string) error {
+	req := generated_v2.DeleteClusterRequest{
+		Cluster: name,
+	}
+	
+	_, err := c.doRequest("DeleteCluster", req)
+	return err
+}
+
+// RegisterTaskDefinition registers a task definition
+func (c *GeneratedClient) RegisterTaskDefinition(family string, definition string) (*TaskDefinition, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("RegisterTaskDefinition not yet implemented with generated types")
+}
+
+// DescribeTaskDefinition describes a task definition
+func (c *GeneratedClient) DescribeTaskDefinition(taskDefArn string) (*TaskDefinition, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("DescribeTaskDefinition not yet implemented with generated types")
+}
+
+// ListTaskDefinitions lists task definitions
+func (c *GeneratedClient) ListTaskDefinitions() ([]string, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("ListTaskDefinitions not yet implemented with generated types")
+}
+
+// DeregisterTaskDefinition deregisters a task definition
+func (c *GeneratedClient) DeregisterTaskDefinition(taskDefArn string) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("DeregisterTaskDefinition not yet implemented with generated types")
+}
+
+// CreateService creates an ECS service
+func (c *GeneratedClient) CreateService(clusterName, serviceName, taskDef string, desiredCount int) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("CreateService not yet implemented with generated types")
+}
+
+// DescribeService describes an ECS service
+func (c *GeneratedClient) DescribeService(clusterName, serviceName string) (*Service, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("DescribeService not yet implemented with generated types")
+}
+
+// ListServices lists services in a cluster
+func (c *GeneratedClient) ListServices(clusterName string) ([]string, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("ListServices not yet implemented with generated types")
+}
+
+// UpdateService updates an ECS service
+func (c *GeneratedClient) UpdateService(clusterName, serviceName string, desiredCount *int, taskDef string) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("UpdateService not yet implemented with generated types")
+}
+
+// DeleteService deletes an ECS service
+func (c *GeneratedClient) DeleteService(clusterName, serviceName string) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("DeleteService not yet implemented with generated types")
+}
+
+// RunTask runs a task
+func (c *GeneratedClient) RunTask(clusterName, taskDefArn string, count int) (*RunTaskResponse, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("RunTask not yet implemented with generated types")
+}
+
+// DescribeTasks describes tasks
+func (c *GeneratedClient) DescribeTasks(clusterName string, taskArns []string) ([]Task, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("DescribeTasks not yet implemented with generated types")
+}
+
+// ListTasks lists tasks
+func (c *GeneratedClient) ListTasks(clusterName string, serviceName string) ([]string, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("ListTasks not yet implemented with generated types")
+}
+
+// StopTask stops a task
+func (c *GeneratedClient) StopTask(clusterName, taskArn, reason string) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("StopTask not yet implemented with generated types")
+}
+
+// TagResource tags a resource
+func (c *GeneratedClient) TagResource(resourceArn string, tags map[string]string) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("TagResource not yet implemented with generated types")
+}
+
+// UntagResource untags a resource
+func (c *GeneratedClient) UntagResource(resourceArn string, tagKeys []string) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("UntagResource not yet implemented with generated types")
+}
+
+// ListTagsForResource lists tags for a resource
+func (c *GeneratedClient) ListTagsForResource(resourceArn string) (map[string]string, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("ListTagsForResource not yet implemented with generated types")
+}
+
+// PutAttributes puts attributes
+func (c *GeneratedClient) PutAttributes(clusterName string, attributes []Attribute) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("PutAttributes not yet implemented with generated types")
+}
+
+// ListAttributes lists attributes
+func (c *GeneratedClient) ListAttributes(clusterName, targetType string) ([]Attribute, error) {
+	// TODO: Implement using generated types
+	return nil, fmt.Errorf("ListAttributes not yet implemented with generated types")
+}
+
+// DeleteAttributes deletes attributes
+func (c *GeneratedClient) DeleteAttributes(clusterName string, attributes []Attribute) error {
+	// TODO: Implement using generated types
+	return fmt.Errorf("DeleteAttributes not yet implemented with generated types")
+}
+
+// GetLocalStackStatus gets LocalStack status
+func (c *GeneratedClient) GetLocalStackStatus(clusterName string) (string, error) {
+	// This is specific to LocalStack integration
+	// For now, return not implemented
+	return "", fmt.Errorf("GetLocalStackStatus not yet implemented with generated types")
+}
+
+// Helper functions
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefInt32(i *int32) int32 {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func derefInterface(i *interface{}) interface{} {
+	if i == nil {
+		return nil
+	}
+	return *i
+}
+
+// extractNameFromArn extracts the name from an ARN
+func extractNameFromArn(arn string) string {
+	parts := strings.Split(arn, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return arn
+}


### PR DESCRIPTION
## Summary
This PR adds support for testing with generated types, demonstrating that the generated types work correctly with KECS APIs.

## Changes
- Created `GeneratedClient` that uses generated types for ECS operations
- Added `GeneratedMode` to client factory for test scenarios
- Implemented cluster operations (Create, Describe, List, Delete)
- Added integration tests to verify generated types work correctly
- Documented testing approach with generated types

## Test Results


## Benefits
- ✅ Validates generated types work correctly with KECS API
- ✅ Provides migration path for test scenarios
- ✅ Ensures AWS CLI compatibility with camelCase JSON tags
- ✅ Tests can run with curl, AWS CLI, or generated types

## TODO
- [ ] Implement remaining ECS operations in GeneratedClient
- [ ] Migrate more test scenarios to use generated types
- [ ] Remove AWS SDK v2 dependencies from LocalStack helpers

## Related Issues
- Part of AWS SDK v2 removal plan (#177)

🤖 Generated with [Claude Code](https://claude.ai/code)