### PR TITLE
fix: Enable automatic k3d cluster recovery on startup (fixes #279)

### DIFF
--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -94,7 +94,7 @@ func InitConfig() error {
 	// Features defaults
 	v.SetDefault("features.testMode", false)
 	v.SetDefault("features.containerMode", false)
-	v.SetDefault("features.autoRecoverState", false)
+	v.SetDefault("features.autoRecoverState", true)
 	v.SetDefault("features.securityAcknowledged", false)
 	v.SetDefault("features.skipSecurityDisclaimer", false)
 	

--- a/controlplane/internal/config/config_recovery_test.go
+++ b/controlplane/internal/config/config_recovery_test.go
@@ -1,0 +1,47 @@
+package config_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
+)
+
+var _ = Describe("Config Recovery Defaults", func() {
+	BeforeEach(func() {
+		// Reset config before each test
+		config.ResetConfig()
+	})
+
+	Context("when getting default configuration", func() {
+		It("should have autoRecoverState enabled by default", func() {
+			// Initialize config without any environment variables
+			err := config.InitConfig()
+			Expect(err).To(BeNil())
+
+			// Get the default configuration
+			cfg := config.DefaultConfig()
+			Expect(cfg).NotTo(BeNil())
+
+			// Verify autoRecoverState is true by default
+			Expect(cfg.Features.AutoRecoverState).To(BeTrue(),
+				"autoRecoverState should be enabled by default to ensure k3d clusters are recreated after KECS restart")
+		})
+
+		It("should respect KECS_AUTO_RECOVER_STATE environment variable", func() {
+			// Test with false value
+			os.Setenv("KECS_AUTO_RECOVER_STATE", "false")
+			defer os.Unsetenv("KECS_AUTO_RECOVER_STATE")
+
+			// Re-initialize config to pick up env var
+			config.ResetConfig()
+			config.InitConfig()
+
+			cfg := config.DefaultConfig()
+			Expect(cfg.Features.AutoRecoverState).To(BeFalse(),
+				"autoRecoverState should be false when KECS_AUTO_RECOVER_STATE=false")
+		})
+	})
+})

--- a/controlplane/kecs.yaml.example
+++ b/controlplane/kecs.yaml.example
@@ -62,9 +62,9 @@ features:
   # Can be set via KECS_CONTAINER_MODE environment variable
   containerMode: false
   
-  # Enable automatic state recovery on startup (default: false)
+  # Enable automatic state recovery on startup (default: true)
   # Can be set via KECS_AUTO_RECOVER_STATE environment variable
-  autoRecoverState: false
+  autoRecoverState: true
 
 # AWS configuration
 aws:

--- a/tests/scenarios/phase1/cluster_persistence_test.go
+++ b/tests/scenarios/phase1/cluster_persistence_test.go
@@ -1,0 +1,163 @@
+// cluster_persistence_test.go
+// This test verifies that KECS properly recovers k3d clusters after restart.
+
+package phase1
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nandemo-ya/kecs/tests/scenarios/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClusterPersistenceAfterRestart verifies that ECS clusters and their
+// corresponding k3d clusters are properly recovered after KECS restart
+func TestClusterPersistenceAfterRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster persistence test in short mode")
+	}
+
+	// Ensure we're not in test mode
+	os.Unsetenv("KECS_TEST_MODE")
+
+	// Start KECS container with persistent data directory
+	kecs := utils.StartKECSWithPersistence(t)
+	defer kecs.Cleanup()
+
+	// Create ECS client
+	client := utils.NewECSClientInterface(kecs.Endpoint())
+
+	// Test data
+	clusterName := "persistence-test-cluster"
+
+	// Step 1: Create a cluster
+	t.Log("Creating ECS cluster...")
+	err := client.CreateCluster(clusterName)
+	require.NoError(t, err, "Failed to create cluster")
+
+	// Wait for cluster to be active
+	utils.AssertClusterActive(t, client, clusterName)
+
+	// Verify k3d cluster exists
+	k3dName := "kecs-" + clusterName
+	k3dExists, err := utils.K3dClusterExists(k3dName)
+	require.NoError(t, err, "Failed to check k3d cluster")
+	assert.True(t, k3dExists, "k3d cluster should exist after creation")
+
+	// Step 2: Stop KECS
+	t.Log("Stopping KECS...")
+	err = kecs.Stop()
+	require.NoError(t, err, "Failed to stop KECS container")
+
+	// Wait a bit for container to fully stop
+	time.Sleep(2 * time.Second)
+
+	// Step 3: Start KECS again with the same data directory
+	t.Log("Restarting KECS...")
+	kecs2 := utils.RestartKECSWithPersistence(t, kecs.DataDir)
+	defer kecs2.Cleanup()
+
+	// Create new client with new endpoint
+	client2 := utils.NewECSClientInterface(kecs2.Endpoint())
+
+	// Step 4: Verify cluster is recovered
+	t.Log("Verifying cluster recovery...")
+	clusters, err := client2.ListClusters()
+	require.NoError(t, err, "Failed to list clusters after restart")
+	assert.Contains(t, clusters, clusterName, "Cluster should be recovered from storage")
+
+	// Step 5: Verify k3d cluster is recreated
+	t.Log("Verifying k3d cluster recreation...")
+	// Give some time for the recovery process to complete
+	time.Sleep(10 * time.Second)
+
+	k3dExists, err = utils.K3dClusterExists(k3dName)
+	require.NoError(t, err, "Failed to check k3d cluster after restart")
+	assert.True(t, k3dExists, "k3d cluster should be recreated after KECS restart")
+
+	// Step 6: Verify cluster is functional
+	t.Log("Verifying cluster functionality...")
+	cluster, err := client2.DescribeCluster(clusterName)
+	require.NoError(t, err, "Failed to describe cluster after restart")
+	assert.Equal(t, "ACTIVE", cluster.Status, "Cluster should be active after restart")
+
+	// Clean up
+	err = client2.DeleteCluster(clusterName)
+	assert.NoError(t, err, "Failed to delete cluster during cleanup")
+}
+
+// TestMultipleClusterPersistence tests recovery of multiple clusters
+func TestMultipleClusterPersistence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping multiple cluster persistence test in short mode")
+	}
+
+	// Ensure we're not in test mode
+	os.Unsetenv("KECS_TEST_MODE")
+
+	// Start KECS
+	kecs := utils.StartKECSWithPersistence(t)
+	defer kecs.Cleanup()
+
+	client := utils.NewECSClientInterface(kecs.Endpoint())
+
+	// Create multiple clusters
+	clusterNames := []string{
+		"persistence-cluster-1",
+		"persistence-cluster-2",
+		"persistence-cluster-3",
+	}
+
+	t.Log("Creating multiple clusters...")
+	for _, name := range clusterNames {
+		err := client.CreateCluster(name)
+		require.NoError(t, err, "Failed to create cluster %s", name)
+		utils.AssertClusterActive(t, client, name)
+	}
+
+	// Verify all k3d clusters exist
+	for _, name := range clusterNames {
+		k3dName := "kecs-" + name
+		exists, err := utils.K3dClusterExists(k3dName)
+		require.NoError(t, err)
+		assert.True(t, exists, "k3d cluster %s should exist", k3dName)
+	}
+
+	// Restart KECS
+	t.Log("Restarting KECS...")
+	err := kecs.Stop()
+	require.NoError(t, err)
+	time.Sleep(2 * time.Second)
+
+	kecs2 := utils.RestartKECSWithPersistence(t, kecs.DataDir)
+	defer kecs2.Cleanup()
+
+	client2 := utils.NewECSClientInterface(kecs2.Endpoint())
+
+	// Wait for recovery
+	time.Sleep(15 * time.Second)
+
+	// Verify all clusters are recovered
+	t.Log("Verifying all clusters are recovered...")
+	clusters, err := client2.ListClusters()
+	require.NoError(t, err)
+
+	for _, name := range clusterNames {
+		assert.Contains(t, clusters, name, "Cluster %s should be recovered", name)
+
+		// Verify k3d cluster is recreated
+		k3dName := "kecs-" + name
+		exists, err := utils.K3dClusterExists(k3dName)
+		require.NoError(t, err)
+		assert.True(t, exists, "k3d cluster %s should be recreated", k3dName)
+	}
+
+	// Clean up
+	for _, name := range clusterNames {
+		err := client2.DeleteCluster(name)
+		assert.NoError(t, err, "Failed to delete cluster %s", name)
+	}
+}

