### PR TITLE
feat: Implement automatic LocalStack deployment on cluster creation

### DIFF
--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -133,6 +133,7 @@ func bindLegacyEnvVars() {
 	v.BindEnv("aws.proxyImage", "KECS_AWS_PROXY_IMAGE")
 	v.BindEnv("features.securityAcknowledged", "KECS_SECURITY_ACKNOWLEDGED")
 	v.BindEnv("features.skipSecurityDisclaimer", "KECS_SKIP_SECURITY_DISCLAIMER")
+	v.BindEnv("localstack.enabled", "KECS_LOCALSTACK_ENABLED")
 }
 
 // DefaultConfig returns the default configuration

--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/secretsmanager"
 	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/ssm"
 	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
+	"github.com/nandemo-ya/kecs/controlplane/internal/localstack"
 	"github.com/nandemo-ya/kecs/controlplane/internal/servicediscovery"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
 )
@@ -24,6 +25,7 @@ type DefaultECSAPI struct {
 	secretsManagerIntegration secretsmanager.Integration
 	s3Integration             s3.Integration
 	serviceDiscoveryManager   servicediscovery.Manager
+	localStackManager         localstack.Manager
 }
 
 // NewDefaultECSAPI creates a new default ECS API implementation with storage
@@ -64,6 +66,11 @@ func (api *DefaultECSAPI) SetS3Integration(s3Integration s3.Integration) {
 // SetServiceDiscoveryManager sets the service discovery manager for the ECS API
 func (api *DefaultECSAPI) SetServiceDiscoveryManager(serviceDiscoveryManager servicediscovery.Manager) {
 	api.serviceDiscoveryManager = serviceDiscoveryManager
+}
+
+// SetLocalStackManager sets the LocalStack manager for the ECS API
+func (api *DefaultECSAPI) SetLocalStackManager(localStackManager localstack.Manager) {
+	api.localStackManager = localStackManager
 }
 
 // NewDefaultECSAPIWithConfig creates a new default ECS API implementation with custom region and accountID

--- a/controlplane/internal/controlplane/api/server.go
+++ b/controlplane/internal/controlplane/api/server.go
@@ -286,6 +286,9 @@ func NewServer(port int, kubeconfig string, storage storage.Storage, localStackC
 		if s.s3Integration != nil {
 			defaultAPI.SetS3Integration(s.s3Integration)
 		}
+		if s.localStackManager != nil {
+			defaultAPI.SetLocalStackManager(s.localStackManager)
+		}
 
 		// Initialize Service Discovery if we have kubernetes client
 		if localStackConfig != nil && localStackConfig.Enabled {


### PR DESCRIPTION
## Summary
- Automatically deploy LocalStack when creating a new ECS cluster if `KECS_LOCALSTACK_ENABLED=true`
- Each k3d cluster gets its own LocalStack instance for AWS service emulation
- LocalStack pods persist when KECS is restarted with `KECS_KEEP_CLUSTERS_ON_SHUTDOWN=true`

## Changes
- Add LocalStack manager to DefaultECSAPI
- Implement `deployLocalStackIfEnabled` method that deploys LocalStack after cluster creation
- Add environment variable binding for `KECS_LOCALSTACK_ENABLED`
- Use cluster-specific Kubernetes client for LocalStack deployment

## Testing
1. Start KECS with LocalStack enabled:
   ```bash
   KECS_SECURITY_ACKNOWLEDGED=true KECS_LOCALSTACK_ENABLED=true ./bin/kecs server
   ```

2. Create a new cluster:
   ```bash
   aws --endpoint-url http://localhost:8080 ecs create-cluster --cluster-name test-cluster
   ```

3. Verify LocalStack is running:
   ```bash
   docker exec k3d-kecs-test-cluster-server-0 kubectl get pods -n aws-services
   ```

## Known Issues
- LocalStack deployment state is not tracked in storage, so KECS doesn't remember which clusters have LocalStack deployed after restart
- Health check fails with DNS resolution errors when checking from outside the cluster, but LocalStack works correctly within the cluster

These issues will be addressed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.ai/code)