### PR TITLE
Fix Traefik NodePort configuration and remove unnecessary health checks

### DIFF
--- a/controlplane/internal/kubernetes/deployer.go
+++ b/controlplane/internal/kubernetes/deployer.go
@@ -103,12 +103,8 @@ func (d *ResourceDeployer) DeployControlPlane(ctx context.Context, config *resou
 func (d *ResourceDeployer) DeployTraefik(ctx context.Context, config *resources.TraefikConfig) error {
 	klog.Info("Deploying Traefik gateway resources")
 	
-	// Deploy Traefik CRDs first if we have extClient
-	if d.extClient != nil {
-		if err := d.deployTraefikCRDs(ctx); err != nil {
-			return fmt.Errorf("failed to deploy Traefik CRDs: %w", err)
-		}
-	}
+	// Skip CRD deployment - using file-based configuration instead
+	// CRDs are not needed with file provider
 	
 	// Create resources
 	res := resources.CreateTraefikResources(config)
@@ -147,12 +143,8 @@ func (d *ResourceDeployer) DeployTraefik(ctx context.Context, config *resources.
 		return fmt.Errorf("failed to create deployment: %w", err)
 	}
 	
-	// Deploy IngressRoutes if we have the necessary clients
-	if d.config != nil {
-		if err := d.deployTraefikRoutes(ctx); err != nil {
-			return fmt.Errorf("failed to deploy Traefik routes: %w", err)
-		}
-	}
+	// Skip IngressRoute deployment - using file-based configuration
+	// Routes are defined in the dynamic ConfigMap instead
 	
 	klog.Info("Traefik resources deployed successfully")
 	return nil

--- a/controlplane/internal/kubernetes/resources/traefik.go
+++ b/controlplane/internal/kubernetes/resources/traefik.go
@@ -129,16 +129,7 @@ func createTraefikClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{"ingresses", "ingressclasses"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
-			// Traefik CRDs
-			{
-				APIGroups: []string{"traefik.io", "traefik.containo.us"},
-				Resources: []string{
-					"middlewares", "middlewaretcps", "ingressroutes", "traefikservices",
-					"ingressroutetcps", "ingressrouteudps", "tlsoptions", "tlsstores",
-					"serverstransports", "serverstransporttcps",
-				},
-				Verbs: []string{"get", "list", "watch"},
-			},
+			// Traefik CRDs - removed as we use file-based configuration
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed Traefik NodePort to use valid port 30890 instead of dynamic API port
- Removed unnecessary LocalStack HTTP health checks from host
- Removed unnecessary KECS admin API health checks from host
- Fixed k3d port mapping to work regardless of EnableTraefik setting
- Removed Traefik CRD deployment and IngressRoute references
- Removed CRD permissions from Traefik ClusterRole

## Problem
The deployment was failing due to:
1. Invalid NodePort values (dynamic ports outside the valid 30000-32767 range)
2. Unnecessary external health checks failing due to DNS resolution issues
3. Deprecated CRD-based routing configuration

## Solution
1. **Fixed NodePort Configuration**: Changed Traefik AWS NodePort from dynamic API port to fixed port 30890, which is within the valid NodePort range
2. **Removed External Health Checks**: 
   - For k8s deployments, pod readiness/liveness probes are sufficient
   - External HTTP health checks from the host were failing due to DNS resolution issues
   - Now only relying on Kubernetes pod status checks
3. **Fixed k3d Port Mapping**: The port mapping now works for HTTP access regardless of whether Traefik is enabled
4. **Simplified Traefik Configuration**: 
   - Removed CRD deployment as we're using file-based configuration
   - Removed unnecessary CRD permissions from ClusterRole
   - Routes are now defined in the dynamic ConfigMap instead of IngressRoutes

## Test Plan
- [x] Run `kecs start` and verify deployment completes successfully
- [x] Verify Traefik is accessible on the configured port
- [x] Verify LocalStack is accessible through Traefik
- [ ] Test with both `--enable-traefik` and without
- [ ] Run scenario tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)