### PR TITLE
fix: Route ECS API calls correctly based on X-Amz-Target header

### DIFF
--- a/controlplane/internal/kubernetes/resources/traefik.go
+++ b/controlplane/internal/kubernetes/resources/traefik.go
@@ -424,7 +424,7 @@ func createTraefikDynamicConfigMap() *corev1.ConfigMap {
     ecs-api:
       entryPoints:
         - aws
-      rule: "Headers(` + "`X-Amz-Target`" + `, ` + "`AmazonEC2ContainerServiceV20141113.*`" + `)"
+      rule: "HeaderRegexp(` + "`X-Amz-Target`" + `, ` + "`^AmazonEC2ContainerServiceV20141113\\\\..*`" + `)"
       service: ecs-api
       priority: 100
     # Legacy ECS API routing for path-based requests


### PR DESCRIPTION
## Summary
- Fix ECS API routing to correctly handle AWS CLI requests
- AWS CLI sends ECS API requests to `/` with `X-Amz-Target` header containing `AmazonEC2ContainerService`
- Previously all requests to `/` were being routed to LocalStack, causing ECS commands to fail

## Changes
- Add header-based routing rule for ECS API calls using `HeadersRegexp` in Traefik
- Check for `X-Amz-Target` header starting with `AmazonEC2ContainerService`
- Maintain backward compatibility with legacy `/v1` path routing
- Higher priority (100) for header-based routing ensures it takes precedence

## Test Plan
- [x] Start KECS instance with LocalStack enabled
- [x] Run `aws ecs create-cluster --cluster-name test-cluster --profile kecs`
- [x] Verify the request is routed to KECS API, not LocalStack
- [ ] Verify cluster is created successfully
- [ ] Test other AWS services still route to LocalStack correctly

🤖 Generated with [Claude Code](https://claude.ai/code)