### PR TITLE
fix: Use in-cluster config for namespace operations when running in Kubernetes

### DIFF
--- a/controlplane/internal/kubernetes/kubeconfig.go
+++ b/controlplane/internal/kubernetes/kubeconfig.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -23,4 +24,26 @@ func GetKubeConfig() (*rest.Config, error) {
 	config.Burst = 200
 
 	return config, nil
+}
+
+// GetInClusterClient returns a Kubernetes clientset using in-cluster configuration
+// This should be used when the control plane is running inside a Kubernetes pod
+func GetInClusterClient() (*kubernetes.Clientset, error) {
+	// Get in-cluster configuration
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Adjust config for better performance
+	config.QPS = 100
+	config.Burst = 200
+
+	// Create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
 }


### PR DESCRIPTION
## Summary
- Add support for in-cluster Kubernetes configuration to avoid Docker dependency
- Control plane can now create/delete namespaces when running inside Kubernetes

## Changes
1. **Added `GetInClusterClient` function**:
   - Creates Kubernetes clientset using in-cluster configuration
   - Uses ServiceAccount credentials when running as a Pod

2. **Updated namespace operations**:
   - `createNamespaceForCluster`: Try in-cluster config first, fall back to cluster manager
   - `deleteK8sClusterAndNamespace`: Same fallback logic
   - Improved log messages to clarify when in-cluster config fails

## Context
When the control plane runs inside Kubernetes (as deployed by `kecs start`), it needs to use in-cluster configuration instead of trying to access Docker through k3d cluster manager. This allows namespace operations to work properly without Docker socket access.

The control plane Pod already has appropriate ServiceAccount and RBAC permissions configured in the deployment.

## Test Results
All tests pass. In-cluster config failures are expected during local development/testing.

🤖 Generated with [Claude Code](https://claude.ai/code)