### PR TITLE
docs: Add Docker permissions ADR and security disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@
 
 </div>
 
+## ⚠️ Important Disclaimer
+
+**KECS is designed exclusively for local development and CI environments.**
+
+### Supported Environments
+✅ Local development machines  
+✅ CI/CD pipelines (GitHub Actions, GitLab CI, etc.)  
+✅ Isolated test environments  
+
+### NOT Supported
+❌ Production environments  
+❌ Public-facing deployments  
+❌ Multi-tenant systems  
+❌ Any environment with untrusted users  
+
+**Security Notice**: KECS requires Docker daemon access to manage local Kubernetes clusters (k3d). This level of access is equivalent to root privileges. Only run KECS in trusted environments.
+
 ## Overview
 
 KECS (Kubernetes-based ECS Compatible Service) is a standalone service that provides Amazon ECS compatible APIs running on Kubernetes. It enables a fully local ECS-compatible environment that operates independently of AWS environments.
@@ -85,6 +102,24 @@ docker pull ghcr.io/nandemo-ya/kecs:latest
 ```
 
 ## Usage
+
+### Required Permissions
+
+KECS requires the following permissions to function properly:
+
+- **Docker Socket Access**: When running in a container, mount `/var/run/docker.sock`
+- **Network Ports**: Default ports 8080 (API) and 8081 (Admin)
+- **Local Storage**: For data persistence (default: `~/.kecs/data`)
+
+```bash
+# Container mode requires Docker socket mounting
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+           -p 8080:8080 -p 8081:8081 \
+           ghcr.io/nandemo-ya/kecs:latest
+
+# Binary mode requires Docker to be installed and accessible
+kecs server
+```
 
 ### Container Commands
 
@@ -340,6 +375,26 @@ KECS provides ECS-compatible API endpoints:
 - Architectural Decision Records (ADRs) are stored in the `docs/adr/records` directory
 - API documentation is available in the `docs/api` directory
 - For more detailed documentation, visit our [documentation site](https://nandemo-ya.github.io/kecs/)
+
+## Security Considerations
+
+KECS is a development tool that requires elevated permissions:
+
+1. **Docker Daemon Access**: KECS needs access to the Docker daemon to create and manage k3d clusters. This is equivalent to root access on Linux systems.
+
+2. **Network Access**: KECS creates virtual networks and exposes ports for service communication.
+
+3. **Not for Production**: KECS is explicitly NOT designed for production use. It lacks the security features required for multi-tenant or public-facing deployments.
+
+### Comparison with Similar Tools
+
+| Tool | Purpose | Required Permissions |
+|------|---------|---------------------|
+| Docker Desktop | Container runtime | Root/Admin privileges |
+| kind | Local Kubernetes | Docker socket access |
+| k3d | Local k3s clusters | Docker socket access |
+| LocalStack | AWS service emulation | Network ports |
+| **KECS** | ECS emulation | Docker socket + Network ports |
 
 ## License
 

--- a/docs/adr/records/0015-docker-permissions-and-supported-environments.md
+++ b/docs/adr/records/0015-docker-permissions-and-supported-environments.md
@@ -1,0 +1,90 @@
+# ADR-0015. Docker Permissions and Supported Environments
+
+Date: 2025-06-26
+
+## Status
+
+Accepted
+
+## Context
+
+KECS requires the ability to create and manage local Kubernetes clusters (k3d/kind) to provide full Amazon ECS compatibility. This functionality requires access to the Docker daemon, which has significant security implications.
+
+We needed to decide:
+1. Whether to support Docker access in all distribution methods
+2. How to handle the security implications
+3. Which environments to officially support
+
+### Options Considered
+
+1. **Separate images with/without Docker access**
+   - `kecs:latest` without Docker access (distroless)
+   - `kecs:docker` with Docker access
+   - Pros: Clear security boundaries
+   - Cons: Confusing for users, limited functionality in default image
+
+2. **Binary-only distribution**
+   - No container images
+   - Pros: Simpler permissions model
+   - Cons: Loses Testcontainers support, harder CI/CD integration
+
+3. **All images with Docker access + clear disclaimer**
+   - All distribution methods support full functionality
+   - Clear documentation about security implications
+   - Pros: Consistent experience, full functionality
+   - Cons: Requires elevated permissions
+
+## Decision
+
+We will provide Docker daemon access in all distribution methods (binary and container images) with clear disclaimers about the security implications and supported environments.
+
+### Supported Environments
+
+- ✅ Local development machines
+- ✅ CI/CD pipelines (GitHub Actions, GitLab CI, Jenkins, etc.)
+- ✅ Isolated test environments
+- ❌ Production environments
+- ❌ Public-facing deployments
+- ❌ Multi-tenant systems
+
+### Security Model
+
+1. **Explicit Acknowledgment**: Users must acknowledge the security implications on first run
+2. **Clear Documentation**: README and documentation clearly state the permission requirements
+3. **Environment Restrictions**: Explicitly document that KECS is not for production use
+
+### Implementation
+
+All container images will:
+- Include docker-cli for k3d management
+- Run as non-root user in docker group
+- Include entrypoint script to handle Docker socket permissions
+- Show disclaimer on first run
+
+## Consequences
+
+### Positive
+
+- **Consistent Experience**: All users get full functionality regardless of installation method
+- **Testcontainers Support**: Container images work seamlessly with Testcontainers
+- **Simple Mental Model**: One product, one set of features
+- **Development Focus**: Optimized for the primary use case (local development)
+
+### Negative
+
+- **Security Concerns**: Requires elevated permissions (Docker socket access)
+- **Limited Use Cases**: Cannot be safely used in production or multi-tenant environments
+- **Trust Requirement**: Users must trust KECS with Docker daemon access
+
+### Mitigation
+
+- Clear and prominent disclaimers in documentation
+- First-run acknowledgment requirement
+- Option to disable k3d features (though Docker access still required)
+- Comparison with similar tools (Docker Desktop, kind, etc.) to set expectations
+
+## References
+
+- [Docker Socket Security](https://docs.docker.com/engine/security/#docker-daemon-attack-surface)
+- [Kind Security Model](https://kind.sigs.k8s.io/docs/user/security/)
+- [Testcontainers Requirements](https://www.testcontainers.org/)


### PR DESCRIPTION
## Summary

This PR adds clear documentation about KECS's security requirements and supported environments.

## Changes

1. **ADR-0015: Docker Permissions and Supported Environments**
   - Documents the decision to require Docker socket access for all distribution methods
   - Clarifies supported environments (local dev, CI) vs unsupported (production)
   - Explains security implications and mitigation strategies

2. **README.md Updates**
   - Added prominent disclaimer at the top about supported/unsupported environments
   - Added "Required Permissions" section explaining Docker socket and port requirements
   - Added "Security Considerations" section with comparison to similar tools

## Why This Matters

KECS requires Docker daemon access to create and manage k3d clusters for full ECS compatibility. This level of access is equivalent to root privileges, so it's crucial that users understand:

- The security implications
- Appropriate use cases (development only)
- That this is by design, not a security flaw

## Related Discussion

Based on our discussion about whether to provide separate images with/without Docker access, we decided to:
- Support Docker access in all images for consistency
- Clearly document the security implications
- Explicitly state that KECS is for development use only

This approach aligns with similar tools like Docker Desktop, kind, and k3d.