### PR TITLE
feat: Add configuration API endpoint to admin server

### DIFF
--- a/controlplane/internal/controlplane/admin/server.go
+++ b/controlplane/internal/controlplane/admin/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
 )
 
@@ -17,6 +18,7 @@ type Server struct {
 	port             int
 	healthChecker    *HealthChecker
 	metricsCollector *MetricsCollector
+	config           *config.Config
 }
 
 // NewServer creates a new admin server instance
@@ -24,6 +26,7 @@ func NewServer(port int, storage storage.Storage) *Server {
 	s := &Server{
 		port:             port,
 		metricsCollector: NewMetricsCollector(),
+		config:           config.GetConfig(),
 	}
 
 	// Initialize health checker if storage is provided
@@ -74,6 +77,9 @@ func (s *Server) setupRoutes() http.Handler {
 	mux.HandleFunc("/metrics", s.handleMetrics(s.metricsCollector))
 	mux.HandleFunc("/metrics/prometheus", s.handlePrometheusMetrics(s.metricsCollector))
 
+	// Configuration endpoint
+	mux.HandleFunc("/config", s.handleConfig)
+
 	return mux
 }
 
@@ -90,6 +96,110 @@ func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 		Status:    "OK",
 		Timestamp: time.Now(),
 		Version:   getVersion(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// ConfigResponse represents the configuration response
+type ConfigResponse struct {
+	Server     ServerConfigResponse     `json:"server"`
+	LocalStack LocalStackConfigResponse `json:"localstack"`
+	Kubernetes KubernetesConfigResponse `json:"kubernetes"`
+	Features   FeaturesConfigResponse   `json:"features"`
+	AWS        AWSConfigResponse        `json:"aws"`
+}
+
+// ServerConfigResponse represents the server configuration in the response
+type ServerConfigResponse struct {
+	Port           int    `json:"port"`
+	AdminPort      int    `json:"adminPort"`
+	DataDir        string `json:"dataDir"`
+	LogLevel       string `json:"logLevel"`
+	Endpoint       string `json:"endpoint,omitempty"`
+	AllowedOrigins []string `json:"allowedOrigins,omitempty"`
+}
+
+// LocalStackConfigResponse represents the LocalStack configuration in the response
+type LocalStackConfigResponse struct {
+	Enabled    bool   `json:"enabled"`
+	UseTraefik bool   `json:"useTraefik"`
+	Port       int    `json:"port,omitempty"`
+	EdgePort   int    `json:"edgePort,omitempty"`
+}
+
+// KubernetesConfigResponse represents the Kubernetes configuration in the response
+type KubernetesConfigResponse struct {
+	KubeconfigPath         string `json:"kubeconfigPath,omitempty"`
+	K3DOptimized           bool   `json:"k3dOptimized"`
+	K3DAsync               bool   `json:"k3dAsync"`
+	DisableCoreDNS         bool   `json:"disableCoreDNS"`
+	KeepClustersOnShutdown bool   `json:"keepClustersOnShutdown"`
+}
+
+// FeaturesConfigResponse represents the features configuration in the response
+type FeaturesConfigResponse struct {
+	TestMode         bool `json:"testMode"`
+	ContainerMode    bool `json:"containerMode"`
+	AutoRecoverState bool `json:"autoRecoverState"`
+	Traefik          bool `json:"traefik"`
+}
+
+// AWSConfigResponse represents the AWS configuration in the response
+type AWSConfigResponse struct {
+	DefaultRegion string `json:"defaultRegion"`
+	AccountID     string `json:"accountID"`
+}
+
+// handleConfig handles the configuration endpoint
+func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	cfg := s.config
+	if cfg == nil {
+		http.Error(w, "Configuration not available", http.StatusInternalServerError)
+		return
+	}
+
+	// Build response with only non-sensitive configuration
+	response := ConfigResponse{
+		Server: ServerConfigResponse{
+			Port:           cfg.Server.Port,
+			AdminPort:      cfg.Server.AdminPort,
+			DataDir:        cfg.Server.DataDir,
+			LogLevel:       cfg.Server.LogLevel,
+			Endpoint:       cfg.Server.Endpoint,
+			AllowedOrigins: cfg.Server.AllowedOrigins,
+		},
+		LocalStack: LocalStackConfigResponse{
+			Enabled:    cfg.LocalStack.Enabled,
+			UseTraefik: cfg.LocalStack.UseTraefik,
+			Port:       cfg.LocalStack.Port,
+			EdgePort:   cfg.LocalStack.EdgePort,
+		},
+		Kubernetes: KubernetesConfigResponse{
+			KubeconfigPath:         cfg.Kubernetes.KubeconfigPath,
+			K3DOptimized:           cfg.Kubernetes.K3DOptimized,
+			K3DAsync:               cfg.Kubernetes.K3DAsync,
+			DisableCoreDNS:         cfg.Kubernetes.DisableCoreDNS,
+			KeepClustersOnShutdown: cfg.Kubernetes.KeepClustersOnShutdown,
+		},
+		Features: FeaturesConfigResponse{
+			TestMode:         cfg.Features.TestMode,
+			ContainerMode:    cfg.Features.ContainerMode,
+			AutoRecoverState: cfg.Features.AutoRecoverState,
+			Traefik:          cfg.Features.Traefik,
+		},
+		AWS: AWSConfigResponse{
+			DefaultRegion: cfg.AWS.DefaultRegion,
+			AccountID:     cfg.AWS.AccountID,
+		},
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -1,0 +1,184 @@
+# KECS Admin API Documentation
+
+The KECS Admin Server provides operational endpoints for health checks, metrics, and configuration management.
+
+## Base URL
+
+The Admin Server runs on port 8081 by default (configurable via `--admin-port` flag).
+
+```
+http://localhost:8081
+```
+
+## Endpoints
+
+### Health Check Endpoints
+
+#### GET /health
+Basic health check endpoint.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-01-16T10:00:00Z"
+}
+```
+
+#### GET /healthz
+Legacy health check endpoint for backward compatibility.
+
+**Response:**
+```json
+{
+  "status": "OK",
+  "timestamp": "2025-01-16T10:00:00Z",
+  "version": "0.1.0"
+}
+```
+
+#### GET /live
+Kubernetes liveness probe endpoint.
+
+**Response:**
+- Status: 200 OK if the server is alive
+- Status: 503 Service Unavailable if the server is not alive
+
+#### GET /ready
+Kubernetes readiness probe endpoint.
+
+**Response:**
+- Status: 200 OK if the server is ready to accept requests
+- Status: 503 Service Unavailable if the server is not ready
+
+#### GET /health/detailed
+Detailed health check with component status.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "components": {
+    "storage": "healthy",
+    "kubernetes": "healthy",
+    "localstack": "disabled"
+  },
+  "timestamp": "2025-01-16T10:00:00Z"
+}
+```
+
+### Metrics Endpoints
+
+#### GET /metrics
+Basic metrics in JSON format.
+
+**Response:**
+```json
+{
+  "requests_total": 1000,
+  "requests_per_second": 10.5,
+  "active_connections": 25,
+  "errors_total": 5
+}
+```
+
+#### GET /metrics/prometheus
+Metrics in Prometheus format.
+
+**Response:**
+```
+# HELP kecs_requests_total Total number of requests
+# TYPE kecs_requests_total counter
+kecs_requests_total 1000
+# HELP kecs_active_connections Number of active connections
+# TYPE kecs_active_connections gauge
+kecs_active_connections 25
+```
+
+### Configuration Endpoint
+
+#### GET /config
+Returns the current server configuration (non-sensitive values only).
+
+**Response:**
+```json
+{
+  "server": {
+    "port": 8080,
+    "adminPort": 8081,
+    "dataDir": "/home/user/.kecs/data",
+    "logLevel": "info",
+    "endpoint": "",
+    "allowedOrigins": []
+  },
+  "localstack": {
+    "enabled": false,
+    "useTraefik": false,
+    "port": 4566,
+    "edgePort": 4566
+  },
+  "kubernetes": {
+    "kubeconfigPath": "",
+    "k3dOptimized": false,
+    "k3dAsync": false,
+    "disableCoreDNS": false,
+    "keepClustersOnShutdown": false
+  },
+  "features": {
+    "testMode": false,
+    "containerMode": false,
+    "autoRecoverState": true,
+    "traefik": false
+  },
+  "aws": {
+    "defaultRegion": "us-east-1",
+    "accountID": "000000000000"
+  }
+}
+```
+
+## Usage Examples
+
+### Check Server Health
+```bash
+curl http://localhost:8081/health
+```
+
+### Get Current Configuration
+```bash
+curl http://localhost:8081/config | jq .
+```
+
+### Monitor Metrics
+```bash
+# JSON format
+curl http://localhost:8081/metrics
+
+# Prometheus format
+curl http://localhost:8081/metrics/prometheus
+```
+
+### Kubernetes Probes
+```yaml
+# In your Kubernetes deployment
+livenessProbe:
+  httpGet:
+    path: /live
+    port: 8081
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+## Security Considerations
+
+- The Admin Server is intended for internal use only
+- It should not be exposed to the public internet
+- Consider using network policies or firewall rules to restrict access
+- Sensitive configuration values (like secrets) are not exposed through the config endpoint


### PR DESCRIPTION
## Summary
This PR adds a new `/config` endpoint to the KECS admin server that returns the current server configuration in JSON format.

## Motivation
Currently, there's no programmatic way to check KECS configuration at runtime. This makes it difficult to:
- Debug configuration issues
- Monitor deployed instances
- Integrate KECS with other tools that need to know its configuration

## Changes

### New Endpoint
- **URL**: `GET http://localhost:8081/config`
- **Response**: JSON object with current configuration
- **Security**: Excludes sensitive information like secrets

### Configuration Categories Exposed
1. **Server Config**: Port numbers, data directory, log level, allowed origins
2. **LocalStack Config**: Enabled status, Traefik usage, port information
3. **Kubernetes Config**: Kubeconfig path, K3D optimizations, CoreDNS settings
4. **Feature Flags**: Test mode, container mode, auto-recovery, Traefik
5. **AWS Config**: Default region and account ID

### Documentation
Added comprehensive admin API documentation in `docs/admin-api.md` covering:
- All admin endpoints (health, metrics, config)
- Usage examples
- Response formats
- Security considerations

## Testing
```bash
# Start KECS server
KECS_SECURITY_ACKNOWLEDGED=true kecs server

# Test the config endpoint
curl http://localhost:8081/config | jq .

# Example response
{
  "server": {
    "port": 8080,
    "adminPort": 8081,
    "dataDir": "/Users/username/.kecs/data",
    "logLevel": "info"
  },
  "localstack": {
    "enabled": false,
    "useTraefik": false,
    "port": 4566,
    "edgePort": 4566
  },
  "kubernetes": {
    "k3dOptimized": false,
    "k3dAsync": false,
    "disableCoreDNS": false,
    "keepClustersOnShutdown": false
  },
  "features": {
    "testMode": false,
    "containerMode": false,
    "autoRecoverState": true,
    "traefik": false
  },
  "aws": {
    "defaultRegion": "us-east-1",
    "accountID": "000000000000"
  }
}
```

## Security Considerations
- Only non-sensitive configuration is exposed
- No secrets, credentials, or private keys are included
- Admin server should not be exposed to public internet
- Intended for internal monitoring and debugging only

## Future Enhancements
- Configuration update API (PUT/PATCH)
- Configuration validation endpoint
- Configuration history tracking
- Environment variable listing

🤖 Generated with [Claude Code](https://claude.ai/code)