### PR TITLE
feat: Add interactive instance selection to stop-v2 command

### DIFF
--- a/controlplane/internal/kubernetes/k3d_cluster_manager.go
+++ b/controlplane/internal/kubernetes/k3d_cluster_manager.go
@@ -298,6 +298,24 @@ func (k *K3dClusterManager) ClusterExists(ctx context.Context, clusterName strin
 	return false, nil
 }
 
+// ListClusters returns a list of all k3d clusters
+func (k *K3dClusterManager) ListClusters(ctx context.Context) ([]string, error) {
+	clusters, err := client.ClusterList(ctx, k.runtime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	var clusterNames []string
+	for _, cluster := range clusters {
+		// Only include KECS clusters (those with kecs- prefix)
+		if strings.HasPrefix(cluster.Name, "kecs-") {
+			clusterNames = append(clusterNames, cluster.Name)
+		}
+	}
+
+	return clusterNames, nil
+}
+
 // GetKubeClient returns a Kubernetes client for the specified cluster
 func (k *K3dClusterManager) GetKubeClient(clusterName string) (kubernetes.Interface, error) {
 	normalizedName := k.normalizeClusterName(clusterName)


### PR DESCRIPTION
## Summary
- Added interactive instance selection to the `stop-v2` command when `--instance` flag is not provided
- Users can now select from a list of running KECS instances using an interactive terminal UI

## Changes
- Added `ListClusters` method to `K3dClusterManager` that returns all KECS instances (filtered by "kecs-" prefix)
- Modified `runStopV2` to show an interactive selection prompt using pterm when no instance is specified
- Added pterm import for interactive terminal UI components

## Test plan
- [x] Build the updated binary
- [x] Create test k3d clusters with "kecs-" prefix
- [x] Run `kecs stop-v2` without --instance flag to verify interactive selection appears
- [x] Verify that only KECS instances (with "kecs-" prefix) are shown in the list
- [x] Verify selection works and proceeds with stopping the selected instance

## Demo
When running `kecs stop-v2` without specifying an instance:
```
$ kecs stop-v2
▀  Fetching KECS instances (0s)

Select KECS instance to stop [type to search]: 
> kecs-test-2
  kecs-test-1
```

🤖 Generated with [Claude Code](https://claude.ai/code)