### PR TITLE
feat: API Gateway with Traefik (Phase 3)

### DIFF
--- a/controlplane/manifests/traefik/aws-middleware.yaml
+++ b/controlplane/manifests/traefik/aws-middleware.yaml
@@ -1,0 +1,84 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: aws-headers
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/type: "middleware"
+spec:
+  headers:
+    customRequestHeaders:
+      # Preserve original host header for AWS signature validation
+      X-Forwarded-Host: "localhost:4566"
+      # Add KECS identification
+      X-KECS-Gateway: "true"
+      X-KECS-Version: "v2"
+    # Pass through AWS headers
+    accessControlAllowHeaders:
+    - "*"
+    accessControlAllowMethods:
+    - "GET"
+    - "POST"
+    - "PUT"
+    - "DELETE"
+    - "OPTIONS"
+    - "HEAD"
+    - "PATCH"
+    accessControlAllowOriginList:
+    - "*"
+    accessControlMaxAge: 100
+    addVaryHeader: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: aws-auth
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/type: "middleware"
+spec:
+  # For now, we pass through AWS auth headers
+  # In the future, we can add validation here
+  headers:
+    # Preserve AWS authentication headers
+    customRequestHeaders:
+      Authorization: "{{ .Authorization }}"
+      X-Amz-Date: "{{ .X-Amz-Date }}"
+      X-Amz-Security-Token: "{{ .X-Amz-Security-Token }}"
+      X-Amz-Content-SHA256: "{{ .X-Amz-Content-SHA256 }}"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-prefix
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/type: "middleware"
+spec:
+  stripPrefix:
+    prefixes:
+    - "/aws"
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: rate-limit
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/type: "middleware"
+spec:
+  rateLimit:
+    average: 100
+    burst: 200
+    period: 1s
+    sourceCriterion:
+      requestHost: true

--- a/controlplane/manifests/traefik/aws-routes.yaml
+++ b/controlplane/manifests/traefik/aws-routes.yaml
@@ -1,0 +1,74 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ecs-routes
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/service: "ecs"
+spec:
+  entryPoints:
+  - aws
+  routes:
+  # ECS API routes to KECS control plane
+  - match: PathPrefix(`/`) && Headers(`X-Amz-Target`, `AmazonEC2ContainerServiceV20141113.`)
+    kind: Rule
+    priority: 100
+    services:
+    - name: kecs-api
+      port: 80
+      namespace: kecs-system
+    middlewares:
+    - name: aws-headers
+      namespace: kecs-system
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: elbv2-routes
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/service: "elbv2"
+spec:
+  entryPoints:
+  - aws
+  routes:
+  # ELBv2 API routes to KECS control plane
+  - match: PathPrefix(`/`) && Headers(`X-Amz-Target`, `ElasticLoadBalancingV2.`)
+    kind: Rule
+    priority: 90
+    services:
+    - name: kecs-api
+      port: 80
+      namespace: kecs-system
+    middlewares:
+    - name: aws-headers
+      namespace: kecs-system
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: localstack-routes
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/service: "localstack"
+spec:
+  entryPoints:
+  - aws
+  routes:
+  # Default route to LocalStack for other AWS services
+  - match: PathPrefix(`/`)
+    kind: Rule
+    priority: 10
+    services:
+    - name: localstack
+      port: 4566
+      namespace: kecs-system
+    middlewares:
+    - name: aws-headers
+      namespace: kecs-system

--- a/controlplane/manifests/traefik/kustomization.yaml
+++ b/controlplane/manifests/traefik/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kecs-system
+
+resources:
+- traefik-crd.yaml
+- traefik-rbac.yaml
+- traefik-config.yaml
+- traefik-deployment.yaml
+- traefik-service.yaml
+- aws-middleware.yaml
+- aws-routes.yaml
+
+commonLabels:
+  kecs.dev/managed: "true"
+  kecs.dev/component: "gateway"

