### PR TITLE
fix: Fix k3d cluster creation and deployment issues in new architecture

### DIFF
--- a/controlplane/manifests/kecs-deployment.yaml
+++ b/controlplane/manifests/kecs-deployment.yaml
@@ -29,8 +29,9 @@ spec:
         fsGroup: 65532
       containers:
       - name: controlplane
-        image: ghcr.io/nandemo-ya/kecs-controlplane:v2
-        imagePullPolicy: Always
+        image: ghcr.io/nandemo-ya/kecs:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/controlplane", "server"]
         ports:
         - name: api
           containerPort: 8080
@@ -45,6 +46,12 @@ spec:
           value: "/data"
         - name: KECS_CONFIG_FILE
           value: "/config/config.yaml"
+        - name: KECS_SKIP_DOCKER_CHECK
+          value: "true"
+        - name: KECS_KUBERNETES_MODE
+          value: "true"
+        - name: KECS_SECURITY_ACKNOWLEDGED
+          value: "true"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Summary

This PR fixes several critical issues discovered during Phase 1 testing of the new architecture:

1. **k3d kubeconfig server URL issue** - The GetKubeconfigPath method now checks multiple locations including `~/.config` which is used by k3d v5
2. **Traefik enablement** - Fixed EnableTraefik to be true for the new architecture in start_v2.go
3. **Manifest path resolution** - Improved path resolution to try multiple locations for finding manifest files
4. **Docker image issues** - Updated deployment to use existing public image instead of private v2 image
5. **Container binary path** - Fixed command path to use `/controlplane` instead of `/app/kecs`
6. **Security acknowledgment** - Added KECS_SECURITY_ACKNOWLEDGED environment variable to skip interactive prompt

## Changes

- Modified `GetKubeconfigPath` in k3d_cluster_manager.go to check ~/.config directory
- Set `EnableTraefik: true` in start_v2.go for proper Traefik deployment
- Enhanced manifest path resolution with multiple fallback locations
- Updated kecs-deployment.yaml to use correct image and binary path
- Added required environment variables for in-cluster mode

## Test Results

After these fixes:
- ✅ k3d cluster creation works properly
- ✅ Kubeconfig is found in the correct location
- ✅ KECS control plane starts successfully in the cluster
- ✅ API and Admin servers are running

Note: There's still a RBAC permission issue for creating PVCs in the aws-services namespace, but this can be addressed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.ai/code)