### PR TITLE
fix: Complete container mode support for LocalStack and AWS proxy

### DIFF
--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -27,6 +27,7 @@ type DefaultECSAPI struct {
 	serviceDiscoveryManager   servicediscovery.Manager
 	localStackManager         localstack.Manager
 	localStackConfig          *localstack.Config
+	localStackUpdateCallback  func(localstack.Manager) // Callback when LocalStack manager is updated
 }
 
 // NewDefaultECSAPI creates a new default ECS API implementation with storage
@@ -77,6 +78,11 @@ func (api *DefaultECSAPI) SetLocalStackManager(localStackManager localstack.Mana
 // SetLocalStackConfig sets the LocalStack configuration for the ECS API
 func (api *DefaultECSAPI) SetLocalStackConfig(config *localstack.Config) {
 	api.localStackConfig = config
+}
+
+// SetLocalStackUpdateCallback sets the callback function to be called when LocalStack manager is updated
+func (api *DefaultECSAPI) SetLocalStackUpdateCallback(callback func(localstack.Manager)) {
+	api.localStackUpdateCallback = callback
 }
 
 // NewDefaultECSAPIWithConfig creates a new default ECS API implementation with custom region and accountID

--- a/controlplane/internal/controlplane/api/middleware.go
+++ b/controlplane/internal/controlplane/api/middleware.go
@@ -75,7 +75,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 }
 
 // LocalStackProxyMiddleware intercepts AWS API calls and routes them to LocalStack
-func LocalStackProxyMiddleware(next http.Handler, awsProxyRouter *AWSProxyRouter) http.Handler {
+func LocalStackProxyMiddleware(next http.Handler, server *Server) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Debug log
 		target := r.Header.Get("X-Amz-Target")
@@ -84,11 +84,11 @@ func LocalStackProxyMiddleware(next http.Handler, awsProxyRouter *AWSProxyRouter
 				r.Method, r.URL.Path, target, r.Header.Get("Authorization") != "")
 		}
 		
