### PR TITLE
fix: Replace Traefik CRD with file-based dynamic configuration

### DIFF
--- a/controlplane/internal/controlplane/cmd/start_v2.go
+++ b/controlplane/internal/controlplane/cmd/start_v2.go
@@ -234,7 +234,7 @@ func createK3dCluster(ctx context.Context, clusterName string, cfg *config.Confi
 	clusterConfig := &kubernetes.ClusterManagerConfig{
 		Provider:      "k3d",
 		ContainerMode: false,
-		EnableTraefik: true, // Enable Traefik for the new architecture
+		EnableTraefik: false, // Disable old Traefik deployment (we use our own)
 		TraefikPort:   startV2ApiPort, // Use the API port for Traefik
 		VolumeMounts: []kubernetes.VolumeMount{
 			{
@@ -410,7 +410,7 @@ func deployLocalStack(ctx context.Context, clusterName string, cfg *config.Confi
 		Services:      cfg.LocalStack.Services,
 		Port:          4566,
 		EdgePort:      4566,
-		ProxyEndpoint: "http://traefik.kecs-system.svc.cluster.local:4566",
+		ProxyEndpoint: "http://localhost:4566",
 		ContainerMode: false, // We're deploying in k8s, not standalone container
 		Image:         cfg.LocalStack.Image,
 		Version:       cfg.LocalStack.Version,
@@ -740,7 +740,7 @@ func deployLocalStackWithProgress(ctx context.Context, clusterName string, cfg *
 		Services:      cfg.LocalStack.Services,
 		Port:          4566,
 		EdgePort:      4566,
-		ProxyEndpoint: "http://traefik.kecs-system.svc.cluster.local:4566",
+		ProxyEndpoint: "http://localhost:4566",
 		ContainerMode: false,
 		Image:         cfg.LocalStack.Image,
 		Version:       cfg.LocalStack.Version,

--- a/controlplane/internal/controlplane/cmd/start_v2_bubbletea.go
+++ b/controlplane/internal/controlplane/cmd/start_v2_bubbletea.go
@@ -188,7 +188,7 @@ func createK3dClusterWithProgress(ctx context.Context, clusterName string, cfg *
 	clusterConfig := &kubernetes.ClusterManagerConfig{
 		Provider:      "k3d",
 		ContainerMode: false,
-		EnableTraefik: true,
+		EnableTraefik: false, // Disable old Traefik deployment (we use our own)
 		TraefikPort:   startV2ApiPort,
 		VolumeMounts: []kubernetes.VolumeMount{
 			{
@@ -391,7 +391,7 @@ func deployLocalStackWithBubbleTeaProgress(ctx context.Context, clusterName stri
 		Services:      cfg.LocalStack.Services,
 		Port:          4566,
 		EdgePort:      4566,
-		ProxyEndpoint: "http://traefik.kecs-system.svc.cluster.local:4566",
+		ProxyEndpoint: "http://localhost:4566",
 		ContainerMode: false,
 		Image:         cfg.LocalStack.Image,
 		Version:       cfg.LocalStack.Version,

--- a/controlplane/internal/kubernetes/deployer.go
+++ b/controlplane/internal/kubernetes/deployer.go
@@ -126,9 +126,13 @@ func (d *ResourceDeployer) DeployTraefik(ctx context.Context, config *resources.
 		return fmt.Errorf("failed to create cluster role binding: %w", err)
 	}
 	
-	// Deploy ConfigMap
+	// Deploy ConfigMaps
 	if err := d.applyConfigMap(ctx, res.ConfigMap); err != nil {
 		return fmt.Errorf("failed to create config map: %w", err)
+	}
+	
+	if err := d.applyConfigMap(ctx, res.DynamicConfigMap); err != nil {
+		return fmt.Errorf("failed to create dynamic config map: %w", err)
 	}
 	
 	// Deploy Services


### PR DESCRIPTION
## Summary
- Replaced Traefik CRD-based routing with file-based dynamic configuration
- Fixed LocalStack health check endpoint accessibility from host
- Eliminated CRD timeout errors during deployment

## Problem
1. Traefik CRDs were not installed, causing timeout errors: `Failed to ensure Traefik CRDs: timeout`
2. LocalStack health check was not accessible from host at `http://traefik.kecs-system.svc.cluster.local:4566`
3. Routing between KECS API and LocalStack was not working properly

## Solution
Implemented file-based dynamic configuration for Traefik, which is simpler and more reliable than CRDs.

## Changes
- **traefik.go**:
  - Removed IngressRoute CRD and unstructured dependencies
  - Added `createTraefikDynamicConfigMap()` for file-based routing
  - Changed provider from `kubernetesCRD` to `file`
  - Added dynamic config volume mount to deployment
  - Routes `/v1` → KECS API, `/` → LocalStack

- **deployer.go**:
  - Updated to deploy DynamicConfigMap alongside main ConfigMap

- **start_v2.go & start_v2_bubbletea.go**:
  - Set `EnableTraefik: false` to disable old TraefikManager
  - Changed ProxyEndpoint to `http://localhost:4566` for host access

## Test Results
```bash
# LocalStack health check now works
$ curl http://localhost:4566/_localstack/health
{"services": {"iam": "available", "logs": "available", ...}, "edition": "community", "version": "4.6.1.dev35"}

# ECS API routing works
$ curl -X POST http://localhost:4566/v1/ \
  -H "X-Amz-Target: AmazonEC2ContainerServiceV20141113.DescribeClusters" \
  -H "Content-Type: application/x-amz-json-1.1" \
  -d '{}'
{}
```

## Benefits
- No CRD installation required
- More stable and predictable routing
- Simpler configuration management
- No timeout errors during deployment
- Compatible with any Kubernetes version

🤖 Generated with [Claude Code](https://claude.ai/code)