### PR TITLE
feat: Improve Bubble Tea UX for text selection and scrolling

### DIFF
--- a/controlplane/internal/progress/bubbletea/model.go
+++ b/controlplane/internal/progress/bubbletea/model.go
@@ -155,9 +155,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "l":
 			m.showLogs = !m.showLogs
+		case "up", "k":
+			// Scroll up
+			m.logViewport.LineUp(1)
+		case "down", "j":
+			// Scroll down
+			m.logViewport.LineDown(1)
+		case "pgup":
+			// Page up
+			m.logViewport.ViewUp()
+		case "pgdown":
+			// Page down
+			m.logViewport.ViewDown()
+		case "home":
+			// Go to top
+			m.logViewport.GotoTop()
+		case "end":
+			// Go to bottom
+			m.logViewport.GotoBottom()
 		}
 		
-		// Handle viewport scrolling
+		// Handle viewport scrolling for other keys
 		var cmd tea.Cmd
 		m.logViewport, cmd = m.logViewport.Update(msg)
 		cmds = append(cmds, cmd)
@@ -368,7 +386,7 @@ func (m Model) renderLogSection() string {
 func (m Model) renderFooter() string {
 	help := "l: toggle logs • q: quit"
 	if m.showLogs {
-		help = "↑/↓: scroll logs • " + help
+		help = "↑/↓/j/k: scroll • PgUp/PgDn: page • Home/End: top/bottom • " + help
 	}
 	
 	return lipgloss.NewStyle().

--- a/controlplane/internal/progress/bubbletea/program.go
+++ b/controlplane/internal/progress/bubbletea/program.go
@@ -36,8 +36,8 @@ func NewProgram(title string) *Program {
 	// Create the program with full screen mode
 	teaProgram := tea.NewProgram(
 		model,
-		tea.WithAltScreen(),       // Use alternate screen buffer
-		tea.WithMouseCellMotion(), // Enable mouse support
+		tea.WithAltScreen(),     // Use alternate screen buffer
+		// No mouse capture - allows text selection while keyboard controls work for scrolling
 	)
 	
 	lc.program = teaProgram


### PR DESCRIPTION
## Summary
- Enable text selection in terminal by removing mouse capture
- Add comprehensive keyboard controls for log scrolling
- Improve user experience with clear navigation instructions

## Changes
1. **Removed mouse capture**: Terminal text can now be selected and copied
2. **Added keyboard scrolling controls**:
   - `↑/↓` or `j/k`: Line by line scrolling
   - `PgUp/PgDn`: Page scrolling  
   - `Home/End`: Jump to top/bottom
3. **Updated footer**: Shows all available scroll controls when logs are visible

## User Impact
- Users can now copy/paste from the terminal output
- Intuitive keyboard navigation for scrolling through logs
- Clear instructions in the UI for available controls

## Test plan
- [x] Build and test keyboard scrolling works
- [x] Verify text selection works in terminal
- [ ] Test on different terminals (iTerm2, Terminal.app, etc.)
- [ ] Verify no regressions in progress display

🤖 Generated with [Claude Code](https://claude.ai/code)