-		// Check if this request should be proxied to LocalStack
-		if awsProxyRouter != nil && awsProxyRouter.LocalStackManager != nil && 
-		   ShouldProxyToLocalStack(r, awsProxyRouter.LocalStackManager) {
+		// Dynamically check if awsProxyRouter is available
+		if server.awsProxyRouter != nil && server.awsProxyRouter.LocalStackManager != nil && 
+		   ShouldProxyToLocalStack(r, server.awsProxyRouter.LocalStackManager) {
 			log.Printf("[LocalStackProxyMiddleware] Proxying to LocalStack: %s %s", r.Method, r.URL.Path)
-			awsProxyRouter.AWSProxyHandler.ServeHTTP(w, r)
+			server.awsProxyRouter.AWSProxyHandler.ServeHTTP(w, r)
 			return
 		}
 

--- a/docs/issues/container-mode-kubeconfig-github.md
+++ b/docs/issues/container-mode-kubeconfig-github.md
@@ -1,0 +1,51 @@
+# Container Mode: kubeconfig not accessible from host machine
+
+## Description
+
+When running KECS in container mode (`kecs start`), the generated kubeconfig files use internal container hostnames that are not resolvable from the host machine, preventing direct kubectl access from the host.
+
+## Steps to Reproduce
+
+1. Start KECS in container mode:
+   ```bash
+   kecs start
+   ```
+
+2. Create a cluster:
+   ```bash
+   aws --endpoint-url http://localhost:8080 ecs create-cluster --cluster-name test-cluster
+   ```
+
+3. Try to access the cluster from the host:
+   ```bash
+   docker exec kecs-server cat /data/kubeconfig/kecs-test-cluster.config > ~/.kube/config
+   kubectl get nodes
+   ```
+
+## Actual Result
+
+```
+Error from server (BadRequest): dial tcp: lookup k3d-kecs-test-cluster-server-0: no such host
+```
+
+## Expected Result
+
+kubectl commands should work from the host machine when using the exported kubeconfig.
+
+## Environment
+
+- KECS Version: latest
+- OS: macOS/Linux
+- Container Runtime: Docker
+
+## Proposed Solution
+
+Generate host-compatible kubeconfig files that use `localhost:<mapped-port>` instead of internal container hostnames when KECS runs in container mode.
+
+## Workaround
+
+Manually edit the kubeconfig file to replace the k3d container hostname with `localhost` and the appropriate port (usually found in k3d cluster list).
+
+## Additional Context
+
+This is particularly important for developer workflows where users want to interact with the k3d clusters created by KECS directly from their host machine for debugging or development purposes.

--- a/docs/issues/container-mode-kubeconfig.md
+++ b/docs/issues/container-mode-kubeconfig.md
@@ -1,0 +1,53 @@
+# Issue: Container Mode kubeconfig Host Access
+
+## Problem Description
+
+When KECS runs in container mode, the kubeconfig files generated for k3d clusters use the container's internal hostname (e.g., `k3d-kecs-test-cluster2-server-0`) as the API server endpoint. This hostname is not resolvable from the host machine, making it impossible to use kubectl directly from the host.
+
+## Current Behavior
+
+```yaml
+# Current kubeconfig in container mode
+server: https://k3d-kecs-test-cluster2-server-0:6443
+```
+
+This results in errors when trying to use kubectl from the host:
+```
+dial tcp: lookup k3d-kecs-test-cluster2-server-0: no such host
+```
+
+## Expected Behavior
+
+When KECS is running in container mode, it should generate kubeconfig files that work from both inside the container and from the host machine. The kubeconfig should use `localhost` with the appropriate mapped port.
+
+```yaml
+# Expected kubeconfig for host access
+server: https://localhost:<mapped-port>
+```
+
+## Workaround
+
+Currently, users need to manually edit the kubeconfig file to replace the k3d container hostname with localhost and the correct port.
+
+## Proposed Solution
+
+1. Detect when KECS is running in container mode
+2. When generating/updating kubeconfig files, create two versions:
+   - Internal version: Uses k3d container hostnames (for KECS container use)
+   - External version: Uses localhost with mapped ports (for host machine use)
+3. Provide a command or API to retrieve the host-compatible kubeconfig
+
+## Implementation Notes
+
+- The k3d cluster manager already knows about port mappings
+- Need to track which ports are mapped to which k3d API server ports
+- Consider adding a new endpoint or command: `kecs get-kubeconfig --cluster <name> --host-access`
+
+## Related Code
+
+- `/controlplane/internal/kubernetes/k3d_cluster_manager.go` - Handles kubeconfig generation
+- `/controlplane/internal/controlplane/cmd/start.go` - Container mode configuration
+
+## Priority
+
+Medium - This affects developer experience but has a manual workaround.


### PR DESCRIPTION
## Summary

This PR completes the container mode implementation for LocalStack integration, enabling non-ECS AWS API requests (like SecretsManager) to be properly proxied to LocalStack in both binary and container modes.

## Key Changes

### 1. Container Networking
- Create dedicated KECS network for k3d clusters to join
- Fix container-to-container communication between KECS and k3d
- Add insecure TLS support for container mode

### 2. LocalStack Configuration
- Pass all LocalStack environment variables to container (`KECS_LOCALSTACK_SERVICES`, `KECS_LOCALSTACK_USE_TRAEFIK`)
- Fix health check endpoints to use Traefik proxy in container mode
- Add lazy loading (`EAGER_SERVICE_LOADING=0`) for faster startup
- Handle DNS resolution failures gracefully

### 3. AWS Proxy Router
- Fix middleware to dynamically check `awsProxyRouter` availability
- Add callback mechanism to reinitialize proxy when LocalStack is deployed
- Remove unused `isAWSAPICall` and `isECSAPICall` functions
- Update proxy handler to get endpoint from LocalStack manager

### 4. Kubeconfig Management
- Fix symlink handling for k3d kubeconfig files
- Document issue with host access to kubeconfig in container mode

## Test Results

Successfully tested SecretsManager operations in container mode:
```bash
# Start KECS in container mode with LocalStack
export KECS_LOCALSTACK_ENABLED=true
export KECS_LOCALSTACK_SERVICES=secretsmanager
export KECS_LOCALSTACK_USE_TRAEFIK=true
kecs start --local-build

# Create cluster
aws --endpoint-url http://localhost:8080 ecs create-cluster --cluster-name test-cluster

# Create and retrieve secret via KECS → LocalStack
aws --endpoint-url http://localhost:8080 secretsmanager create-secret --name my-secret --secret-string "test-value"
aws --endpoint-url http://localhost:8080 secretsmanager get-secret-value --secret-id my-secret
```

Both operations succeed, with logs showing proper proxy routing:
```
[LocalStackProxyMiddleware] Request: Method=POST, Path=/, X-Amz-Target=secretsmanager.CreateSecret, Auth=true
[LocalStackProxyMiddleware] Proxying to LocalStack: POST /
```

## Related Issues

Fixes #313 (Duplicate configuration files)
Fixes #315 (LocalStack health check failures)

## New Issue Documented

- Container mode kubeconfig not accessible from host machine (see `docs/issues/container-mode-kubeconfig.md`)

🤖 Generated with [Claude Code](https://claude.ai/code)