### PR TITLE
feat: Control plane containerization (Phase 2)

### DIFF
--- a/controlplane/Dockerfile.v2
+++ b/controlplane/Dockerfile.v2
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+# KECS Control Plane v2 - Optimized for in-cluster deployment
+
+# Build stage
+FROM --platform=$BUILDPLATFORM golang:1.24.3-alpine AS builder
+WORKDIR /app
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev
+
+# Copy go mod files for better caching
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download && go mod verify
+
+# Copy source files
+COPY cmd/ ./cmd/
+COPY internal/ ./internal/
+
+# Build with cache mount - static binary for better portability
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w -X main.version=v2" \
+    -o controlplane ./cmd/controlplane
+
+# Final stage - distroless for minimal attack surface
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# Copy the binary
+COPY --from=builder /app/controlplane /controlplane
+
+# Set environment variables for in-cluster deployment
+ENV KECS_MODE=in-cluster
+ENV KECS_DATA_DIR=/data
+ENV PORT=8080
+ENV ADMIN_PORT=8081
+
+# Use nonroot user from distroless
+USER nonroot:nonroot
+
+# Data volume for DuckDB persistence
+VOLUME ["/data"]
+
+# Health check endpoint
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/controlplane", "health"]
+
+EXPOSE 8080 8081
+
+ENTRYPOINT ["/controlplane", "server", "--mode=in-cluster"]

