### PR TITLE
feat: Migrate all GitHub Actions workflows to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, medium]
     defaults:
       run:
         working-directory: ./controlplane
@@ -40,7 +40,7 @@ jobs:
   build-and-push:
     name: Build and Push Docker image
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, medium]
     # Only run on main branch pushes and tags, not on PRs
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, small]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-all:
     name: Check All Components
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, medium]
     
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, medium]
     permissions:
       contents: read
       packages: write
@@ -72,7 +72,7 @@ jobs:
 
   create-release:
     needs: build-and-push
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, small]
     permissions:
       contents: write
       

--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test-phases:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, large]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/web-ui-ci.yml
+++ b/.github/workflows/web-ui-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: Test Web UI
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, small]
     defaults:
       run:
         working-directory: ./web-ui
@@ -64,7 +64,7 @@ jobs:
 
   build-check:
     name: Build Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, small]
     defaults:
       run:
         working-directory: ./web-ui


### PR DESCRIPTION
## Summary
This PR migrates all GitHub Actions workflows from GitHub-hosted runners to self-hosted runners for better performance and control.

## Runner Assignment

Based on workload characteristics, I've assigned the following runner sizes:

### Large Runner (High Resource Tasks)
- **scenario-tests.yml**: Heavy Docker operations, multiple test phases, concurrent container runs

### Medium Runner (Standard Build Tasks)  
- **ci.yml**: Go tests, Docker multi-platform builds
- **release.yml**: Multi-platform Docker builds with Web UI compilation
- **full-ci.yml**: Combined Go and Node.js builds with full integration

### Small Runner (Lightweight Tasks)
- **web-ui-ci.yml**: Node.js tests and builds
- **release.yml** (create-release job): Simple GitHub release creation
- **claude.yml**: AI assistant integration (minimal resource usage)

## Changes Made
- Replaced all `runs-on: ubuntu-latest` with appropriate self-hosted runner labels
- Used array syntax for runner labels: `runs-on: [self-hosted, linux, <size>]`

## Benefits
- 🚀 Better performance with dedicated resources
- 🔧 More control over build environment
- 💰 Potential cost savings on GitHub Actions minutes
- 🔐 Enhanced security with self-managed infrastructure

## Testing
The workflows will be tested when this PR is merged, as they trigger on various GitHub events.

🤖 Generated with [Claude Code](https://claude.ai/code)