### PR TITLE
feat: Implement ModifyListener and ModifyTargetGroup with generic pointer utilities

### DIFF
--- a/controlplane/internal/utils/pointer.go
+++ b/controlplane/internal/utils/pointer.go
@@ -1,0 +1,43 @@
+package utils
+
+// Ptr returns a pointer to the given value.
+// This is a generic function that works with any type.
+//
+// Example:
+//   strPtr := utils.Ptr("hello")
+//   intPtr := utils.Ptr(42)
+//   boolPtr := utils.Ptr(true)
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// Deref safely dereferences a pointer, returning the value or the zero value if the pointer is nil.
+//
+// Example:
+//   var strPtr *string = nil
+//   str := utils.Deref(strPtr) // returns ""
+//   
+//   strPtr = utils.Ptr("hello")
+//   str = utils.Deref(strPtr) // returns "hello"
+func Deref[T any](ptr *T) T {
+	if ptr == nil {
+		var zero T
+		return zero
+	}
+	return *ptr
+}
+
+// DerefOrDefault safely dereferences a pointer, returning the value or a default value if the pointer is nil.
+//
+// Example:
+//   var strPtr *string = nil
+//   str := utils.DerefOrDefault(strPtr, "default") // returns "default"
+//   
+//   strPtr = utils.Ptr("hello")
+//   str = utils.DerefOrDefault(strPtr, "default") // returns "hello"
+func DerefOrDefault[T any](ptr *T, defaultValue T) T {
+	if ptr == nil {
+		return defaultValue
+	}
+	return *ptr
+}

--- a/controlplane/internal/utils/pointer_test.go
+++ b/controlplane/internal/utils/pointer_test.go
@@ -1,0 +1,99 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/utils"
+)
+
+var _ = Describe("Pointer Utils", func() {
+	Describe("Ptr", func() {
+		It("should return a pointer to string", func() {
+			str := "hello"
+			ptr := utils.Ptr(str)
+			Expect(ptr).NotTo(BeNil())
+			Expect(*ptr).To(Equal("hello"))
+		})
+
+		It("should return a pointer to int", func() {
+			num := 42
+			ptr := utils.Ptr(num)
+			Expect(ptr).NotTo(BeNil())
+			Expect(*ptr).To(Equal(42))
+		})
+
+		It("should return a pointer to bool", func() {
+			b := true
+			ptr := utils.Ptr(b)
+			Expect(ptr).NotTo(BeNil())
+			Expect(*ptr).To(BeTrue())
+		})
+
+		It("should return a pointer to struct", func() {
+			type TestStruct struct {
+				Name  string
+				Value int
+			}
+			s := TestStruct{Name: "test", Value: 100}
+			ptr := utils.Ptr(s)
+			Expect(ptr).NotTo(BeNil())
+			Expect(ptr.Name).To(Equal("test"))
+			Expect(ptr.Value).To(Equal(100))
+		})
+	})
+
+	Describe("Deref", func() {
+		It("should dereference a string pointer", func() {
+			str := "hello"
+			ptr := &str
+			result := utils.Deref(ptr)
+			Expect(result).To(Equal("hello"))
+		})
+
+		It("should return empty string for nil string pointer", func() {
+			var ptr *string
+			result := utils.Deref(ptr)
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return 0 for nil int pointer", func() {
+			var ptr *int
+			result := utils.Deref(ptr)
+			Expect(result).To(Equal(0))
+		})
+
+		It("should return false for nil bool pointer", func() {
+			var ptr *bool
+			result := utils.Deref(ptr)
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Describe("DerefOrDefault", func() {
+		It("should dereference a string pointer", func() {
+			str := "hello"
+			ptr := &str
+			result := utils.DerefOrDefault(ptr, "default")
+			Expect(result).To(Equal("hello"))
+		})
+
+		It("should return default for nil string pointer", func() {
+			var ptr *string
+			result := utils.DerefOrDefault(ptr, "default")
+			Expect(result).To(Equal("default"))
+		})
+
+		It("should return default for nil int pointer", func() {
+			var ptr *int
+			result := utils.DerefOrDefault(ptr, 99)
+			Expect(result).To(Equal(99))
+		})
+
+		It("should return default for nil bool pointer", func() {
+			var ptr *bool
+			result := utils.DerefOrDefault(ptr, true)
+			Expect(result).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Implement ModifyListener operation to update listener properties
- Implement ModifyTargetGroup operation to update health check settings  
- Add generic pointer utility functions using Go generics

## Changes

### ELBv2 API Operations
- **ModifyListener**: Update listener port, protocol, and default actions
  - Validates listener existence
  - Updates storage layer
  - Syncs with Kubernetes integration
  
- **ModifyTargetGroup**: Update target group health check configuration
  - Supports all health check parameters (path, interval, timeout, thresholds)
  - Handles matcher configuration for HTTP/gRPC codes
  - Updates storage layer

### Generic Pointer Utilities
- Created `utils.Ptr[T any](v T) *T` - Generic function to create pointers
- Created `utils.Deref[T any](ptr *T) T` - Safe dereferencing with zero values
- Created `utils.DerefOrDefault[T any](ptr *T, defaultValue T) T` - Dereferencing with custom defaults
- Replaced all `ptrString` and `ptrInt32` calls with `utils.Ptr` for consistency

### Testing
- Added comprehensive unit tests for ModifyListener
- Added comprehensive unit tests for ModifyTargetGroup  
- Added unit tests for pointer utilities
- All tests passing with good coverage

## Benefits
- Reduced code redundancy using Go generics
- Type-safe pointer operations
- Consistent API implementation patterns
- Better maintainability

## Test plan
- [x] Unit tests for ModifyListener operation
- [x] Unit tests for ModifyTargetGroup operation
- [x] Unit tests for pointer utilities
- [x] Integration with existing ELBv2 tests
- [ ] Manual testing with AWS CLI
- [ ] Integration testing with real Kubernetes cluster

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>