--- a/controlplane/internal/controlplane/cmd/health.go
+++ b/controlplane/internal/controlplane/cmd/health.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	healthURL      string
+	healthTimeout  time.Duration
+	healthDetailed bool
+)
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Check the health of KECS control plane",
+	Long:  `Check the health status of the KECS control plane by querying the admin health endpoint.`,
+	RunE:  runHealth,
+}
+
+func init() {
+	RootCmd.AddCommand(healthCmd)
+
+	healthCmd.Flags().StringVar(&healthURL, "url", "http://localhost:8081", "Admin server URL")
+	healthCmd.Flags().DurationVar(&healthTimeout, "timeout", 5*time.Second, "Request timeout")
+	healthCmd.Flags().BoolVar(&healthDetailed, "detailed", false, "Show detailed health information")
+}
+
+func runHealth(cmd *cobra.Command, args []string) error {
+	client := &http.Client{
+		Timeout: healthTimeout,
+	}
+
+	// Choose endpoint based on detailed flag
+	endpoint := "/health"
+	if healthDetailed {
+		endpoint = "/health/detailed"
+	}
+
+	resp, err := client.Get(healthURL + endpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to connect to admin server: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	// Parse response
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse response: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Pretty print the result
+	output, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to format response: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(output))
+
+	// Exit with appropriate code
+	if resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/controlplane/manifests/kecs-configmap.yaml
+++ b/controlplane/manifests/kecs-configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kecs-config
+  namespace: kecs-system
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+data:
+  config.yaml: |
+    api:
+      port: 8080
+      host: 0.0.0.0
+    admin:
+      port: 8081
+      host: 0.0.0.0
+    storage:
+      type: duckdb
+      duckdb:
+        path: /data/kecs.db
+        memory: false
+    kubernetes:
+      inCluster: true
+      namespace: kecs-system
+    features:
+      containerMode: false
+      traefik: true
+      testMode: false
+    localstack:
+      enabled: true
+      services:
+        - s3
+        - dynamodb
+        - sqs
+        - sns
+        - lambda
+      endpoint: http://localstack.kecs-system.svc.cluster.local:4566
+    elbv2:
+      enabled: true
+      dataDir: /data/elbv2

--- a/controlplane/manifests/kecs-deployment.yaml
+++ b/controlplane/manifests/kecs-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kecs-controlplane
+  namespace: kecs-system
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+    kecs.dev/version: "v2"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kecs-controlplane
+  template:
+    metadata:
+      labels:
+        app: kecs-controlplane
+        kecs.dev/component: "controlplane"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8081"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: kecs-controlplane
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+      - name: controlplane
+        image: ghcr.io/nandemo-ya/kecs-controlplane:v2
+        imagePullPolicy: Always
+        ports:
+        - name: api
+          containerPort: 8080
+          protocol: TCP
+        - name: admin
+          containerPort: 8081
+          protocol: TCP
+        env:
+        - name: KECS_MODE
+          value: "in-cluster"
+        - name: KECS_DATA_DIR
+          value: "/data"
+        - name: KECS_CONFIG_FILE
+          value: "/config/config.yaml"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        - name: data
+          mountPath: /data
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: admin
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: admin
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 15"]
+      volumes:
+      - name: config
+        configMap:
+          name: kecs-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: kecs-data

--- a/controlplane/manifests/kecs-namespace.yaml
+++ b/controlplane/manifests/kecs-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kecs-system
+  labels:
+    kecs.dev/managed: "true"
+    kecs.dev/type: "system"
+    kecs.dev/version: "v2"

--- a/controlplane/manifests/kecs-pvc.yaml
+++ b/controlplane/manifests/kecs-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kecs-data
+  namespace: kecs-system
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-path  # k3d default storage class

--- a/controlplane/manifests/kecs-rbac.yaml
+++ b/controlplane/manifests/kecs-rbac.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kecs-controlplane
+  namespace: kecs-system
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kecs-controlplane
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+rules:
+# Namespace management for ECS clusters
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Pod management for ECS tasks
+- apiGroups: [""]
+  resources: ["pods", "pods/status", "pods/log"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Service management for ECS services
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# ConfigMap and Secret management
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Deployment management for future use
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Job management for ECS tasks
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Ingress management for ALB/ELBv2
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Event recording
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kecs-controlplane
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kecs-controlplane
+subjects:
+- kind: ServiceAccount
+  name: kecs-controlplane
+  namespace: kecs-system

--- a/controlplane/manifests/kecs-service.yaml
+++ b/controlplane/manifests/kecs-service.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kecs-controlplane
+  namespace: kecs-system
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+spec:
+  type: ClusterIP
+  selector:
+    app: kecs-controlplane
+  ports:
+  - name: api
+    port: 8080
+    targetPort: api
+    protocol: TCP
+  - name: admin
+    port: 8081
+    targetPort: admin
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kecs-api
+  namespace: kecs-system
+  labels:
+    app: kecs-controlplane
+    kecs.dev/component: "controlplane"
+    kecs.dev/service: "api"
+spec:
+  type: ClusterIP
+  selector:
+    app: kecs-controlplane
+  ports:
+  - name: http
+    port: 80
+    targetPort: api
+    protocol: TCP

--- a/controlplane/manifests/kustomization.yaml
+++ b/controlplane/manifests/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kecs-system
+
+resources:
+- kecs-namespace.yaml
+- kecs-configmap.yaml
+- kecs-pvc.yaml
+- kecs-rbac.yaml
+- kecs-deployment.yaml
+- kecs-service.yaml
+
+images:
+- name: ghcr.io/nandemo-ya/kecs-controlplane
+  newTag: v2
+
+commonLabels:
+  kecs.dev/managed: "true"


### PR DESCRIPTION
## Summary
This PR implements Phase 2 of the control plane in-cluster architecture migration as outlined in ADR-0018 and issue #347.

## Changes
### Dockerfile and Container Image
- Created optimized `Dockerfile.v2` using distroless base image for minimal attack surface
- Static binary compilation for better portability
- Built-in health check command support
- Nonroot user for security

### Kubernetes Manifests
- **Deployment**: Control plane with health/readiness probes and resource limits
- **Service**: ClusterIP services for API (8080) and admin (8081) endpoints
- **ConfigMap**: Runtime configuration for in-cluster mode
- **PVC**: Persistent volume for DuckDB storage (10Gi)
- **RBAC**: ServiceAccount with permissions for ECS resource management

### CLI Enhancements
- Added `health` command for checking control plane status
- Enhanced server command with `--mode` flag (standalone/in-cluster)
- Improved graceful shutdown for in-cluster deployments
- Implemented `deployControlPlane` function in `start-v2` command

### Key Features
- Health check endpoints: `/health`, `/ready`, `/live`
- Graceful shutdown with proper state persistence
- In-cluster mode optimizations
- Kustomize-ready manifests for easy customization

## Testing
- All existing tests pass
- Manual testing of health endpoints
- Graceful shutdown tested with SIGTERM

## Next Steps
Phase 3: API Gateway Setup (Traefik configuration)

Related to #347