### PR TITLE
ci: Change scenario test runner from medium to large

### DIFF
--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test-phases:
-    runs-on: [self-hosted, aws-testable, medium]
+    runs-on: [self-hosted, aws-testable, large]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Changed the GitHub Actions runner for scenario tests from `medium` to `large`
- This accommodates resource-intensive test operations

## Test plan
- [ ] Verify CI runs successfully with the new runner size
- [ ] Confirm all scenario tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)