### PR TITLE
fix: Add cluster readiness check for service creation

### DIFF
--- a/controlplane/internal/kubernetes/service_manager.go
+++ b/controlplane/internal/kubernetes/service_manager.go
@@ -80,6 +80,11 @@ func (sm *ServiceManager) CreateService(
 		return nil
 	}
 
+	// Wait for cluster to be ready (with 60 second timeout)
+	if err := sm.kindManager.WaitForClusterReady(cluster.KindClusterName, 60*time.Second); err != nil {
+		return fmt.Errorf("cluster is not ready: %w", err)
+	}
+
 	// Get Kubernetes client for the cluster
 	kubeClient, err := sm.kindManager.GetKubeClient(cluster.KindClusterName)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Implement cluster readiness check to fix kubeconfig synchronization issues
- Add WaitForClusterReady method to KindManager that waits for kubeconfig availability
- Update ServiceManager to wait for cluster readiness before creating deployments

## Problem
When creating a service immediately after cluster creation, the service creation fails with:
```
failed to get kubernetes client: failed to build kubeconfig: stat /kecs/kubeconfig/kecs-xxx.config: no such file or directory
```

This happens because cluster creation is asynchronous, and the kubeconfig file may not be available yet when the service tries to create Kubernetes resources.

## Solution
1. Added `WaitForClusterReady()` method to KindManager that:
   - Checks for kubeconfig file existence
   - Verifies Kubernetes API connectivity
   - Retries with 2-second intervals
   - Times out after 60 seconds

2. Updated ServiceManager to call `WaitForClusterReady()` before getting the Kubernetes client

## Technical Details
- Maintains AWS ECS compatibility by keeping CreateCluster asynchronous
- Service creation now gracefully waits for cluster readiness
- Clear error messages if cluster preparation times out
- No breaking changes to existing APIs

## Testing
The fix has been tested with the Phase 2 scenario tests. The kubeconfig file is now properly waited for, though there may be additional timing issues that need to be addressed in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>