### PR TITLE
docs: Add comprehensive documentation for container commands (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Container-based background execution commands (#252)
+  - `kecs start` - Start KECS in a Docker container with customizable options
+  - `kecs stop` - Stop and remove KECS container
+  - `kecs status` - Show container status
+  - `kecs logs` - Display container logs with follow support
+- Multiple instance support (#252 Phase 2)
+  - Run multiple KECS instances with different names and ports
+  - `--auto-port` flag for automatic port assignment
+  - Configuration file support for managing multiple instances
+  - `kecs instances` command for batch management
+- Environment variable management using Viper (#250)
+  - Centralized configuration management
+  - Support for config files, environment variables, and CLI flags
+  - Type-safe configuration access
+- Container features
+  - Health check with 30-second timeout
+  - Data persistence through volume mounts
+  - Local build support with `--local-build` flag
+  - Container labeling for better identification
+
+### Changed
+
+- Improved configuration management with structured config types
+- Enhanced error messages for Docker operations
+- Status command now uses container labels for filtering
+
+### Fixed
+
+- Port conflict detection before container creation
+- Proper cleanup of data directories on container removal
+- Local build path detection for different execution contexts
+
+## [Previous Releases]
+
+### Features in Development
+
+- ECS API Compatibility
+- Kubernetes Backend Integration
+- Web UI Dashboard
+- MCP Server for AI Assistant Integration
+- LocalStack Integration
+- DuckDB Storage Layer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,19 @@ make run            # Build and run the application
 make all            # Clean, format, vet, test, and build
 ```
 
+### Container-based Execution
+```bash
+kecs start          # Start KECS in a Docker container
+kecs stop           # Stop and remove KECS container
+kecs status         # Show container status
+kecs logs -f        # Follow container logs
+
+# Multiple instances
+kecs start --name dev --api-port 8080
+kecs start --name staging --api-port 8090 --auto-port
+kecs instances list # List all instances
+```
+
 ### Testing and Code Quality
 ```bash
 make test           # Run tests with race detection
@@ -199,7 +212,16 @@ cd docs-site && npm run docs:build
 - **Kubernetes**: Task converter with secret management
 - **Web UI**: Dashboard, detail views, WebSocket support
 - **MCP Server**: TypeScript-based Model Context Protocol server for AI assistant integration
+- **Container Commands**: Docker-based background execution with multiple instance support
 - **In Progress**: Full Kubernetes task lifecycle management
+
+### Container Commands Implementation
+KECS includes Docker container management commands similar to kind/k3d:
+- `start`, `stop`, `status`, `logs` commands for container lifecycle
+- Multiple instance support with configuration files
+- Automatic port conflict detection and resolution
+- Data persistence through volume mounts
+- See `docs/container-commands.md` for detailed usage
 
 ## MCP Server Development
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,240 @@ KECS (Kubernetes-based ECS Compatible Service) is a standalone service that prov
 - **ECS API Compatibility**: Provides API endpoints compatible with Amazon ECS
 - **Kubernetes Backend**: Leverages Kubernetes for container orchestration
 - **Local Execution**: Runs completely locally without AWS dependencies
+- **Container-based Background Execution**: Run KECS in Docker containers with simple commands
+- **Multiple Instance Support**: Run multiple KECS instances with different configurations
 - **CI/CD Integration**: Easily integrates with CI/CD pipelines
+
+## Quick Start
+
+### Running KECS in a Container
+
+The easiest way to run KECS is using the container-based execution:
+
+```bash
+# Start KECS in a container
+kecs start
+
+# Check status
+kecs status
+
+# View logs
+kecs logs -f
+
+# Stop KECS
+kecs stop
+```
+
+### Running Multiple Instances
+
+KECS supports running multiple instances with different configurations:
+
+```bash
+# Start with custom name and ports
+kecs start --name dev --api-port 8080 --admin-port 8081
+kecs start --name staging --api-port 8090 --admin-port 8091
+
+# Or use auto-port assignment
+kecs start --name test --auto-port
+
+# List all instances
+kecs instances list
+```
+
+## Installation
+
+### From Source
+
+```bash
+git clone https://github.com/nandemo-ya/kecs.git
+cd kecs/controlplane
+make build
+```
+
+### Using Docker
+
+```bash
+docker pull ghcr.io/nandemo-ya/kecs:latest
+```
+
+## Usage
+
+### Container Commands
+
+KECS provides Docker container-based execution similar to tools like kind and k3d:
+
+#### Start Command
+
+Starts KECS server in a Docker container:
+
+```bash
+kecs start [flags]
+
+Flags:
+  --name string        Container name (default "kecs-server")
+  --image string       Docker image to use (default "ghcr.io/nandemo-ya/kecs:latest")
+  --api-port int       API server port (default 8080)
+  --admin-port int     Admin server port (default 8081)
+  --data-dir string    Data directory (default "~/.kecs/data")
+  -d, --detach         Run container in background (default true)
+  --local-build        Build and use local image
+  --config string      Path to configuration file
+  --auto-port          Automatically find available ports
+```
+
+Examples:
+
+```bash
+# Start with default settings
+kecs start
+
+# Start with custom ports
+kecs start --api-port 9080 --admin-port 9081
+
+# Start with local build
+kecs start --local-build
+
+# Start using configuration file
+kecs start --config ~/.kecs/instances.yaml staging
+```
+
+#### Stop Command
+
+Stops and removes KECS container:
+
+```bash
+kecs stop [flags]
+
+Flags:
+  --name string     Container name (default "kecs-server")
+  -f, --force       Force stop without graceful shutdown
+```
+
+#### Status Command
+
+Shows KECS container status:
+
+```bash
+kecs status [flags]
+
+Flags:
+  --name string     Container name (empty for all KECS containers)
+  -a, --all         Show all containers including stopped ones
+```
+
+#### Logs Command
+
+Displays logs from KECS container:
+
+```bash
+kecs logs [flags]
+
+Flags:
+  --name string        Container name (default "kecs-server")
+  -f, --follow         Follow log output
+  --tail string        Number of lines to show from the end (default "all")
+  -t, --timestamps     Show timestamps
+```
+
+### Multiple Instances Management
+
+KECS supports running multiple instances with the `instances` command:
+
+#### List Instances
+
+```bash
+kecs instances list [--config file]
+```
+
+Shows all configured and running instances with their status, ports, and configuration.
+
+#### Start All Instances
+
+```bash
+kecs instances start-all [--config file]
+```
+
+Starts all instances marked with `autoStart: true` in the configuration file.
+
+#### Stop All Instances
+
+```bash
+kecs instances stop-all
+```
+
+Stops all running KECS instances.
+
+### Configuration File
+
+KECS supports YAML configuration files for managing multiple instances:
+
+```yaml
+# ~/.kecs/instances.yaml
+defaultInstance: dev
+
+instances:
+  - name: dev
+    image: ghcr.io/nandemo-ya/kecs:latest
+    ports:
+      api: 8080
+      admin: 8081
+    dataDir: ~/.kecs/instances/dev/data
+    autoStart: true
+    env:
+      KECS_LOG_LEVEL: debug
+    labels:
+      environment: development
+
+  - name: staging
+    image: ghcr.io/nandemo-ya/kecs:latest
+    ports:
+      api: 8090
+      admin: 8091
+    dataDir: ~/.kecs/instances/staging/data
+    autoStart: true
+    env:
+      KECS_LOG_LEVEL: info
+    labels:
+      environment: staging
+
+  - name: test
+    image: ghcr.io/nandemo-ya/kecs:latest
+    ports:
+      api: 8100
+      admin: 8101
+    dataDir: ~/.kecs/instances/test/data
+    autoStart: false
+    env:
+      KECS_TEST_MODE: "true"
+    labels:
+      environment: test
+```
+
+### Traditional Server Mode
+
+You can also run KECS directly without containers:
+
+```bash
+# Run the server
+kecs server
+
+# Or with custom configuration
+kecs server --port 8080 --admin-port 8081
+```
+
+## API Endpoints
+
+KECS provides ECS-compatible API endpoints:
+
+- **API Server** (default port 8080): ECS API endpoints at `/v1/<action>`
+- **Admin Server** (default port 8081): Health checks at `/health`
+- **Web UI**: Dashboard at `/` (when enabled)
 
 ## Documentation
 
-Architectural Decision Records (ADRs) for this project are stored in the `docs/adr/records` directory.
+- Architectural Decision Records (ADRs) are stored in the `docs/adr/records` directory
+- API documentation is available in the `docs/api` directory
+- For more detailed documentation, visit our [documentation site](https://nandemo-ya.github.io/kecs/)
 
 ## License
 

--- a/docs/adr/records/0001-container-based-execution.md
+++ b/docs/adr/records/0001-container-based-execution.md
@@ -1,0 +1,75 @@
+# 1. Container-based Background Execution
+
+Date: 2025-06-26
+
+## Status
+
+Accepted
+
+## Context
+
+KECS initially required users to run the server process directly, which meant keeping a terminal session open or setting up systemd services. This approach had several limitations:
+
+- Required terminal session to remain open
+- Complex setup for background execution
+- Difficult to manage multiple instances
+- No built-in port conflict resolution
+- Manual process management required
+
+Similar tools in the Kubernetes ecosystem (kind, k3d, minikube) provide container-based execution, which has become the expected pattern for development tools.
+
+## Decision
+
+We will implement container-based background execution for KECS using Docker, providing simple commands to start, stop, and manage KECS instances in containers.
+
+The implementation includes:
+
+1. **Basic Container Commands**:
+   - `kecs start` - Start KECS in a Docker container
+   - `kecs stop` - Stop and remove the container
+   - `kecs status` - Show container status
+   - `kecs logs` - Display container logs
+
+2. **Multiple Instance Support**:
+   - Custom container names for multiple instances
+   - Port conflict detection and auto-assignment
+   - Container labeling for identification
+   - Configuration file support
+
+3. **Instance Management**:
+   - `kecs instances list` - List all instances
+   - `kecs instances start-all` - Start configured instances
+   - `kecs instances stop-all` - Stop all instances
+
+## Consequences
+
+### Positive
+
+- **Improved User Experience**: Simple commands familiar to Kubernetes developers
+- **Background Execution**: No need to keep terminal sessions open
+- **Multiple Instances**: Easy to run dev, staging, and test environments
+- **Port Management**: Automatic port conflict resolution
+- **Data Persistence**: Volume mounts preserve data between restarts
+- **Container Isolation**: Each instance runs in its own container
+
+### Negative
+
+- **Docker Dependency**: Requires Docker to be installed and running
+- **Additional Complexity**: More code to maintain for container management
+- **Resource Overhead**: Each instance consumes container resources
+
+### Implementation Details
+
+The container implementation uses:
+- Docker Go SDK for container management
+- Health checks with configurable timeout
+- Volume mounts for data persistence
+- Environment variables for container mode detection
+- Labels for instance identification
+- YAML configuration files for multi-instance setups
+
+## References
+
+- Issue #252: Add container-based background execution
+- Similar patterns in: kind, k3d, minikube
+- Docker Go SDK documentation

--- a/docs/container-commands.md
+++ b/docs/container-commands.md
@@ -1,0 +1,382 @@
+# Container Commands Guide
+
+This guide covers the container-based execution features of KECS, which allow you to run KECS in Docker containers similar to tools like kind and k3d.
+
+## Overview
+
+KECS provides container commands that make it easy to:
+- Run KECS in the background without keeping a terminal open
+- Manage multiple instances with different configurations
+- Automatically handle port conflicts
+- Persist data between restarts
+
+## Prerequisites
+
+- Docker installed and running
+- KECS binary in your PATH
+- Sufficient permissions to run Docker commands
+
+## Basic Usage
+
+### Starting KECS
+
+The simplest way to start KECS:
+
+```bash
+kecs start
+```
+
+This will:
+- Pull the latest KECS image (if not present)
+- Create a container named `kecs-server`
+- Map ports 8080 (API) and 8081 (Admin)
+- Mount `~/.kecs/data` for persistence
+- Run in detached mode (background)
+
+### Checking Status
+
+To see if KECS is running:
+
+```bash
+kecs status
+```
+
+Output:
+```
+NAME                 STATUS     CREATED         PORTS                IMAGE                         
+-----------------------------------------------------------------------------------------------
+kecs-server          Up 2 mi... 2025-06-26 10:30 8080->8080, 8081-... ghcr.io/nandemo-ya/kecs:latest
+```
+
+### Viewing Logs
+
+To see container logs:
+
+```bash
+# View recent logs
+kecs logs
+
+# Follow logs in real-time
+kecs logs -f
+
+# Show last 100 lines with timestamps
+kecs logs --tail 100 -t
+```
+
+### Stopping KECS
+
+To stop and remove the container:
+
+```bash
+kecs stop
+```
+
+The data directory is preserved when stopping.
+
+## Advanced Usage
+
+### Custom Ports
+
+Run KECS on different ports:
+
+```bash
+kecs start --api-port 9080 --admin-port 9081
+```
+
+### Multiple Instances
+
+Run multiple KECS instances with different names:
+
+```bash
+# Development instance
+kecs start --name kecs-dev --api-port 8080 --admin-port 8081
+
+# Staging instance
+kecs start --name kecs-staging --api-port 8090 --admin-port 8091
+
+# Test instance with auto-port assignment
+kecs start --name kecs-test --auto-port
+```
+
+### Local Build
+
+Build and use a local image:
+
+```bash
+kecs start --local-build
+```
+
+This builds the image from the current source code.
+
+### Custom Data Directory
+
+Specify a custom data directory:
+
+```bash
+kecs start --data-dir /path/to/data
+```
+
+## Configuration File
+
+For complex setups, use a configuration file:
+
+### Example Configuration
+
+Create `~/.kecs/instances.yaml`:
+
+```yaml
+defaultInstance: dev
+
+instances:
+  - name: dev
+    image: ghcr.io/nandemo-ya/kecs:latest
+    ports:
+      api: 8080
+      admin: 8081
+    dataDir: ~/.kecs/instances/dev/data
+    autoStart: true
+    env:
+      KECS_LOG_LEVEL: debug
+      KECS_TEST_MODE: "false"
+    labels:
+      environment: development
+      team: backend
+
+  - name: staging
+    image: ghcr.io/nandemo-ya/kecs:v1.0.0
+    ports:
+      api: 8090
+      admin: 8091
+    dataDir: ~/.kecs/instances/staging/data
+    autoStart: true
+    env:
+      KECS_LOG_LEVEL: info
+    labels:
+      environment: staging
+
+  - name: test
+    image: kecs:local
+    ports:
+      api: 8100
+      admin: 8101
+    dataDir: ~/.kecs/instances/test/data
+    autoStart: false
+    env:
+      KECS_TEST_MODE: "true"
+      KECS_LOG_LEVEL: warn
+    labels:
+      environment: test
+```
+
+### Using Configuration
+
+Start a specific instance from config:
+
+```bash
+kecs start --config ~/.kecs/instances.yaml staging
+```
+
+Start the default instance:
+
+```bash
+kecs start --config ~/.kecs/instances.yaml
+```
+
+## Instance Management
+
+### List All Instances
+
+```bash
+kecs instances list
+```
+
+Output shows both configured and running instances:
+
+```
+INSTANCE             STATUS     API PORT     ADMIN PORT   IMAGE                          DATA DIR
+------------------------------------------------------------------------------------------------
+dev *                running    8080         8081         ghcr.io/nandemo-ya/kecs:latest ~/.kecs/instances/dev/data
+staging              running    8090         8091         ghcr.io/nandemo-ya/kecs:v1.0.0 ~/.kecs/instances/staging/data
+test                 configured 8100         8101         kecs:local                     ~/.kecs/instances/test/data
+
+* Default instance: dev
+```
+
+### Start All Instances
+
+Start all instances with `autoStart: true`:
+
+```bash
+kecs instances start-all --config ~/.kecs/instances.yaml
+```
+
+### Stop All Instances
+
+Stop all running KECS instances:
+
+```bash
+kecs instances stop-all
+```
+
+## Port Management
+
+### Automatic Port Assignment
+
+Use `--auto-port` to automatically find available ports:
+
+```bash
+kecs start --name test --auto-port
+```
+
+This will:
+1. Check for used ports by other KECS instances
+2. Find next available ports starting from defaults
+3. Display assigned ports
+
+### Port Conflict Detection
+
+KECS automatically detects port conflicts:
+
+```bash
+$ kecs start --api-port 8080
+Error: API port 8080 is already in use
+```
+
+## Troubleshooting
+
+### Container Won't Start
+
+1. Check Docker is running:
+   ```bash
+   docker version
+   ```
+
+2. Check for port conflicts:
+   ```bash
+   lsof -i :8080
+   ```
+
+3. Check container logs:
+   ```bash
+   docker logs kecs-server
+   ```
+
+### Permission Issues
+
+If you get permission errors:
+
+```bash
+# Add user to docker group
+sudo usermod -aG docker $USER
+
+# Logout and login again
+```
+
+### Cleanup Orphaned Containers
+
+If containers are left running:
+
+```bash
+# List all KECS containers
+docker ps -a --filter "label=app=kecs"
+
+# Remove all stopped KECS containers
+docker container prune --filter "label=app=kecs"
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+name: Test with KECS
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Start KECS
+        run: |
+          kecs start --name ci-test --auto-port
+          kecs status
+      
+      - name: Run Tests
+        run: |
+          # Your tests here
+          npm test
+      
+      - name: Stop KECS
+        run: kecs stop --name ci-test
+```
+
+### Docker Compose Example
+
+```yaml
+version: '3.8'
+
+services:
+  kecs:
+    image: ghcr.io/nandemo-ya/kecs:latest
+    container_name: kecs-compose
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    volumes:
+      - kecs-data:/data
+    environment:
+      - KECS_CONTAINER_MODE=true
+      - KECS_LOG_LEVEL=info
+    labels:
+      - app=kecs
+
+volumes:
+  kecs-data:
+```
+
+## Best Practices
+
+1. **Use Named Instances**: Always use `--name` for better identification
+2. **Configuration Files**: Use config files for reproducible setups
+3. **Port Planning**: Plan port ranges for different environments
+4. **Data Backup**: Regularly backup data directories
+5. **Resource Limits**: Consider Docker resource limits for production use
+
+## Environment Variables
+
+When running in container mode, these environment variables are set:
+
+- `KECS_CONTAINER_MODE=true` - Indicates container execution
+- `KECS_DATA_DIR=/data` - Data directory inside container
+- `KECS_API_PORT` - API server port
+- `KECS_ADMIN_PORT` - Admin server port
+
+## Security Considerations
+
+1. **Network Isolation**: Containers run in Docker's default bridge network
+2. **Data Permissions**: Data directory inherits host user permissions
+3. **Port Exposure**: Only specified ports are exposed to host
+4. **Image Security**: Use specific version tags in production
+
+## Migration from Direct Execution
+
+If you were running KECS directly:
+
+1. Stop the direct process
+2. Copy data to `~/.kecs/data` (or custom location)
+3. Start with container command: `kecs start`
+4. Verify data is accessible
+
+## Summary
+
+Container commands provide a convenient way to run KECS with:
+- Simple start/stop commands
+- Background execution
+- Multiple instance support
+- Automatic port management
+- Data persistence
+- Configuration file support
+
+For more information, see the [main documentation](../README.md).

--- a/examples/ci-cd/github-actions-kecs.yml
+++ b/examples/ci-cd/github-actions-kecs.yml
@@ -1,0 +1,124 @@
+# Example GitHub Actions workflow using KECS container commands
+name: Test with KECS Container
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-with-kecs:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    
+    - name: Set up Docker
+      uses: docker/setup-buildx-action@v2
+    
+    - name: Install KECS
+      run: |
+        # Download and install KECS binary
+        curl -L https://github.com/nandemo-ya/kecs/releases/latest/download/kecs-linux-amd64 -o kecs
+        chmod +x kecs
+        sudo mv kecs /usr/local/bin/
+    
+    - name: Start KECS Instance
+      run: |
+        # Start KECS with auto-port to avoid conflicts
+        kecs start --name ci-test --auto-port
+        
+        # Wait for KECS to be ready
+        sleep 5
+        
+        # Check status
+        kecs status
+    
+    - name: Get KECS Endpoint
+      id: kecs-endpoint
+      run: |
+        # Extract the API port from status
+        API_PORT=$(kecs status --name ci-test | grep ci-test | awk '{print $3}' | cut -d'-' -f1)
+        echo "endpoint=http://localhost:${API_PORT}" >> $GITHUB_OUTPUT
+    
+    - name: Run Integration Tests
+      env:
+        KECS_ENDPOINT: ${{ steps.kecs-endpoint.outputs.endpoint }}
+      run: |
+        # Run your tests against KECS
+        echo "Running tests against KECS at ${KECS_ENDPOINT}"
+        
+        # Example: Create a cluster
+        aws ecs create-cluster --cluster-name test-cluster --endpoint-url ${KECS_ENDPOINT}
+        
+        # Add your actual tests here
+        # npm test
+        # go test ./...
+        # pytest tests/
+    
+    - name: View KECS Logs
+      if: always()
+      run: |
+        # Show logs for debugging
+        kecs logs --name ci-test --tail 100
+    
+    - name: Stop KECS
+      if: always()
+      run: |
+        # Clean up
+        kecs stop --name ci-test
+
+  test-multiple-instances:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    
+    - name: Install KECS
+      run: |
+        curl -L https://github.com/nandemo-ya/kecs/releases/latest/download/kecs-linux-amd64 -o kecs
+        chmod +x kecs
+        sudo mv kecs /usr/local/bin/
+    
+    - name: Create KECS Configuration
+      run: |
+        mkdir -p ~/.kecs
+        cat > ~/.kecs/ci-instances.yaml << EOF
+        defaultInstance: dev
+        instances:
+          - name: dev
+            ports:
+              api: 8080
+              admin: 8081
+            autoStart: true
+            env:
+              KECS_LOG_LEVEL: debug
+          - name: staging
+            ports:
+              api: 8090
+              admin: 8091
+            autoStart: true
+            env:
+              KECS_LOG_LEVEL: info
+        EOF
+    
+    - name: Start All KECS Instances
+      run: |
+        kecs instances start-all --config ~/.kecs/ci-instances.yaml
+        kecs instances list --config ~/.kecs/ci-instances.yaml
+    
+    - name: Test Against Multiple Instances
+      run: |
+        # Test dev instance
+        aws ecs list-clusters --endpoint-url http://localhost:8080
+        
+        # Test staging instance
+        aws ecs list-clusters --endpoint-url http://localhost:8090
+    
+    - name: Stop All Instances
+      if: always()
+      run: |
+        kecs instances stop-all

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,0 +1,178 @@
+# Docker Compose Examples for KECS
+
+This directory contains Docker Compose examples for running KECS.
+
+## Basic Usage
+
+### Single Instance
+
+Run a single KECS instance:
+
+```bash
+docker-compose up -d
+```
+
+This starts KECS on ports 8080 (API) and 8081 (Admin).
+
+### Multiple Instances
+
+Run multiple KECS instances using profiles:
+
+```bash
+docker-compose --profile multi up -d
+```
+
+This starts:
+- `kecs-dev` on ports 8080/8081
+- `kecs-staging` on ports 8090/8091
+
+### With Application
+
+Run KECS with an example application:
+
+```bash
+docker-compose --profile with-app up -d
+```
+
+## Environment Variables
+
+### Required for KECS
+
+- `KECS_CONTAINER_MODE=true` - Enables container mode
+- `KECS_DATA_DIR=/data` - Data directory inside container
+
+### Optional Configuration
+
+- `KECS_LOG_LEVEL` - Log level (debug, info, warn, error)
+- `KECS_TEST_MODE` - Enable test mode
+- `KECS_DEFAULT_REGION` - Default AWS region
+- `KECS_ACCOUNT_ID` - AWS account ID
+
+### For Applications Using KECS
+
+- `AWS_ENDPOINT_URL=http://kecs:8080` - KECS endpoint
+- `AWS_DEFAULT_REGION=us-east-1` - AWS region
+- `AWS_ACCESS_KEY_ID=dummy` - Dummy credentials
+- `AWS_SECRET_ACCESS_KEY=dummy` - Dummy credentials
+
+## Volumes
+
+Data is persisted in Docker volumes:
+- `kecs-data` - Main instance data
+- `kecs-dev-data` - Dev instance data  
+- `kecs-staging-data` - Staging instance data
+
+## Health Checks
+
+KECS includes health checks that:
+- Test the admin endpoint at `/health`
+- Run every 30 seconds
+- Allow 40 seconds for startup
+- Retry 3 times before marking unhealthy
+
+## Networking
+
+All services run in the `kecs-network` network, allowing:
+- Service discovery by container name
+- Isolation from other Docker networks
+- Communication between KECS and applications
+
+## Commands
+
+### View Logs
+
+```bash
+docker-compose logs -f kecs
+```
+
+### Check Status
+
+```bash
+docker-compose ps
+```
+
+### Stop Services
+
+```bash
+docker-compose down
+```
+
+### Remove Volumes
+
+```bash
+docker-compose down -v
+```
+
+## Customization
+
+### Using Local Build
+
+To use a locally built image:
+
+1. Build the image:
+   ```bash
+   cd ../../controlplane
+   docker build -t kecs:local .
+   ```
+
+2. Update `docker-compose.yml`:
+   ```yaml
+   image: kecs:local
+   ```
+
+### Custom Ports
+
+Modify the ports section:
+```yaml
+ports:
+  - "9080:8080"  # Custom API port
+  - "9081:8081"  # Custom Admin port
+```
+
+### Additional Environment Variables
+
+Add more environment variables:
+```yaml
+environment:
+  - KECS_CONTAINER_MODE=true
+  - KECS_LOG_LEVEL=debug
+  - KECS_FEATURE_X=enabled
+```
+
+## Troubleshooting
+
+### Container Won't Start
+
+Check logs:
+```bash
+docker-compose logs kecs
+```
+
+### Port Conflicts
+
+Change ports in `docker-compose.yml` or stop conflicting services.
+
+### Permission Issues
+
+Ensure Docker daemon is accessible:
+```bash
+sudo usermod -aG docker $USER
+```
+
+## Integration with CI/CD
+
+This compose file can be used in CI/CD:
+
+```bash
+# Start services
+docker-compose up -d
+
+# Wait for health
+docker-compose exec kecs curl -f http://localhost:8081/health
+
+# Run tests
+./run-tests.sh
+
+# Cleanup
+docker-compose down -v
+```

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,0 +1,89 @@
+# Example Docker Compose configuration for KECS
+version: '3.8'
+
+services:
+  # Single KECS instance
+  kecs:
+    image: ghcr.io/nandemo-ya/kecs:latest
+    container_name: kecs-server
+    ports:
+      - "8080:8080"  # API port
+      - "8081:8081"  # Admin port
+    volumes:
+      - kecs-data:/data
+    environment:
+      - KECS_CONTAINER_MODE=true
+      - KECS_LOG_LEVEL=info
+      - KECS_DATA_DIR=/data
+    labels:
+      - app=kecs
+      - environment=development
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+
+  # Multiple instances example
+  kecs-dev:
+    image: ghcr.io/nandemo-ya/kecs:latest
+    container_name: kecs-dev
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    volumes:
+      - kecs-dev-data:/data
+    environment:
+      - KECS_CONTAINER_MODE=true
+      - KECS_LOG_LEVEL=debug
+      - KECS_TEST_MODE=true
+    labels:
+      - app=kecs
+      - instance=dev
+    profiles:
+      - multi
+
+  kecs-staging:
+    image: ghcr.io/nandemo-ya/kecs:latest
+    container_name: kecs-staging
+    ports:
+      - "8090:8080"
+      - "8091:8081"
+    volumes:
+      - kecs-staging-data:/data
+    environment:
+      - KECS_CONTAINER_MODE=true
+      - KECS_LOG_LEVEL=info
+    labels:
+      - app=kecs
+      - instance=staging
+    profiles:
+      - multi
+
+  # Example application using KECS
+  app:
+    image: your-app:latest
+    depends_on:
+      kecs:
+        condition: service_healthy
+    environment:
+      - AWS_ENDPOINT_URL=http://kecs:8080
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_ACCESS_KEY_ID=dummy
+      - AWS_SECRET_ACCESS_KEY=dummy
+    profiles:
+      - with-app
+
+volumes:
+  kecs-data:
+    driver: local
+  kecs-dev-data:
+    driver: local
+  kecs-staging-data:
+    driver: local
+
+networks:
+  default:
+    name: kecs-network


### PR DESCRIPTION
## Summary
- Completes Phase 3 of issue #252
- Adds comprehensive documentation for container-based execution features
- Provides examples, guides, and architectural documentation

## What's Changed

### Documentation Added

1. **README.md Updates**
   - Quick Start section with container commands
   - Detailed command usage and examples
   - Installation instructions
   - Configuration file documentation

2. **Container Commands Guide** (`docs/container-commands.md`)
   - Complete guide covering all aspects of container execution
   - Basic usage (start, stop, status, logs)
   - Advanced features (multiple instances, auto-port)
   - Configuration file examples
   - Troubleshooting guide
   - CI/CD integration examples
   - Security considerations

3. **Architectural Decision Record** (`docs/adr/records/0001-container-based-execution.md`)
   - Documents the decision to implement container-based execution
   - Explains context and rationale
   - Lists positive and negative consequences
   - References similar tools (kind, k3d, minikube)

4. **CHANGELOG.md**
   - Created following Keep a Changelog format
   - Documents all recent features
   - Tracks unreleased changes

5. **Examples Directory**
   - **GitHub Actions**: Complete workflow examples for CI/CD
   - **Docker Compose**: Single and multi-instance configurations
   - Includes README with usage instructions

6. **CLAUDE.md Updates**
   - Added container commands to development workflow
   - Updated implementation status
   - Added references to new documentation

## Documentation Coverage

- ✅ Getting started guide
- ✅ Command reference
- ✅ Configuration examples
- ✅ CI/CD integration
- ✅ Troubleshooting
- ✅ Best practices
- ✅ Security considerations
- ✅ Migration guide

## Related
- Completes #252 (all phases now complete)
- Follows #254 (Phase 1) and #257 (Phase 2)

## Preview

### Quick Start
```bash
# Start KECS
kecs start

# Check status
kecs status

# View logs
kecs logs -f

# Stop KECS
kecs stop
```

### Multiple Instances
```yaml
# ~/.kecs/instances.yaml
defaultInstance: dev
instances:
  - name: dev
    ports:
      api: 8080
      admin: 8081
    autoStart: true
```

This completes the container-based execution feature with full documentation support.

🤖 Generated with [Claude Code](https://claude.ai/code)