### PR TITLE
fix: Fix compilation errors in scenario tests

### DIFF
--- a/tests/scenarios/cluster/cluster_generated_test.go
+++ b/tests/scenarios/cluster/cluster_generated_test.go
@@ -19,8 +19,8 @@ var _ = Describe("Cluster Operations with Generated Types", func() {
 		kecs = utils.StartKECS(GinkgoT())
 		DeferCleanup(kecs.Cleanup)
 
-		// Create ECS client using generated types
-		client = utils.NewECSClientInterface(kecs.Endpoint(), utils.GeneratedMode)
+		// Create ECS client using AWS CLI mode (generated mode was removed)
+		client = utils.NewECSClientInterface(kecs.Endpoint(), utils.AWSCLIMode)
 		logger = utils.NewTestLogger(GinkgoT())
 	})
 

--- a/tests/scenarios/integration/performance/api_performance_test.go
+++ b/tests/scenarios/integration/performance/api_performance_test.go
@@ -51,7 +51,7 @@ var _ = Describe("API Performance Tests", func() {
 			numConcurrentRequests := 50
 			
 			By("Registering task definition for API tests")
-			taskDef, err := ecsClient.RegisterTaskDefinition("api-perf-task", createAPITestTaskDefinition())
+			_, err := ecsClient.RegisterTaskDefinition("api-perf-task", createAPITestTaskDefinition())
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("Making %d concurrent DescribeService requests", numConcurrentRequests))

--- a/tests/scenarios/real-apps/microservices-app/tests/microservices_test.go
+++ b/tests/scenarios/real-apps/microservices-app/tests/microservices_test.go
@@ -55,7 +55,6 @@ var _ = Describe("Microservices Application Integration", func() {
 		var (
 			apiGatewayTaskDef   string
 			userServiceTaskDef  string
-			orderServiceTaskDef string
 		)
 
 		BeforeEach(func() {

--- a/tests/scenarios/utils/client_interface.go
+++ b/tests/scenarios/utils/client_interface.go
@@ -8,8 +8,6 @@ const (
 	CurlMode ClientMode = "curl"
 	// AWSCLIMode uses AWS CLI for API calls
 	AWSCLIMode ClientMode = "awscli"
-	// GeneratedMode uses generated types and custom AWS client
-	GeneratedMode ClientMode = "generated"
 )
 
 // ECSClientInterface defines the interface for ECS operations

--- a/tests/scenarios/utils/factory.go
+++ b/tests/scenarios/utils/factory.go
@@ -9,8 +9,6 @@ func NewECSClientInterface(endpoint string, mode ...ClientMode) ECSClientInterfa
 			return NewAWSCLIClient(endpoint)
 		case CurlMode:
 			return NewCurlClient(endpoint)
-		case GeneratedMode:
-			return NewGeneratedClient(endpoint)
 		}
 	}
 	// Default to curl mode for backward compatibility

--- a/tests/scenarios/utils/types.go
+++ b/tests/scenarios/utils/types.go
@@ -2,13 +2,14 @@ package utils
 
 // Cluster represents an ECS cluster
 type Cluster struct {
-	ClusterArn                        string `json:"clusterArn"`
-	ClusterName                       string `json:"clusterName"`
-	Status                            string `json:"status"`
-	RegisteredContainerInstancesCount int    `json:"registeredContainerInstancesCount"`
-	RunningTasksCount                 int    `json:"runningTasksCount"`
-	PendingTasksCount                 int    `json:"pendingTasksCount"`
-	ActiveServicesCount               int    `json:"activeServicesCount"`
+	ClusterArn                        string        `json:"clusterArn"`
+	ClusterName                       string        `json:"clusterName"`
+	Status                            string        `json:"status"`
+	RegisteredContainerInstancesCount int           `json:"registeredContainerInstancesCount"`
+	RunningTasksCount                 int           `json:"runningTasksCount"`
+	PendingTasksCount                 int           `json:"pendingTasksCount"`
+	ActiveServicesCount               int           `json:"activeServicesCount"`
+	Settings                          []interface{} `json:"settings,omitempty"`
 }
 
 // TaskDefinition represents an ECS task definition


### PR DESCRIPTION
## Summary
- Fixed all compilation errors in the tests/scenarios directory
- Tests now compile successfully without any errors

## Changes

### 1. Removed GeneratedMode references
- Removed undefined `NewGeneratedClient` function usage from `factory.go`
- Removed `GeneratedMode` constant from `client_interface.go`
- Updated `cluster_generated_test.go` to use `AWSCLIMode` instead of the removed `GeneratedMode`

### 2. Fixed type compatibility issues
- Added `Settings` field to `Cluster` struct in `types.go` for API compatibility
- Fixed LocalStack test type mismatches between `ECSClient` and `ECSClientInterface`
- Updated helper functions to accept interface types instead of concrete `*testing.T`

### 3. Fixed unused variables
- Removed unused `taskDef` variable in `api_performance_test.go`
- Removed unused `orderServiceTaskDef` variable in `microservices_test.go`

### 4. Fixed GinkgoT() compatibility in LocalStack tests
- Added wrapper types (`GinkgoWrapper` and `TestingTWrapper`) to adapt GinkgoT() to testing interfaces
- Updated all LocalStack tests to use proper type assertions and wrappers
- Modified helper functions to work with the new interface types

## Test Results
✅ All tests compile successfully:
```bash
$ go test -run=XXX ./...
ok  	github.com/nandemo-ya/kecs/tests/scenarios/cluster	1.306s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/hybrid	0.389s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/integration/advanced	0.627s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/integration/basic	1.088s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/integration/performance	0.857s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/localstack	1.485s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/phase2	1.684s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/real-apps/microservices-app/tests	2.276s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/real-apps/three-tier-app/tests	2.469s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/service	1.874s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/task	2.071s [no tests to run]
ok  	github.com/nandemo-ya/kecs/tests/scenarios/task_definition	2.637s [no tests to run]
```

🤖 Generated with [Claude Code](https://claude.ai/code)