### PR TITLE
fix: Remove duplicate RunSpecs causing test failures

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_ecs_api_v2_test.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api_v2_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -369,8 +368,3 @@ var _ = Describe("Cluster ECS API V2", func() {
 		})
 	})
 })
-
-func TestClusterECSAPIV2(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cluster ECS API V2 Suite")
-}

--- a/controlplane/internal/controlplane/api/integration_test.go
+++ b/controlplane/internal/controlplane/api/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -144,8 +143,3 @@ var _ = Describe("Integration Test - V1 to V2 Migration", func() {
 		})
 	})
 })
-
-func TestIntegration(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Test Suite")
-}

--- a/controlplane/internal/controlplane/api/service_ecs_api_v2_test.go
+++ b/controlplane/internal/controlplane/api/service_ecs_api_v2_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -493,8 +492,3 @@ var _ = Describe("Service ECS API V2", func() {
 		})
 	})
 })
-
-func TestServiceECSAPIV2(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Service ECS API V2 Suite")
-}

--- a/controlplane/internal/controlplane/api/task_definition_ecs_api_v2_test.go
+++ b/controlplane/internal/controlplane/api/task_definition_ecs_api_v2_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -464,8 +463,3 @@ var _ = Describe("TaskDefinition ECS API V2", func() {
 		})
 	})
 })
-
-func TestTaskDefinitionECSAPIV2(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "TaskDefinition ECS API V2 Suite")
-}

--- a/controlplane/internal/controlplane/api/task_ecs_api_v2_test.go
+++ b/controlplane/internal/controlplane/api/task_ecs_api_v2_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -418,8 +417,3 @@ var _ = Describe("Task ECS API V2", func() {
 		})
 	})
 })
-
-func TestTaskECSAPIV2(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Task ECS API V2 Suite")
-}


### PR DESCRIPTION
## Summary
This PR fixes the CI test failures caused by multiple Ginkgo RunSpecs in the same package.

## Problem
The CI was failing with the error:
```
Rerunning Suite
  It looks like you are calling RunSpecs more than once. Ginkgo does not support
  rerunning suites.
```

This happened because several test files in `controlplane/internal/controlplane/api/` had their own `Test*` functions calling `RunSpecs`, which conflicts with the main test suite runner.

## Solution
Removed duplicate test runner functions from:
- `cluster_ecs_api_v2_test.go` - Removed `TestClusterECSAPIV2`
- `integration_test.go` - Removed `TestIntegration`
- `service_ecs_api_v2_test.go` - Removed `TestServiceECSAPIV2`
- `task_definition_ecs_api_v2_test.go` - Removed `TestTaskDefinitionECSAPIV2`
- `task_ecs_api_v2_test.go` - Removed `TestTaskECSAPIV2`

The main test runner `TestApi` in `api_suite_test.go` handles all Ginkgo specs for the package.

## Testing
Verified locally that all tests pass:
```bash
cd controlplane && go test -v ./internal/controlplane/api/...
# All 286 tests pass successfully
```

This should unblock the CI for all PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)