### PR TITLE
refactor: Migrate LocalStack from aws-services to kecs-system namespace

### DIFF
--- a/controlplane/awsproxy/Dockerfile
+++ b/controlplane/awsproxy/Dockerfile
@@ -31,7 +31,7 @@ FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /aws-proxy /aws-proxy
 
 # Set default environment variables
-ENV LOCALSTACK_ENDPOINT=http://localstack.aws-services.svc.cluster.local:4566
+ENV LOCALSTACK_ENDPOINT=http://localstack.kecs-system.svc.cluster.local:4566
 ENV DEBUG=false
 
 # Expose port

--- a/controlplane/awsproxy/main.go
+++ b/controlplane/awsproxy/main.go
@@ -23,7 +23,7 @@ func main() {
 	// Parse command line flags
 	var (
 		port               = flag.Int("port", 4566, "Port to listen on")
-		localStackEndpoint = flag.String("localstack-endpoint", getEnvOrDefault("LOCALSTACK_ENDPOINT", "http://localstack.aws-services.svc.cluster.local:4566"), "LocalStack endpoint URL")
+		localStackEndpoint = flag.String("localstack-endpoint", getEnvOrDefault("LOCALSTACK_ENDPOINT", "http://localstack.kecs-system.svc.cluster.local:4566"), "LocalStack endpoint URL")
 		debug              = flag.Bool("debug", getEnvOrDefaultBool("DEBUG", false), "Enable debug logging")
 		version            = flag.Bool("version", false, "Show version information")
 	)

--- a/controlplane/configs/production.yaml
+++ b/controlplane/configs/production.yaml
@@ -92,7 +92,7 @@ localstack:
   persistence: true
   image: "localstack/localstack"
   version: "latest"
-  namespace: "aws-services"
+  namespace: "kecs-system"
   port: 4566
   edgePort: 4566
   resources:
@@ -113,7 +113,7 @@ localstack:
 # AWS Proxy configuration  
 proxy:
   mode: "disabled"  # Options: environment, sidecar, ebpf, disabled
-  localstackEndpoint: "http://localstack.aws-services.svc.cluster.local:4566"
+  localstackEndpoint: "http://localstack.kecs-system.svc.cluster.local:4566"
   fallbackEnabled: false
   fallbackOrder:
     - sidecar

--- a/controlplane/configs/test.yaml
+++ b/controlplane/configs/test.yaml
@@ -92,7 +92,7 @@ localstack:
   persistence: false
   image: "localstack/localstack"
   version: "latest"
-  namespace: "aws-services"
+  namespace: "kecs-system"
   port: 4566
   edgePort: 4566
   resources:
@@ -113,5 +113,5 @@ localstack:
 # AWS Proxy configuration  
 proxy:
   mode: "disabled"  # Disable proxy in tests
-  localstackEndpoint: "http://localstack.aws-services.svc.cluster.local:4566"
+  localstackEndpoint: "http://localstack.kecs-system.svc.cluster.local:4566"
   fallbackEnabled: false

--- a/controlplane/internal/controlplane/api/cluster_ecs_api.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api.go
@@ -979,7 +979,7 @@ func (api *DefaultECSAPI) updateLocalStackState(cluster *storage.Cluster, status
 		Deployed: true,
 		Status:   status,
 		DeployedAt: &now,
-		Namespace: "aws-services",
+		Namespace: "kecs-system",
 	}
 	
 	// Add error message if status is failed

--- a/controlplane/internal/integrations/cloudwatch/integration.go
+++ b/controlplane/internal/integrations/cloudwatch/integration.go
@@ -222,7 +222,7 @@ func (i *integration) generateFluentBitConfig(logGroupName, logStreamPrefix stri
 
 	endpoint := i.config.LocalStackEndpoint
 	if endpoint == "" {
-		endpoint = "http://localstack.aws-services.svc.cluster.local:4566"
+		endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
 	}
 
 	// FluentBit configuration for CloudWatch

--- a/controlplane/internal/integrations/cloudwatch/integration_complete_test.go
+++ b/controlplane/internal/integrations/cloudwatch/integration_complete_test.go
@@ -143,7 +143,7 @@ var _ = Describe("CloudWatch Integration Complete", func() {
 			// Verify specific settings
 			Expect(config).To(ContainSubstring("region              us-west-2"))
 			Expect(config).To(ContainSubstring("log_group_name      /ecs/my-service"))
-			Expect(config).To(ContainSubstring("endpoint            http://localstack.aws-services.svc.cluster.local:4566"))
+			Expect(config).To(ContainSubstring("endpoint            http://localstack.kecs-system.svc.cluster.local:4566"))
 		})
 	})
 })

