### PR TITLE
fix: Support ARM64 architecture in scenario tests

### DIFF
--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           version: 2
           verbose: false
-          arch: amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- Remove hardcoded `amd64` architecture from AWS CLI installation in GitHub Actions workflow
- Allow the AWS CLI installation action to automatically detect runner architecture
- This enables scenario tests to run on both AMD64 and ARM64 runners

## Test plan
- [x] Updated `.github/workflows/scenario-tests.yml` to remove hardcoded architecture
- [x] Tested workflow syntax with `act` locally
- [ ] CI tests will validate the change when PR is created

🤖 Generated with [Claude Code](https://claude.ai/code)