--- a/tests/scenarios/utils/k3d.go
+++ b/tests/scenarios/utils/k3d.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// K3dClusterExists checks if a k3d cluster exists
+func K3dClusterExists(clusterName string) (bool, error) {
+	cmd := exec.Command("k3d", "cluster", "list", "-o", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to list k3d clusters: %w", err)
+	}
+
+	// Simple check for cluster name in output
+	return strings.Contains(string(output), fmt.Sprintf(`"name":"%s"`, clusterName)), nil
+}
+
+// DeleteK3dCluster deletes a k3d cluster if it exists
+func DeleteK3dCluster(clusterName string) error {
+	exists, err := K3dClusterExists(clusterName)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		cmd := exec.Command("k3d", "cluster", "delete", clusterName)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to delete k3d cluster %s: %w", clusterName, err)
+		}
+	}
+
+	return nil
+}
+
+// GetK3dClusters returns a list of k3d cluster names
+func GetK3dClusters() ([]string, error) {
+	cmd := exec.Command("k3d", "cluster", "list", "-o", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list k3d clusters: %w", err)
+	}
+
+	// Parse JSON output to extract cluster names
+	// For simplicity, use a basic approach
+	clusters := []string{}
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, `"name":"`) {
+			// Extract cluster name
+			start := strings.Index(line, `"name":"`) + 8
+			end := strings.Index(line[start:], `"`)
+			if end > 0 {
+				clusterName := line[start : start+end]
+				clusters = append(clusters, clusterName)
+			}
+		}
+	}
+
+	return clusters, nil
+}


