### PR TITLE
chore: Update Docker Compose files to modern format

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # KECS Control Plane Service
   kecs:

--- a/examples/docker-compose/compose.yaml
+++ b/examples/docker-compose/compose.yaml
@@ -1,5 +1,4 @@
 # Example Docker Compose configuration for KECS
-version: '3.8'
 
 services:
   # Single KECS instance


### PR DESCRIPTION
## Summary
- Rename `docker-compose.yml` to `compose.yaml` (Docker's recommended filename)
- Remove deprecated `version` attribute from compose files
- Apply changes to both root and examples directory

## Test plan
- [ ] Verify `docker compose up` works with the renamed files
- [ ] Confirm no functional changes to the compose configuration

🤖 Generated with [Claude Code](https://claude.ai/code)