--- a/controlplane/manifests/traefik/traefik-config.yaml
+++ b/controlplane/manifests/traefik/traefik-config.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: traefik-config
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+data:
+  traefik.yaml: |
+    api:
+      dashboard: true
+      debug: true
+    
+    entryPoints:
+      web:
+        address: ":80"
+      aws:
+        address: ":4566"
+      metrics:
+        address: ":8082"
+    
+    providers:
+      kubernetesCRD:
+        allowCrossNamespace: true
+        allowExternalNameServices: true
+      kubernetesIngress:
+        allowExternalNameServices: true
+    
+    log:
+      level: INFO
+      format: json
+    
+    accessLog:
+      format: json
+      fields:
+        defaultMode: keep
+        headers:
+          defaultMode: keep
+          names:
+            X-Amz-Target: keep
+            Authorization: redact
+    
+    metrics:
+      prometheus:
+        entryPoint: metrics
+        addEntryPointsLabels: true
+        addServicesLabels: true
+    
+    ping:
+      entryPoint: web

--- a/controlplane/manifests/traefik/traefik-crd.yaml
+++ b/controlplane/manifests/traefik/traefik-crd.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressroutes.traefik.io
+  labels:
+    kecs.dev/component: "gateway"
+spec:
+  group: traefik.io
+  version: v1alpha1
+  names:
+    kind: IngressRoute
+    plural: ingressroutes
+    singular: ingressroute
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              entryPoints:
+                type: array
+                items:
+                  type: string
+              routes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    match:
+                      type: string
+                    kind:
+                      type: string
+                    priority:
+                      type: integer
+                    services:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            x-kubernetes-int-or-string: true
+                          namespace:
+                            type: string
+                          weight:
+                            type: integer
+                    middlewares:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: middlewares.traefik.io
+  labels:
+    kecs.dev/component: "gateway"
+spec:
+  group: traefik.io
+  version: v1alpha1
+  names:
+    kind: Middleware
+    plural: middlewares
+    singular: middleware
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/controlplane/manifests/traefik/traefik-deployment.yaml
+++ b/controlplane/manifests/traefik/traefik-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traefik
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/version: "v2"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traefik
+  template:
+    metadata:
+      labels:
+        app: traefik
+        kecs.dev/component: "gateway"
+    spec:
+      serviceAccountName: traefik
+      containers:
+      - name: traefik
+        image: traefik:v3.2
+        args:
+        - --configfile=/config/traefik.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP
+        - name: aws
+          containerPort: 4566
+          protocol: TCP
+        - name: admin
+          containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 8082
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: admin
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: admin
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+      volumes:
+      - name: config
+        configMap:
+          name: traefik-config

--- a/controlplane/manifests/traefik/traefik-rbac.yaml
+++ b/controlplane/manifests/traefik/traefik-rbac.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+rules:
+# IngressRoute and Middleware CRDs
+- apiGroups:
+  - traefik.io
+  - traefik.containo.us
+  resources:
+  - ingressroutes
+  - ingressroutetcps
+  - ingressrouteudps
+  - middlewares
+  - middlewaretcps
+  - tlsoptions
+  - tlsstores
+  - traefikservices
+  - serverstransports
+  verbs:
+  - get
+  - list
+  - watch
+# Kubernetes Ingress
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik
+subjects:
+- kind: ServiceAccount
+  name: traefik
+  namespace: kecs-system

--- a/controlplane/manifests/traefik/traefik-service.yaml
+++ b/controlplane/manifests/traefik/traefik-service.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+spec:
+  type: LoadBalancer
+  selector:
+    app: traefik
+  ports:
+  - name: web
+    port: 80
+    targetPort: web
+    protocol: TCP
+  - name: aws
+    port: 4566
+    targetPort: aws
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-dashboard
+  namespace: kecs-system
+  labels:
+    app: traefik
+    kecs.dev/component: "gateway"
+    kecs.dev/service: "dashboard"
+spec:
+  type: ClusterIP
+  selector:
+    app: traefik
+  ports:
+  - name: admin
+    port: 8080
+    targetPort: admin
+    protocol: TCP

