### PR TITLE
fix: Add server command to container config in kecs start

### DIFF
--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -213,6 +213,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	containerConfig := &runtime.ContainerConfig{
 		Name:  startContainerName,
 		Image: imageName,
+		Cmd:   []string{"server"}, // Run the server command
 		Env:   env,
 		Labels: map[string]string{
 			"com.kecs.managed": "true",


### PR DESCRIPTION
## Summary
Fix `kecs start` command to properly launch KECS server in container

## Problem
When running `kecs start`, the created container was restarting continuously because no command was specified in the ContainerConfig. The entrypoint.sh script was being executed without any arguments, causing the container to exit immediately.

## Solution
Added `Cmd: []string{"server"}` to the ContainerConfig to ensure the KECS server command is executed when the container starts.

## Test Results
```bash
$ kecs start
Using container runtime: docker
Pulling image ghcr.io/nandemo-ya/kecs:latest...
Creating KECS server container...
Starting KECS server...
KECS server 'kecs-server' started successfully
API endpoint: http://localhost:8080
Admin endpoint: http://localhost:8081
Data directory: /Users/stormcat/.kecs/data
Waiting for server to be ready... ready\!

$ docker ps | grep kecs-server
a203da521502   ghcr.io/nandemo-ya/kecs:latest   "/entrypoint.sh serv…"   6 seconds ago   Up 6 seconds   0.0.0.0:8080-8081->8080-8081/tcp   kecs-server

$ curl http://localhost:8081/health
{"status":"ok"}
```

## Test plan
[x] Run `kecs start` and verify container starts successfully
[x] Verify port forwarding works (8080 and 8081)
[x] Verify health endpoint responds
[x] Verify container stays running (no restart loop)

🤖 Generated with [Claude Code](https://claude.ai/code)