### PR TITLE
fix: Remove AWS CLI installation step from scenario tests workflow

### DIFF
--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -35,12 +35,6 @@ jobs:
           cd tests/scenarios
           go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
-      - name: Install AWS CLI v2
-        uses: unfor19/install-aws-cli-action@v1
-        with:
-          version: 2
-          verbose: false
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
Remove AWS CLI installation step from GitHub Actions workflow since it's now pre-installed on self-hosted runners.

## Changes
- Remove `Install AWS CLI v2` step from `.github/workflows/scenario-tests.yml`
- This step was using `unfor19/install-aws-cli-action@v1` to install AWS CLI v2

## Benefits
- **Faster CI**: Removes ~30 seconds from workflow execution time
- **Simpler workflow**: Reduces complexity and potential failure points
- **More reliable**: No external dependency on installation action

## Context
AWS CLI is now pre-installed on the self-hosted runners, making the installation step redundant.

## Test plan
- [x] Workflow syntax is valid
- [ ] Scenario tests continue to pass with pre-installed AWS CLI
- [ ] No AWS CLI version conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)