--- a/controlplane/scripts/test-traefik-routing.sh
+++ b/controlplane/scripts/test-traefik-routing.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Test script for Traefik AWS API routing
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Testing Traefik AWS API routing...${NC}"
+
+# Default values
+ENDPOINT="${ENDPOINT:-http://localhost:4566}"
+REGION="${AWS_REGION:-us-east-1}"
+
+# Test ECS API routing
+echo -e "\n${YELLOW}1. Testing ECS API routing:${NC}"
+aws ecs list-clusters --endpoint-url "$ENDPOINT" --region "$REGION" --no-cli-pager || {
+    echo -e "${RED}ECS API routing test failed${NC}"
+    exit 1
+}
+echo -e "${GREEN}✓ ECS API routing works${NC}"
+
+# Test ELBv2 API routing
+echo -e "\n${YELLOW}2. Testing ELBv2 API routing:${NC}"
+aws elbv2 describe-load-balancers --endpoint-url "$ENDPOINT" --region "$REGION" --no-cli-pager || {
+    echo -e "${RED}ELBv2 API routing test failed${NC}"
+    exit 1
+}
+echo -e "${GREEN}✓ ELBv2 API routing works${NC}"
+
+# Test LocalStack routing (S3)
+echo -e "\n${YELLOW}3. Testing LocalStack routing (S3):${NC}"
+aws s3 ls --endpoint-url "$ENDPOINT" --region "$REGION" --no-cli-pager || {
+    echo -e "${RED}LocalStack routing test failed${NC}"
+    exit 1
+}
+echo -e "${GREEN}✓ LocalStack routing works${NC}"
+
+# Check Traefik dashboard
+echo -e "\n${YELLOW}4. Checking Traefik dashboard:${NC}"
+DASHBOARD_URL="http://localhost:8080/dashboard/"
+if curl -s -o /dev/null -w "%{http_code}" "$DASHBOARD_URL" | grep -q "200"; then
+    echo -e "${GREEN}✓ Traefik dashboard is accessible at $DASHBOARD_URL${NC}"
+else
+    echo -e "${YELLOW}⚠ Traefik dashboard not accessible (this is expected with k3d port forwarding)${NC}"
+fi
+
+# Show routing information
+echo -e "\n${YELLOW}5. Routing information:${NC}"
+echo "- ECS APIs (X-Amz-Target: AmazonEC2ContainerServiceV20141113.*) → KECS control plane"
+echo "- ELBv2 APIs (X-Amz-Target: ElasticLoadBalancingV2.*) → KECS control plane"
+echo "- Other AWS APIs → LocalStack"
+
+echo -e "\n${GREEN}All routing tests passed!${NC}"

