### PR TITLE
fix: Enforce strict config file existence check

### DIFF
--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -195,12 +195,17 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 	
 	if configPath != "" {
+		// Check if the config file exists before trying to read it
+		if _, err := os.Stat(configPath); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("config file does not exist: %s", configPath)
+			}
+			return nil, fmt.Errorf("failed to access config file: %w", err)
+		}
+		
 		v.SetConfigFile(configPath)
 		if err := v.ReadInConfig(); err != nil {
-			if !os.IsNotExist(err) {
-				return nil, fmt.Errorf("failed to read config file: %w", err)
-			}
-			// Config file doesn't exist, continue with defaults and env vars
+			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}
 	} else {
 		// Look for config file in standard locations


### PR DESCRIPTION
## Summary
- Add explicit validation that config files exist when specified via `--config` flag
- Return clear error messages when config files are not found or inaccessible
- Prevent silent fallback to defaults which could confuse users

## Problem
Previously, when users specified a non-existent config file with `--config`, KECS would silently fall back to default values. This could lead to confusion when users made typos in file paths or expected their config to be loaded.

## Solution
- Added explicit `os.Stat()` check before attempting to read config file
- Return descriptive error: `config file does not exist: <path>`
- Also handle permission denied errors appropriately

## Test plan
- [x] Updated unit tests to verify new behavior
- [x] Tested manually with non-existent config file
- [x] Tested manually with valid config file
- [x] All existing tests pass

### Manual test results:
```bash
# Non-existent file now shows clear error
$ ./bin/kecs server --config /tmp/nonexistent.yaml
2025/07/14 13:22:47 Failed to load configuration: config file does not exist: /tmp/nonexistent.yaml

# Valid config file works as expected
$ ./bin/kecs server --config /tmp/test-kecs.yaml
Starting KECS Control Plane server on port 9999 with log level debug
```

🤖 Generated with [Claude Code](https://claude.ai/code)