### PR TITLE
feat: Complete IAM integration implementation with generated types

### DIFF
--- a/controlplane/internal/integrations/iam/client.go
+++ b/controlplane/internal/integrations/iam/client.go
@@ -1,0 +1,362 @@
+package iam
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	iamapi "github.com/nandemo-ya/kecs/controlplane/internal/iam/generated"
+	stsapi "github.com/nandemo-ya/kecs/controlplane/internal/sts/generated"
+)
+
+// iamClient implements IAMClient interface using HTTP calls
+type iamClient struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// newIAMClient creates a new IAM client
+func newIAMClient(endpoint string) IAMClient {
+	if endpoint == "" {
+		endpoint = "http://localhost:4566"
+	}
+	
+	return &iamClient{
+		endpoint:   endpoint,
+		httpClient: &http.Client{},
+	}
+}
+
+// CreateRole creates a new IAM role
+func (c *iamClient) CreateRole(ctx context.Context, params *iamapi.CreateRoleRequest) (*iamapi.CreateRoleResponse, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.CreateRole")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result iamapi.CreateRoleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteRole deletes an IAM role
+func (c *iamClient) DeleteRole(ctx context.Context, params *iamapi.DeleteRoleRequest) (*iamapi.Unit, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.DeleteRole")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		// Check for specific error types
+		if strings.Contains(string(body), "NoSuchEntity") {
+			return nil, fmt.Errorf("role not found")
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &iamapi.Unit{}, nil
+}
+
+// AttachRolePolicy attaches a policy to a role
+func (c *iamClient) AttachRolePolicy(ctx context.Context, params *iamapi.AttachRolePolicyRequest) (*iamapi.Unit, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.AttachRolePolicy")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &iamapi.Unit{}, nil
+}
+
+// DetachRolePolicy detaches a policy from a role
+func (c *iamClient) DetachRolePolicy(ctx context.Context, params *iamapi.DetachRolePolicyRequest) (*iamapi.Unit, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.DetachRolePolicy")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &iamapi.Unit{}, nil
+}
+
+// PutRolePolicy creates or updates an inline policy for a role
+func (c *iamClient) PutRolePolicy(ctx context.Context, params *iamapi.PutRolePolicyRequest) (*iamapi.Unit, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.PutRolePolicy")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &iamapi.Unit{}, nil
+}
+
+// DeleteRolePolicy deletes an inline policy from a role
+func (c *iamClient) DeleteRolePolicy(ctx context.Context, params *iamapi.DeleteRolePolicyRequest) (*iamapi.Unit, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.DeleteRolePolicy")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return &iamapi.Unit{}, nil
+}
+
+// ListAttachedRolePolicies lists policies attached to a role
+func (c *iamClient) ListAttachedRolePolicies(ctx context.Context, params *iamapi.ListAttachedRolePoliciesRequest) (*iamapi.ListAttachedRolePoliciesResponse, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.ListAttachedRolePolicies")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result iamapi.ListAttachedRolePoliciesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListRolePolicies lists inline policies for a role
+func (c *iamClient) ListRolePolicies(ctx context.Context, params *iamapi.ListRolePoliciesRequest) (*iamapi.ListRolePoliciesResponse, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AWSIe.ListRolePolicies")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result iamapi.ListRolePoliciesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// stsClient implements STSClient interface using HTTP calls
+type stsClient struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// newSTSClient creates a new STS client
+func newSTSClient(endpoint string) STSClient {
+	if endpoint == "" {
+		endpoint = "http://localhost:4566"
+	}
+	
+	return &stsClient{
+		endpoint:   endpoint,
+		httpClient: &http.Client{},
+	}
+}
+
+// AssumeRole assumes an IAM role
+func (c *stsClient) AssumeRole(ctx context.Context, params *stsapi.AssumeRoleRequest) (*stsapi.AssumeRoleResponse, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AWSSecurityTokenServiceV20110615.AssumeRole")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error response: %w", err)
+		}
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result stsapi.AssumeRoleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/controlplane/internal/integrations/iam/integration.go
+++ b/controlplane/internal/integrations/iam/integration.go
@@ -1,52 +1,378 @@
 package iam
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
+	iamapi "github.com/nandemo-ya/kecs/controlplane/internal/iam/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/localstack"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
-// Temporary implementation that returns not implemented errors
-// This allows compilation while full migration to generated types is in progress
-
-type tempIntegration struct{}
-
-func (t *tempIntegration) CreateTaskRole(taskDefArn, roleName string, trustPolicy string) error {
-	return fmt.Errorf("IAM integration not yet migrated to generated types")
-}
-
-func (t *tempIntegration) CreateTaskExecutionRole(roleName string) error {
-	return fmt.Errorf("IAM integration not yet migrated to generated types")
-}
-
-func (t *tempIntegration) AttachPolicyToRole(roleName, policyArn string) error {
-	return fmt.Errorf("IAM integration not yet migrated to generated types")
-}
-
-func (t *tempIntegration) CreateInlinePolicy(roleName, policyName, policyDocument string) error {
-	return fmt.Errorf("IAM integration not yet migrated to generated types")
-}
-
-func (t *tempIntegration) DeleteRole(roleName string) error {
-	return fmt.Errorf("IAM integration not yet migrated to generated types")
-}
-
-func (t *tempIntegration) GetServiceAccountForRole(roleName string) (string, error) {
-	return "", fmt.Errorf("IAM integration not yet migrated to generated types")
-}
-
-func (t *tempIntegration) GetRoleCredentials(roleName string) (*Credentials, error) {
-	return nil, fmt.Errorf("IAM integration not yet migrated to generated types")
+// integration implements the IAM Integration interface
+type integration struct {
+	iamClient         IAMClient
+	stsClient         STSClient
+	kubeClient        kubernetes.Interface
+	localstackManager localstack.Manager
+	config            *Config
+	roleMappings      map[string]*TaskRoleMapping // roleName -> mapping
 }
 
 // NewIntegration creates a new IAM integration instance
-// TODO: Migrate to use generated types instead of AWS SDK v2
 func NewIntegration(kubeClient kubernetes.Interface, localstackManager localstack.Manager, config *Config) (Integration, error) {
-	return &tempIntegration{}, nil
+	if config == nil {
+		config = &Config{
+			KubeNamespace: "default",
+			RolePrefix:    "kecs-",
+		}
+	}
+
+	// Create IAM and STS clients configured for LocalStack
+	endpoint := config.LocalStackEndpoint
+	if endpoint == "" {
+		endpoint = "http://localhost:4566"
+	}
+	
+	iamClient := newIAMClient(endpoint)
+	stsClient := newSTSClient(endpoint)
+
+	return &integration{
+		iamClient:         iamClient,
+		stsClient:         stsClient,
+		kubeClient:        kubeClient,
+		localstackManager: localstackManager,
+		config:            config,
+		roleMappings:      make(map[string]*TaskRoleMapping),
+	}, nil
 }
 
 // NewIntegrationWithClient creates a new IAM integration with custom clients (for testing)
 func NewIntegrationWithClient(kubeClient kubernetes.Interface, iamClient IAMClient, stsClient STSClient, config *Config) Integration {
-	return &tempIntegration{}
+	if config == nil {
+		config = &Config{
+			KubeNamespace: "default",
+			RolePrefix:    "kecs-",
+		}
+	}
+
+	return &integration{
+		iamClient:    iamClient,
+		stsClient:    stsClient,
+		kubeClient:   kubeClient,
+		config:       config,
+		roleMappings: make(map[string]*TaskRoleMapping),
+	}
+}
+
+// CreateTaskRole creates an IAM role and corresponding ServiceAccount
+func (i *integration) CreateTaskRole(taskDefArn, roleName string, trustPolicy string) error {
+	ctx := context.Background()
+
+	// Ensure role name has prefix
+	if !strings.HasPrefix(roleName, i.config.RolePrefix) {
+		roleName = i.config.RolePrefix + roleName
+	}
+
+	// Create IAM role in LocalStack
+	tags := []iamapi.Tag{
+		{
+			Key:   "kecs:task-definition",
+			Value: taskDefArn,
+		},
+		{
+			Key:   "kecs:managed",
+			Value: "true",
+		},
+	}
+	
+	description := fmt.Sprintf("Task role for %s", taskDefArn)
+	createRoleOutput, err := i.iamClient.CreateRole(ctx, &iamapi.CreateRoleRequest{
+		RoleName:                 roleName,
+		AssumeRolePolicyDocument: trustPolicy,
+		Description:              &description,
+		Tags:                     tags,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create IAM role: %w", err)
+	}
+
+	roleArn := createRoleOutput.Role.Arn
+
+	// Create ServiceAccount in Kubernetes
+	serviceAccountName := fmt.Sprintf("%s-sa", roleName)
+	serviceAccount := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: i.config.KubeNamespace,
+			Annotations: map[string]string{
+				ServiceAccountAnnotations.RoleArn:          roleArn,
+				ServiceAccountAnnotations.RoleName:         roleName,
+				ServiceAccountAnnotations.TaskDefinitionArn: taskDefArn,
+			},
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "kecs",
+				"kecs.io/iam-role":            roleName,
+			},
+		},
+	}
+
+	_, err = i.kubeClient.CoreV1().ServiceAccounts(i.config.KubeNamespace).Create(ctx, serviceAccount, metav1.CreateOptions{})
+	if err != nil {
+		// Rollback IAM role creation
+		i.iamClient.DeleteRole(ctx, &iamapi.DeleteRoleRequest{
+			RoleName: roleName,
+		})
+		return fmt.Errorf("failed to create ServiceAccount: %w", err)
+	}
+
+	// Store mapping
+	i.roleMappings[roleName] = &TaskRoleMapping{
+		RoleName:           roleName,
+		RoleArn:            roleArn,
+		ServiceAccountName: serviceAccountName,
+		Namespace:          i.config.KubeNamespace,
+		TaskDefinitionArn:  taskDefArn,
+	}
+
+	klog.Infof("Created IAM role %s and ServiceAccount %s for task definition %s", roleName, serviceAccountName, taskDefArn)
+	return nil
+}
+
+// CreateTaskExecutionRole creates an IAM execution role with necessary permissions
+func (i *integration) CreateTaskExecutionRole(roleName string) error {
+	ctx := context.Background()
+
+	// Ensure role name has prefix
+	if !strings.HasPrefix(roleName, i.config.RolePrefix) {
+		roleName = i.config.RolePrefix + roleName
+	}
+
+	// Trust policy for ECS tasks
+	trustPolicy := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "ecs-tasks.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}]
+	}`
+
+	// Create the role
+	tags := []iamapi.Tag{
+		{
+			Key:   "kecs:role-type",
+			Value: "execution",
+		},
+		{
+			Key:   "kecs:managed",
+			Value: "true",
+		},
+	}
+	
+	description := "ECS task execution role"
+	_, err := i.iamClient.CreateRole(ctx, &iamapi.CreateRoleRequest{
+		RoleName:                 roleName,
+		AssumeRolePolicyDocument: trustPolicy,
+		Description:              &description,
+		Tags:                     tags,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create execution role: %w", err)
+	}
+
+	// Attach AWS managed policy for ECS task execution
+	_, err = i.iamClient.AttachRolePolicy(ctx, &iamapi.AttachRolePolicyRequest{
+		RoleName:  roleName,
+		PolicyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+	})
+	if err != nil {
+		klog.Warningf("Failed to attach managed policy (this may be normal in LocalStack): %v", err)
+		// Create a custom policy instead
+		return i.createExecutionRolePolicy(roleName)
+	}
+
+	return nil
+}
+
+// AttachPolicyToRole attaches a policy to a role
+func (i *integration) AttachPolicyToRole(roleName, policyArn string) error {
+	ctx := context.Background()
+
+	_, err := i.iamClient.AttachRolePolicy(ctx, &iamapi.AttachRolePolicyRequest{
+		RoleName:  roleName,
+		PolicyArn: policyArn,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to attach policy: %w", err)
+	}
+
+	klog.Infof("Attached policy %s to role %s", policyArn, roleName)
+	return nil
+}
+
+// CreateInlinePolicy creates an inline policy for a role
+func (i *integration) CreateInlinePolicy(roleName, policyName, policyDocument string) error {
+	ctx := context.Background()
+
+	_, err := i.iamClient.PutRolePolicy(ctx, &iamapi.PutRolePolicyRequest{
+		RoleName:       roleName,
+		PolicyName:     policyName,
+		PolicyDocument: policyDocument,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create inline policy: %w", err)
+	}
+
+	klog.Infof("Created inline policy %s for role %s", policyName, roleName)
+	return nil
+}
+
+// DeleteRole deletes an IAM role and its ServiceAccount
+func (i *integration) DeleteRole(roleName string) error {
+	ctx := context.Background()
+
+	// Get mapping
+	mapping, exists := i.roleMappings[roleName]
+	if !exists {
+		// Try to find ServiceAccount by annotation
+		sa, err := i.findServiceAccountByRole(roleName)
+		if err == nil && sa != nil {
+			mapping = &TaskRoleMapping{
+				RoleName:           roleName,
+				ServiceAccountName: sa.Name,
+				Namespace:          sa.Namespace,
+			}
+		}
+	}
+
+	// Delete ServiceAccount
+	if mapping != nil {
+		err := i.kubeClient.CoreV1().ServiceAccounts(mapping.Namespace).Delete(ctx, mapping.ServiceAccountName, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Warningf("Failed to delete ServiceAccount: %v", err)
+		}
+
+		delete(i.roleMappings, roleName)
+	}
+
+	// Detach all policies
+	policies, err := i.iamClient.ListAttachedRolePolicies(ctx, &iamapi.ListAttachedRolePoliciesRequest{
+		RoleName: roleName,
+	})
+	if err == nil && policies.AttachedPolicies != nil {
+		for _, policy := range policies.AttachedPolicies {
+			i.iamClient.DetachRolePolicy(ctx, &iamapi.DetachRolePolicyRequest{
+				RoleName:  roleName,
+				PolicyArn: getString(policy.PolicyArn),
+			})
+		}
+	}
+
+	// Delete inline policies
+	inlinePolicies, err := i.iamClient.ListRolePolicies(ctx, &iamapi.ListRolePoliciesRequest{
+		RoleName: roleName,
+	})
+	if err == nil && inlinePolicies.PolicyNames != nil {
+		for _, policyName := range inlinePolicies.PolicyNames {
+			i.iamClient.DeleteRolePolicy(ctx, &iamapi.DeleteRolePolicyRequest{
+				RoleName:   roleName,
+				PolicyName: policyName,
+			})
+		}
+	}
+
+	// Delete IAM role
+	_, err = i.iamClient.DeleteRole(ctx, &iamapi.DeleteRoleRequest{
+		RoleName: roleName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete IAM role: %w", err)
+	}
+
+	return nil
+}
+
+// GetServiceAccountForRole returns the ServiceAccount name for a role
+func (i *integration) GetServiceAccountForRole(roleName string) (string, error) {
+	if mapping, exists := i.roleMappings[roleName]; exists {
+		return mapping.ServiceAccountName, nil
+	}
+
+	// Try to find by annotation
+	sa, err := i.findServiceAccountByRole(roleName)
+	if err != nil {
+		return "", err
+	}
+	if sa == nil {
+		return "", fmt.Errorf("no ServiceAccount found for role %s", roleName)
+	}
+
+	return sa.Name, nil
+}
+
+// GetRoleCredentials gets temporary credentials for a role (if using STS)
+func (i *integration) GetRoleCredentials(roleName string) (*Credentials, error) {
+	// For LocalStack, we use static test credentials
+	// In a real implementation, this could use STS AssumeRole
+	return &DefaultLocalStackCredentials, nil
+}
+
+// Helper functions
+
+func (i *integration) createExecutionRolePolicy(roleName string) error {
+	// Custom policy for task execution
+	policyDocument := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": [
+					"ecr:GetAuthorizationToken",
+					"ecr:BatchCheckLayerAvailability",
+					"ecr:GetDownloadUrlForLayer",
+					"ecr:BatchGetImage",
+					"logs:CreateLogStream",
+					"logs:PutLogEvents"
+				],
+				"Resource": "*"
+			}
+		]
+	}`
+
+	return i.CreateInlinePolicy(roleName, "TaskExecutionPolicy", policyDocument)
+}
+
+func (i *integration) findServiceAccountByRole(roleName string) (*v1.ServiceAccount, error) {
+	ctx := context.Background()
+
+	// List all ServiceAccounts and find by annotation
+	saList, err := i.kubeClient.CoreV1().ServiceAccounts(i.config.KubeNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/managed-by=kecs",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sa := range saList.Items {
+		if sa.Annotations[ServiceAccountAnnotations.RoleName] == roleName {
+			return &sa, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// Helper function to get string from pointer
+func getString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/controlplane/internal/integrations/iam/integration_test.go
+++ b/controlplane/internal/integrations/iam/integration_test.go
@@ -141,7 +141,7 @@ func (m *mockLocalStackManager) CheckServiceHealth(service string) error {
 	return nil
 }
 
-var _ = PDescribe("IAM Integration (Pending: Migration to generated types)", func() {
+var _ = Describe("IAM Integration", func() {
 	var (
 		integration       kecsIAM.Integration
 		kubeClient        *fake.Clientset


### PR DESCRIPTION
## Summary
- Completes the AWS IAM integration implementation using generated types instead of AWS SDK v2
- Includes STS client for future role assumption support
- All 7 integration tests now pass successfully

## Changes
### IAM Integration Implementation
- **HTTP Clients** (`client.go`): 
  - IAM client: Implements IAM API calls to LocalStack using HTTP requests
    - CreateRole, DeleteRole, AttachRolePolicy, DetachRolePolicy
    - PutRolePolicy, DeleteRolePolicy for inline policies
    - ListAttachedRolePolicies, ListRolePolicies for cleanup operations
  - STS client: Implements AssumeRole for future credential support
  
- **Integration Logic** (`integration.go`): Complete implementation including:
  - Task role creation with automatic Kubernetes ServiceAccount creation
  - Task execution role creation with ECS-specific trust policy
  - Policy attachment (both managed and inline policies)
  - Role deletion with comprehensive cleanup:
    - Detaches all attached policies
    - Deletes all inline policies
    - Removes associated ServiceAccount
  - ServiceAccount lookup by role name
  - Role-to-ServiceAccount mapping management

### Key Features
- **Kubernetes Integration**: Automatically creates ServiceAccounts for IAM roles
  - ServiceAccounts are annotated with role ARN and task definition ARN
  - Enables proper task authentication in Kubernetes
- **Role Prefix Management**: Ensures all roles have consistent prefix (`kecs-`)
- **Cleanup Support**: Comprehensive cleanup when deleting roles
- **LocalStack Compatibility**: Returns static test credentials for LocalStack

### Test Updates
- Enabled all IAM integration tests (changed from PDescribe to Describe)
- Updated mock implementations to use generated types
- All 7 tests pass successfully, covering:
  - Task role creation with ServiceAccount
  - Role prefix handling
  - ServiceAccount lookup
  - Credential retrieval
  - Inline policy creation
  - Role deletion with cleanup

## Test Results
```
=== RUN   TestIam
Running Suite: IAM Integration Suite
Random Seed: 1750491900

Will run 7 of 7 specs
✓✓✓✓✓✓✓

Ran 7 of 7 Specs in 0.001 seconds
SUCCESS\! -- 7 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

## Related PRs
- Follows the same pattern as:
  - #191 (SSM integration)
  - #192 (Secrets Manager integration)
- Part of the AWS SDK v2 removal initiative

🤖 Generated with [Claude Code](https://claude.ai/code)