### PR TITLE
feat: Implement KECS Instance concept with auto-naming

### DIFF
--- a/controlplane/internal/controlplane/cmd/stop_v2.go
+++ b/controlplane/internal/controlplane/cmd/stop_v2.go
@@ -12,26 +12,30 @@ import (
 )
 
 var (
-	stopV2ClusterName string
-	stopV2DeleteData  bool
+	stopV2InstanceName string
+	stopV2DeleteData   bool
 )
 
 var stopV2Cmd = &cobra.Command{
 	Use:   "stop-v2",
-	Short: "Stop KECS k3d cluster (new architecture)",
-	Long:  `Stop and delete the k3d cluster running KECS control plane.`,
+	Short: "Stop KECS instance (new architecture)",
+	Long:  `Stop and delete the KECS instance including its k3d cluster and control plane.`,
 	RunE:  runStopV2,
 }
 
 func init() {
 	RootCmd.AddCommand(stopV2Cmd)
 
-	stopV2Cmd.Flags().StringVar(&stopV2ClusterName, "name", "kecs", "Cluster name to stop")
+	stopV2Cmd.Flags().StringVar(&stopV2InstanceName, "instance", "", "KECS instance name to stop (required)")
 	stopV2Cmd.Flags().BoolVar(&stopV2DeleteData, "delete-data", false, "Delete persistent data")
 }
 
 func runStopV2(cmd *cobra.Command, args []string) error {
-	fmt.Printf("Stopping KECS cluster '%s'...\n", stopV2ClusterName)
+	if stopV2InstanceName == "" {
+		return fmt.Errorf("instance name is required. Use --instance flag to specify the instance to stop")
+	}
+
+	fmt.Printf("Stopping KECS instance '%s'...\n", stopV2InstanceName)
 
 	// Create k3d cluster manager
 	manager, err := kubernetes.NewK3dClusterManager(nil)
@@ -42,34 +46,34 @@ func runStopV2(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Check if cluster exists
-	exists, err := manager.ClusterExists(ctx, stopV2ClusterName)
+	exists, err := manager.ClusterExists(ctx, stopV2InstanceName)
 	if err != nil {
 		return fmt.Errorf("failed to check cluster existence: %w", err)
 	}
 
 	if !exists {
-		fmt.Printf("Cluster '%s' does not exist\n", stopV2ClusterName)
+		fmt.Printf("KECS instance '%s' does not exist\n", stopV2InstanceName)
 		return nil
 	}
 
 	// Delete the cluster
-	if err := manager.DeleteCluster(ctx, stopV2ClusterName); err != nil {
+	if err := manager.DeleteCluster(ctx, stopV2InstanceName); err != nil {
 		return fmt.Errorf("failed to delete cluster: %w", err)
 	}
 
-	fmt.Printf("Successfully stopped and deleted cluster '%s'\n", stopV2ClusterName)
+	fmt.Printf("Successfully stopped and deleted KECS instance '%s'\n", stopV2InstanceName)
 
 	// Delete data if requested
 	if stopV2DeleteData {
 		home, _ := os.UserHomeDir()
-		dataDir := filepath.Join(home, ".kecs", "data")
+		dataDir := filepath.Join(home, ".kecs", "instances", stopV2InstanceName, "data")
 		
 		fmt.Printf("Deleting data directory: %s\n", dataDir)
 		if err := os.RemoveAll(dataDir); err != nil {
 			fmt.Printf("Warning: Failed to delete data directory: %v\n", err)
 		}
 	} else {
-		fmt.Println("Data directory preserved. Use --delete-data to remove it.")
+		fmt.Println("Instance data preserved. Use --delete-data to remove it.")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Implements KECS Instance concept to prevent confusion with ECS clusters
- Adds auto-generation of instance names when not specified
- Updates command flags from `--name` to `--instance`

## Changes
1. **start-v2 command**: Changed `--name` flag to `--instance` with auto-generation
2. **stop-v2 command**: Changed `--name` flag to `--instance` with validation
3. **Instance naming**: Uses existing name generator (adjective-noun pattern) when instance name not provided
4. **Data directories**: Now instance-specific: `.kecs/instances/<instance-name>/data/`
5. **Messaging**: All output messages now refer to "KECS instance" instead of "cluster"

## Test plan
- [x] Tested start-v2 with auto-generated instance name
- [x] Tested start-v2 with specified instance name
- [x] Tested stop-v2 with instance name
- [x] Verified data directory structure is instance-specific
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)