--- a/controlplane/internal/integrations/s3/integration.go
+++ b/controlplane/internal/integrations/s3/integration.go
@@ -184,7 +184,7 @@ func (b *bodyReadCloser) Close() error {
 // TODO: Implement LocalStack HTTP client that uses generated types
 func createLocalStackConfig(endpoint, region string) error {
 	if endpoint == "" {
-		endpoint = "http://localstack.aws-services.svc.cluster.local:4566"
+		endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
 	}
 	// Implementation needed for LocalStack HTTP client
 	return fmt.Errorf("LocalStack configuration not implemented with generated types")

--- a/controlplane/internal/kubernetes/manifests/traefik.yaml
+++ b/controlplane/internal/kubernetes/manifests/traefik.yaml
@@ -105,7 +105,7 @@ data:
         localstack:
           loadBalancer:
             servers:
-              - address: "localstack.aws-services.svc.cluster.local:4566"
+              - address: "localstack.kecs-system.svc.cluster.local:4566"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/controlplane/internal/localstack/config_test.go
+++ b/controlplane/internal/localstack/config_test.go
@@ -22,7 +22,7 @@ var _ = Describe("LocalStack Configuration", func() {
 			Expect(config.Persistence).To(BeTrue())
 			Expect(config.Image).To(Equal("localstack/localstack"))
 			Expect(config.Version).To(Equal("latest"))
-			Expect(config.Namespace).To(Equal("aws-services"))
+			Expect(config.Namespace).To(Equal("kecs-system"))
 			Expect(config.Port).To(Equal(4566))
 			Expect(config.EdgePort).To(Equal(4566))
 		})

--- a/controlplane/internal/localstack/types.go
+++ b/controlplane/internal/localstack/types.go
@@ -160,7 +160,7 @@ type ProxyConfig struct {
 
 // Constants for LocalStack
 const (
-	DefaultNamespace     = "aws-services"
+	DefaultNamespace     = "kecs-system"
 	DefaultImage         = "localstack/localstack"
 	DefaultVersion       = "latest"
 	DefaultPort          = 4566

--- a/controlplane/internal/storage/duckdb/cluster_store_localstack_test.go
+++ b/controlplane/internal/storage/duckdb/cluster_store_localstack_test.go
@@ -40,9 +40,9 @@ func TestClusterStore_LocalStackState(t *testing.T) {
 			Deployed:    true,
 			Status:      "running",
 			Version:     "2.3.0",
-			Namespace:   "aws-services",
+			Namespace:   "kecs-system",
 			PodName:     "localstack-0",
-			Endpoint:    "http://localstack.aws-services.svc.cluster.local:4566",
+			Endpoint:    "http://localstack.kecs-system.svc.cluster.local:4566",
 			DeployedAt:  &now,
 			HealthStatus: "healthy",
 		}
@@ -83,9 +83,9 @@ func TestClusterStore_LocalStackState(t *testing.T) {
 		assert.True(t, retrievedState.Deployed)
 		assert.Equal(t, "running", retrievedState.Status)
 		assert.Equal(t, "2.3.0", retrievedState.Version)
-		assert.Equal(t, "aws-services", retrievedState.Namespace)
+		assert.Equal(t, "kecs-system", retrievedState.Namespace)
 		assert.Equal(t, "localstack-0", retrievedState.PodName)
-		assert.Equal(t, "http://localstack.aws-services.svc.cluster.local:4566", retrievedState.Endpoint)
+		assert.Equal(t, "http://localstack.kecs-system.svc.cluster.local:4566", retrievedState.Endpoint)
 		assert.Equal(t, "healthy", retrievedState.HealthStatus)
 	})
 
@@ -184,9 +184,9 @@ func TestLocalStackState_Serialization(t *testing.T) {
 			Deployed:         true,
 			Status:          "running",
 			Version:         "2.3.0",
-			Namespace:       "aws-services",
+			Namespace:       "kecs-system",
 			PodName:         "localstack-0",
-			Endpoint:        "http://localstack.aws-services.svc.cluster.local:4566",
+			Endpoint:        "http://localstack.kecs-system.svc.cluster.local:4566",
 			DeployedAt:      &now,
 			LastHealthCheck: &lastCheck,
 			HealthStatus:    "healthy",

--- a/deployments/kubernetes/localstack/configmap.yaml
+++ b/deployments/kubernetes/localstack/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: localstack-config
-  namespace: aws-services
+  namespace: kecs-system
   labels:
     app: localstack
     app.kubernetes.io/name: localstack

--- a/deployments/kubernetes/localstack/deployment.yaml
+++ b/deployments/kubernetes/localstack/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: localstack
-  namespace: aws-services
+  namespace: kecs-system
   labels:
     app: localstack
     app.kubernetes.io/name: localstack

--- a/deployments/kubernetes/localstack/namespace.yaml
+++ b/deployments/kubernetes/localstack/namespace.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: aws-services
+  name: kecs-system
   labels:
-    app.kubernetes.io/name: aws-services
+    app.kubernetes.io/name: kecs-system
     app.kubernetes.io/managed-by: kecs
     app.kubernetes.io/component: localstack

--- a/deployments/kubernetes/localstack/pvc.yaml
+++ b/deployments/kubernetes/localstack/pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: localstack-data
-  namespace: aws-services
+  namespace: kecs-system
   labels:
     app: localstack
     app.kubernetes.io/name: localstack

--- a/deployments/kubernetes/localstack/service.yaml
+++ b/deployments/kubernetes/localstack/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: localstack
-  namespace: aws-services
+  namespace: kecs-system
   labels:
     app: localstack
     app.kubernetes.io/name: localstack

--- a/docs/adr/records/0012-kecs-localstack-adr.md
+++ b/docs/adr/records/0012-kecs-localstack-adr.md
@@ -133,7 +133,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: localstack
-  namespace: aws-services
+  namespace: kecs-system
 spec:
   replicas: 1
   selector:

--- a/docs/adr/records/0018-control-plane-in-cluster.md
+++ b/docs/adr/records/0018-control-plane-in-cluster.md
@@ -9,7 +9,7 @@ Proposed
 The current KECS architecture runs the control plane as a standalone process (either in a container or directly on the host) that manages k3d clusters. This design has revealed a significant limitation:
 
 **Problem**: Application containers running inside KECS clusters cannot access KECS control plane APIs (ECS, ELBv2) while they can access LocalStack APIs. This is because:
-- LocalStack runs inside the k3d cluster (in `aws-services` namespace)
+- LocalStack runs inside the k3d cluster (in `kecs-system` namespace)
 - KECS control plane runs outside the k3d cluster
 - Applications that need to call ECS APIs from within containers face networking complexity
 

--- a/docs/localstack-integration.md
+++ b/docs/localstack-integration.md
@@ -31,7 +31,7 @@ localstack:
     - elbv2
   persistence: true
   image: "localstack/localstack:latest"
-  namespace: "aws-services"
+  namespace: "kecs-system"
   port: 4566
   edgePort: 4566
   resources:
@@ -90,7 +90,7 @@ Configure how ECS tasks connect to LocalStack:
 # AWS Proxy configuration  
 proxy:
   mode: "environment"  # Options: environment, sidecar, disabled
-  localstackEndpoint: "http://localstack.aws-services.svc.cluster.local:4566"
+  localstackEndpoint: "http://localstack.kecs-system.svc.cluster.local:4566"
   fallbackEnabled: true
   fallbackOrder:
     - sidecar
@@ -135,7 +135,7 @@ kecs localstack status
 LocalStack Status:
   Running: true
   Healthy: true
-  Endpoint: http://localstack.aws-services.svc.cluster.local:4566
+  Endpoint: http://localstack.kecs-system.svc.cluster.local:4566
   Uptime: 2h30m
 
 Enabled Services:
@@ -147,11 +147,11 @@ Enabled Services:
 
 Service Health:
   SERVICE         HEALTHY  ENDPOINT
-  iam             true     http://localstack.aws-services.svc.cluster.local:4566
-  logs            true     http://localstack.aws-services.svc.cluster.local:4566
-  ssm             true     http://localstack.aws-services.svc.cluster.local:4566
-  secretsmanager  true     http://localstack.aws-services.svc.cluster.local:4566
-  elbv2           true     http://localstack.aws-services.svc.cluster.local:4566
+  iam             true     http://localstack.kecs-system.svc.cluster.local:4566
+  logs            true     http://localstack.kecs-system.svc.cluster.local:4566
+  ssm             true     http://localstack.kecs-system.svc.cluster.local:4566
+  secretsmanager  true     http://localstack.kecs-system.svc.cluster.local:4566
+  elbv2           true     http://localstack.kecs-system.svc.cluster.local:4566
 ```
 
 ## Proxy Modes
@@ -242,8 +242,8 @@ If you need to deploy LocalStack manually:
 kubectl apply -f deployments/kubernetes/localstack/
 
 # Check deployment
-kubectl -n aws-services get pods
-kubectl -n aws-services get svc
+kubectl -n kecs-system get pods
+kubectl -n kecs-system get svc
 ```
 
 ## Troubleshooting
@@ -252,31 +252,31 @@ kubectl -n aws-services get svc
 
 1. Check pod status:
    ```bash
-   kubectl -n aws-services describe pod -l app=localstack
+   kubectl -n kecs-system describe pod -l app=localstack
    ```
 
 2. Check logs:
    ```bash
-   kubectl -n aws-services logs -l app=localstack
+   kubectl -n kecs-system logs -l app=localstack
    ```
 
 3. Verify resources:
    ```bash
-   kubectl -n aws-services get pvc
-   kubectl -n aws-services get events
+   kubectl -n kecs-system get pvc
+   kubectl -n kecs-system get events
    ```
 
 ### Connection Issues
 
 1. Verify service endpoint:
    ```bash
-   kubectl -n aws-services get svc localstack
+   kubectl -n kecs-system get svc localstack
    ```
 
 2. Test connectivity from a pod:
    ```bash
    kubectl run test --rm -it --image=curlimages/curl -- \
-     curl http://localstack.aws-services.svc.cluster.local:4566/_localstack/health
+     curl http://localstack.kecs-system.svc.cluster.local:4566/_localstack/health
    ```
 
 3. Check proxy configuration:

--- a/docs/localstack-version-management.md
+++ b/docs/localstack-version-management.md
@@ -58,7 +58,7 @@ Output includes version information:
 LocalStack Status:
   Running: true
   Healthy: true
-  Endpoint: http://localstack.aws-services.svc.cluster.local:4566
+  Endpoint: http://localstack.kecs-system.svc.cluster.local:4566
   Version: 4.5
 ```
 


### PR DESCRIPTION
## Summary
- Migrate LocalStack deployment from `aws-services` namespace to `kecs-system` namespace
- Update all references across the codebase to use the new namespace
- Consolidate all KECS components under a single namespace for better organization

## Changes
- Updated Kubernetes manifests for LocalStack deployment
- Updated configuration files (production.yaml, test.yaml)
- Updated source code references in controlplane
- Updated AWS proxy default configurations
- Updated tests to reflect the namespace change
- Updated documentation references

## Motivation
This change simplifies the deployment architecture by having all KECS components in a single namespace (`kecs-system`) rather than spreading them across multiple namespaces. This makes it easier to:
- Manage RBAC permissions
- Monitor all components in one place
- Simplify deployment and cleanup operations

## Test Plan
- [x] All unit tests pass
- [ ] Deploy LocalStack to k3d cluster and verify it runs in kecs-system namespace
- [ ] Verify LocalStack is accessible from control plane via the new endpoint
- [ ] Run integration tests to ensure LocalStack functionality works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)