### PR TITLE
fix: Add kubeconfig path environment variable to kecs start

### DIFF
--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -187,6 +187,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 		fmt.Sprintf("KECS_DATA_DIR=%s", "/data"),
 		"KECS_LOG_LEVEL=info",
 		"KECS_SECURITY_ACKNOWLEDGED=true",  // Skip security disclaimer in container
+		"KECS_KUBECONFIG_PATH=/data/kubeconfig", // Store kubeconfig in data directory
+		"KECS_TEST_MODE=false", // Disable test mode for normal operation
 	}
 
 	// Add config file if specified


### PR DESCRIPTION
## Summary
Fix kubeconfig directory permission error in `kecs start` container

## Problem
When running `kecs start`, the KECS server container was trying to create kubeconfig files in `/kecs/kubeconfig/` directory, which doesn't exist and can't be created due to permission issues:
```
Failed to create client for cluster kecs-test-cluster: failed to create kubeconfig directory: mkdir /kecs: permission denied
```

## Solution
- Added `KECS_KUBECONFIG_PATH=/data/kubeconfig` environment variable to store kubeconfig files in the mounted data directory
- Added `KECS_TEST_MODE=false` to ensure normal operation mode
- The `/data` directory is already mounted and has proper permissions for the kecs user

## Test plan
[x] Run `kecs start` and verify no permission errors
[x] Create a cluster and verify k3d cluster is created successfully
[x] Verify kubeconfig files are stored in the data directory

🤖 Generated with [Claude Code](https://claude.ai/code)