### PR TITLE
feat: Implement container mode for KECS

### DIFF
--- a/controlplane/internal/controlplane/cmd/server.go
+++ b/controlplane/internal/controlplane/cmd/server.go
@@ -55,9 +55,12 @@ func init() {
 }
 
 func runServer() {
-	// Log test mode status for debugging
+	// Log mode status for debugging
 	if os.Getenv("KECS_TEST_MODE") == "true" {
 		fmt.Println("KECS_TEST_MODE is enabled - running in test mode")
+	}
+	if os.Getenv("KECS_CONTAINER_MODE") == "true" {
+		fmt.Println("KECS_CONTAINER_MODE is enabled - running in container mode")
 	}
 
 	// Load configuration

--- a/controlplane/internal/kubernetes/kind_manager.go
+++ b/controlplane/internal/kubernetes/kind_manager.go
@@ -3,8 +3,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"k8s.io/client-go/kubernetes"
@@ -43,17 +45,26 @@ func (k *KindManager) CreateCluster(ctx context.Context, clusterName string) err
 		return nil
 	}
 
+	kubeconfigPath := k.getKubeconfigPath(kecsClusterName)
+	
 	err = k.provider.Create(
 		kecsClusterName,
 		cluster.CreateWithNodeImage("kindest/node:v1.31.4"),
 		cluster.CreateWithWaitForReady(0),
-		cluster.CreateWithKubeconfigPath(k.getKubeconfigPath(kecsClusterName)),
+		cluster.CreateWithKubeconfigPath(kubeconfigPath),
 		cluster.CreateWithDisplayUsage(false),
 		cluster.CreateWithDisplaySalutation(false),
 	)
 
 	if err != nil {
 		return fmt.Errorf("failed to create kind cluster: %w", err)
+	}
+
+	// In container mode, adjust the kubeconfig for container access
+	if os.Getenv("KECS_CONTAINER_MODE") == "true" {
+		if err := k.adjustKubeconfigForContainer(kubeconfigPath); err != nil {
+			return fmt.Errorf("failed to adjust kubeconfig for container: %w", err)
+		}
 	}
 
 	return nil
@@ -101,6 +112,16 @@ func (k *KindManager) GetKubeClient(clusterName string) (*kubernetes.Clientset, 
 	}
 	kubeconfigPath := k.getKubeconfigPath(kecsClusterName)
 
+	// In container mode, ensure kubeconfig is adjusted
+	if os.Getenv("KECS_CONTAINER_MODE") == "true" {
+		if _, err := os.Stat(kubeconfigPath); err == nil {
+			// Kubeconfig exists, ensure it's adjusted for container access
+			if err := k.adjustKubeconfigForContainer(kubeconfigPath); err != nil {
+				log.Printf("Warning: failed to adjust kubeconfig for container: %v", err)
+			}
+		}
+	}
+
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build kubeconfig: %w", err)
@@ -124,6 +145,18 @@ func (k *KindManager) GetClusterNodes(clusterName string) ([]nodes.Node, error) 
 }
 
 func (k *KindManager) getKubeconfigPath(kecsClusterName string) string {
+	// In container mode, use a specific path that can be mounted
+	if os.Getenv("KECS_CONTAINER_MODE") == "true" {
+		kubeconfigPath := os.Getenv("KECS_KUBECONFIG_PATH")
+		if kubeconfigPath == "" {
+			kubeconfigPath = "/kecs/kubeconfig"
+		}
+		// Ensure directory exists
+		os.MkdirAll(kubeconfigPath, 0755)
+		return filepath.Join(kubeconfigPath, fmt.Sprintf("%s.config", kecsClusterName))
+	}
+	
+	// Default behavior for non-container mode
 	homeDir, _ := os.UserHomeDir()
 	return filepath.Join(homeDir, ".kube", fmt.Sprintf("%s.config", kecsClusterName))
 }
@@ -147,4 +180,55 @@ func GetKubeConfig() (*rest.Config, error) {
 	}
 
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// adjustKubeconfigForContainer modifies the kubeconfig to work from within a container
+func (k *KindManager) adjustKubeconfigForContainer(kubeconfigPath string) error {
+	// Read the kubeconfig
+	config, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	// Determine the host address based on the platform
+	hostAddr := k.getHostAddress()
+
+	// Update all cluster server addresses
+	for _, cluster := range config.Clusters {
+		// Replace localhost or 127.0.0.1 with the host address
+		if strings.Contains(cluster.Server, "localhost") || strings.Contains(cluster.Server, "127.0.0.1") {
+			if strings.Contains(cluster.Server, "https://localhost:") {
+				cluster.Server = strings.Replace(cluster.Server, "localhost", hostAddr, 1)
+			} else if strings.Contains(cluster.Server, "https://127.0.0.1:") {
+				cluster.Server = strings.Replace(cluster.Server, "127.0.0.1", hostAddr, 1)
+			}
+			log.Printf("Adjusted cluster server address to: %s", cluster.Server)
+		}
+	}
+
+	// Write the adjusted kubeconfig back
+	if err := clientcmd.WriteToFile(*config, kubeconfigPath); err != nil {
+		return fmt.Errorf("failed to write adjusted kubeconfig: %w", err)
+	}
+
+	return nil
+}
+
+// getHostAddress returns the appropriate host address for accessing from within a container
+func (k *KindManager) getHostAddress() string {
+	// Check if a custom host address is specified
+	if hostAddr := os.Getenv("KECS_HOST_DOCKER_INTERNAL"); hostAddr != "" {
+		return hostAddr
+	}
+
+	// Default based on platform
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		// macOS and Windows use host.docker.internal
+		return "host.docker.internal"
+	default:
+		// Linux typically uses the docker bridge gateway
+		// This is a common default, but might need adjustment
+		return "172.17.0.1"
+	}
 }


### PR DESCRIPTION
## Summary
- Implement container mode for KECS to enable realistic testing with actual Kind clusters
- Add KECS_CONTAINER_MODE environment variable for deferred Kubernetes client initialization
- Modify KindManager to adjust kubeconfig for container access
- Update testcontainers configuration to mount Docker socket and kubeconfig directory

## Changes
- **KindManager**: Add kubeconfig adjustment for container environments
  - Replace localhost with host-accessible addresses (host.docker.internal on macOS, Docker bridge IP on Linux)
  - Add platform-specific host address detection
- **TaskManager**: Implement deferred client initialization for container mode
- **API Server**: Recognize container mode during initialization
- **Test Infrastructure**: Update testcontainers.go with proper mounts and environment variables

## Test Results
Task definition registration works successfully in container mode. Service creation still has synchronization issues with Kind cluster creation that need to be addressed in a follow-up PR.

## Technical Details
This implementation allows KECS to run in a container while creating Kind clusters on the host Docker environment, avoiding the Docker-in-Docker-in-Docker nesting problem.

## Next Steps
- Fix synchronization between Kind cluster creation and service deployment
- Complete remaining Phase 2 scenario tests

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>