### PR TITLE
fix: Update ECS cluster creation to use namespaces instead of k3d clusters

### DIFF
--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -22,12 +22,13 @@ type Config struct {
 
 // ServerConfig represents server-specific configuration
 type ServerConfig struct {
-	Port           int      `yaml:"port" mapstructure:"port"`
-	AdminPort      int      `yaml:"adminPort" mapstructure:"adminPort"`
-	DataDir        string   `yaml:"dataDir" mapstructure:"dataDir"`
-	LogLevel       string   `yaml:"logLevel" mapstructure:"logLevel"`
-	AllowedOrigins []string `yaml:"allowedOrigins" mapstructure:"allowedOrigins"`
-	Endpoint       string   `yaml:"endpoint" mapstructure:"endpoint"`
+	Port              int      `yaml:"port" mapstructure:"port"`
+	AdminPort         int      `yaml:"adminPort" mapstructure:"adminPort"`
+	DataDir           string   `yaml:"dataDir" mapstructure:"dataDir"`
+	LogLevel          string   `yaml:"logLevel" mapstructure:"logLevel"`
+	AllowedOrigins    []string `yaml:"allowedOrigins" mapstructure:"allowedOrigins"`
+	Endpoint          string   `yaml:"endpoint" mapstructure:"endpoint"`
+	ControlPlaneImage string   `yaml:"controlPlaneImage" mapstructure:"controlPlaneImage"`
 }
 
 // KubernetesConfig represents Kubernetes-related configuration
@@ -83,6 +84,7 @@ func InitConfig() error {
 	v.SetDefault("server.logLevel", "info")
 	v.SetDefault("server.allowedOrigins", []string{})
 	v.SetDefault("server.endpoint", "")
+	v.SetDefault("server.controlPlaneImage", "ghcr.io/nandemo-ya/kecs:latest")
 	
 	// Kubernetes defaults
 	v.SetDefault("kubernetes.kubeconfigPath", "")
@@ -144,6 +146,7 @@ func bindLegacyEnvVars() {
 	v.BindEnv("features.traefik", "KECS_ENABLE_TRAEFIK", "KECS_FEATURES_TRAEFIK")
 	v.BindEnv("localstack.enabled", "KECS_LOCALSTACK_ENABLED")
 	v.BindEnv("localstack.useTraefik", "KECS_LOCALSTACK_USE_TRAEFIK")
+	v.BindEnv("server.controlPlaneImage", "KECS_CONTROLPLANE_IMAGE")
 }
 
 // DefaultConfig returns the default configuration

--- a/controlplane/internal/controlplane/api/cluster_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api_test.go
@@ -52,11 +52,9 @@ var _ = Describe("Cluster ECS API", func() {
 				cluster, err := mockClusterStore.Get(ctx, "test-cluster")
 				Expect(err).NotTo(HaveOccurred())
 
-				// Verify that the k8s cluster name follows the expected pattern
-				Expect(cluster.K8sClusterName).To(HavePrefix("kecs-"))
-
-				// Should be kecs-<cluster-name>
-				Expect(cluster.K8sClusterName).To(Equal("kecs-test-cluster"))
+				// In the new design, all ECS clusters share the same k3d cluster (KECS instance)
+				// Since we don't have a real KECS instance in tests, it defaults to "kecs-default"
+				Expect(cluster.K8sClusterName).To(Equal("kecs-default"))
 			})
 
 			It("should create different random names for different clusters", func() {
@@ -82,8 +80,10 @@ var _ = Describe("Cluster ECS API", func() {
 				cluster2, err := mockClusterStore.Get(ctx, "test-cluster-2")
 				Expect(err).NotTo(HaveOccurred())
 
-				// Verify the two clusters have different k8s cluster names
-				Expect(cluster1.K8sClusterName).NotTo(Equal(cluster2.K8sClusterName))
+				// In the new design, all ECS clusters share the same k3d cluster (KECS instance)
+				// So both clusters should have the same k8s cluster name
+				Expect(cluster1.K8sClusterName).To(Equal(cluster2.K8sClusterName))
+				Expect(cluster1.K8sClusterName).To(Equal("kecs-default"))
 			})
 		})
 

--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -342,7 +342,7 @@ func deployControlPlane(ctx context.Context, clusterName string, cfg *config.Con
 
 	// Configure control plane
 	controlPlaneConfig := &resources.ControlPlaneConfig{
-		Image:           "ghcr.io/nandemo-ya/kecs:latest",
+		Image:           cfg.Server.ControlPlaneImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CPURequest:      "100m",
 		MemoryRequest:   "128Mi",
@@ -356,6 +356,10 @@ func deployControlPlane(ctx context.Context, clusterName string, cfg *config.Con
 			{
 				Name:  "KECS_SKIP_SECURITY_DISCLAIMER",
 				Value: "true",
+			},
+			{
+				Name:  "KECS_INSTANCE_NAME",
+				Value: clusterName,
 			},
 		},
 	}
@@ -650,7 +654,7 @@ func deployControlPlaneWithProgress(ctx context.Context, clusterName string, cfg
 	
 	// Configure control plane
 	controlPlaneConfig := &resources.ControlPlaneConfig{
-		Image:           "ghcr.io/nandemo-ya/kecs:latest",
+		Image:           cfg.Server.ControlPlaneImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CPURequest:      "100m",
 		MemoryRequest:   "128Mi",
@@ -664,6 +668,10 @@ func deployControlPlaneWithProgress(ctx context.Context, clusterName string, cfg
 			{
 				Name:  "KECS_SKIP_SECURITY_DISCLAIMER",
 				Value: "true",
+			},
+			{
+				Name:  "KECS_INSTANCE_NAME",
+				Value: clusterName,
 			},
 		},
 	}

--- a/controlplane/internal/controlplane/cmd/start_bubbletea.go
+++ b/controlplane/internal/controlplane/cmd/start_bubbletea.go
@@ -308,7 +308,7 @@ func deployControlPlaneWithBubbleTeaProgress(ctx context.Context, clusterName st
 	
 	// Configure control plane
 	controlPlaneConfig := &resources.ControlPlaneConfig{
-		Image:           "ghcr.io/nandemo-ya/kecs:latest",
+		Image:           cfg.Server.ControlPlaneImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CPURequest:      "100m",
 		MemoryRequest:   "128Mi",
@@ -322,6 +322,10 @@ func deployControlPlaneWithBubbleTeaProgress(ctx context.Context, clusterName st
 			{
 				Name:  "KECS_SKIP_SECURITY_DISCLAIMER",
 				Value: "true",
+			},
+			{
+				Name:  "KECS_INSTANCE_NAME",
+				Value: clusterName,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Changed ECS cluster creation to use Kubernetes namespaces instead of creating new k3d clusters
- Added support for KECS_CONTROLPLANE_IMAGE environment variable
- Fixed the cluster creation implementation to align with the new architecture

## Changes
1. **Updated cluster creation logic**:
   - `createK8sClusterAndNamespace` now only creates namespaces within the existing KECS instance
   - `ensureK8sClusterExists` checks namespace existence instead of creating k3d clusters  
   - `deleteK8sClusterAndNamespace` only deletes namespaces, not k3d clusters

2. **Added KECS instance name detection**:
   - Added `getKecsInstanceName()` method that checks KECS_INSTANCE_NAME env var
   - Falls back to detecting from hostname when running inside k3d
   - Uses default name if detection fails

3. **Added control plane image configuration**:
   - Added `KECS_CONTROLPLANE_IMAGE` environment variable support
   - Added `server.controlPlaneImage` configuration field
   - Allows custom control plane images to be specified

4. **Updated tests**:
   - Fixed test expectations to reflect that all ECS clusters share the same k3d cluster name

## New Architecture
- **KECS instance** = one k3d cluster (created during `kecs start`)
- **ECS clusters** = Kubernetes namespaces within that k3d cluster
- No new k3d clusters are created when creating ECS clusters

## Test plan
- [x] Unit tests pass
- [ ] Manual testing with actual KECS instance
- [ ] Create multiple ECS clusters and verify they use namespaces
- [ ] Verify KECS_CONTROLPLANE_IMAGE works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)