--- a/docs/traefik-gateway.md
+++ b/docs/traefik-gateway.md
@@ -1,0 +1,129 @@
+# Traefik API Gateway
+
+This document describes the Traefik-based API gateway implementation in KECS v2 architecture.
+
+## Overview
+
+In the new architecture, Traefik serves as the unified AWS API gateway that routes requests to appropriate backends:
+- ECS API requests → KECS control plane
+- ELBv2 API requests → KECS control plane  
+- Other AWS service requests → LocalStack
+
+## Architecture
+
+```
+┌─────────────────┐
+│ AWS CLI/SDK     │
+└────────┬────────┘
+         │ :4566
+┌────────▼────────┐
+│ Traefik Gateway │
+│  (kecs-system)  │
+└────────┬────────┘
+         │ Route by X-Amz-Target header
+         │
+    ┌────┴────┬─────────┐
+    │         │         │
+┌───▼──┐  ┌──▼──┐  ┌──▼────────┐
+│ ECS  │  │ELBv2│  │LocalStack │
+│ API  │  │ API │  │ (S3, etc) │
+└──────┘  └─────┘  └───────────┘
+```
+
+## Routing Rules
+
+Traefik routes requests based on the `X-Amz-Target` header:
+
+1. **ECS APIs**: `X-Amz-Target: AmazonEC2ContainerServiceV20141113.*`
+   - Routes to KECS control plane on port 8080
+   - Priority: 100
+
+2. **ELBv2 APIs**: `X-Amz-Target: ElasticLoadBalancingV2.*`
+   - Routes to KECS control plane on port 8080
+   - Priority: 90
+
+3. **Default**: All other requests
+   - Routes to LocalStack on port 4566
+   - Priority: 10
+
+## Middleware
+
+### aws-headers
+Manages AWS-specific headers:
+- Preserves original host header for signature validation
+- Adds KECS identification headers
+- Configures CORS for browser-based clients
+
+### aws-auth
+Preserves AWS authentication headers:
+- Authorization
+- X-Amz-Date
+- X-Amz-Security-Token
+- X-Amz-Content-SHA256
+
+### rate-limit
+Protects against abuse:
+- Average: 100 requests/second
+- Burst: 200 requests
+- Per-host rate limiting
+
+## Deployment
+
+Traefik is deployed as part of the KECS control plane setup:
+
+```bash
+# Start KECS with new architecture
+kecs start-v2 --name my-cluster
+
+# Traefik is automatically deployed and configured
+```
+
+## Testing
+
+Test the routing with the provided script:
+
+```bash
+./controlplane/scripts/test-traefik-routing.sh
+```
+
+Or manually:
+
+```bash
+# Test ECS routing
+aws ecs list-clusters --endpoint-url http://localhost:4566
+
+# Test ELBv2 routing  
+aws elbv2 describe-load-balancers --endpoint-url http://localhost:4566
+
+# Test LocalStack routing
+aws s3 ls --endpoint-url http://localhost:4566
+```
+
+## Monitoring
+
+### Dashboard
+Access the Traefik dashboard at http://localhost:8080 (when port-forwarded).
+
+### Metrics
+Prometheus metrics are exposed on port 8082:
+- Request counts by service
+- Response times
+- Error rates
+
+## Troubleshooting
+
+### Check Traefik logs
+```bash
+kubectl logs -n kecs-system -l app=traefik
+```
+
+### Verify routing rules
+```bash
+kubectl get ingressroute -n kecs-system
+```
+
+### Test connectivity
+```bash
+kubectl port-forward -n kecs-system svc/traefik 8080:8080
+curl http://localhost:8080/api/rawdata
+```


### PR DESCRIPTION
## Summary
This PR implements Phase 3 of the control plane in-cluster architecture migration as outlined in ADR-0018 and issue #347.

## Changes
### Traefik Deployment
- **Deployment**: Traefik v3.2 with health checks and resource limits
- **Service**: LoadBalancer for external access on port 4566
- **Dashboard**: ClusterIP service for monitoring
- **RBAC**: Permissions for IngressRoute and Kubernetes resources
- **ConfigMap**: Traefik configuration with logging and metrics

### API Routing Configuration
- **ECS routes**: `X-Amz-Target: AmazonEC2ContainerServiceV20141113.*` → KECS control plane
- **ELBv2 routes**: `X-Amz-Target: ElasticLoadBalancingV2.*` → KECS control plane
- **Default route**: All other requests → LocalStack
- Priority-based routing for proper request handling

### Middleware
- **aws-headers**: Preserve host header and add KECS identification
- **aws-auth**: Pass through AWS authentication headers
- **rate-limit**: 100 req/s average with 200 burst limit
- **strip-prefix**: Remove path prefixes when needed

### Implementation
- Updated `deployTraefikGateway` function to apply manifests
- Added Traefik port configuration to k3d cluster creation
- Implemented deployment readiness checks
- Added test script for routing validation

### Documentation
- Comprehensive Traefik gateway documentation
- Architecture diagram and routing rules
- Testing and troubleshooting guide

## Testing
```bash
# Test the routing
./controlplane/scripts/test-traefik-routing.sh

# Or manually test each service
aws ecs list-clusters --endpoint-url http://localhost:4566
aws elbv2 describe-load-balancers --endpoint-url http://localhost:4566
aws s3 ls --endpoint-url http://localhost:4566
```

## Architecture
```
AWS CLI/SDK → Traefik Gateway (:4566) → Route by X-Amz-Target
                     ├── ECS/ELBv2 → KECS Control Plane
                     └── Others → LocalStack
```

## Next Steps
Phase 4: Migration and Testing

Related to #347