### PR DESCRIPTION
## Summary
This PR fixes issue #279 by enabling automatic k3d cluster recovery on KECS startup by default.

## Problem
When KECS is restarted, ECS resources (clusters, services, task definitions) are properly restored from the DuckDB database, but the underlying k3d clusters are not automatically recreated. This leads to a situation where ECS resources exist in KECS but have no backing Kubernetes infrastructure.

## Solution
The existing `RecoverState()` method already handles cluster recreation perfectly - it just wasn't being called by default. This PR simply changes the default value of `features.autoRecoverState` from `false` to `true`.

## Changes
- 🔧 Set `features.autoRecoverState` default to `true` in config
- ✅ Add comprehensive tests for cluster persistence after restart
- 🧪 Add utility functions for persistence testing with testcontainers
- 🛠️ Add k3d cluster management utilities
- 📝 Update example configuration to reflect new default

## Testing
1. **Unit tests**: Added config tests to verify the default value and environment variable override
2. **Scenario tests**: Added comprehensive persistence tests that:
   - Create clusters
   - Stop KECS
   - Restart KECS with same data directory
   - Verify clusters are recreated

## Backwards Compatibility
Users can still disable automatic recovery by setting `KECS_AUTO_RECOVER_STATE=false` if they prefer manual cluster management.

## Test Plan
- [x] Unit tests pass
- [x] Scenario tests added
- [ ] Manual testing:
  1. Start KECS
  2. Create a cluster
  3. Stop KECS
  4. Start KECS again
  5. Verify k3d cluster is recreated

Fixes #279

🤖 Generated with [Claude Code](https://claude.ai/code)