### PR TITLE
feat: Suppress k3d logs in both verbose and bubbletea modes

### DIFF
--- a/controlplane/cmd/controlplane/main.go
+++ b/controlplane/cmd/controlplane/main.go
@@ -1,16 +1,8 @@
 package main
 
 import (
-	"os"
-	
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd"
 )
-
-func init() {
-	// Set environment variable to suppress k3d logs
-	// This will be checked by our kubernetes package
-	os.Setenv("K3D_LOG_LEVEL", "panic")
-}
 
 func main() {
 	cmd.Execute()

--- a/controlplane/internal/kubernetes/init_k3d_log.go
+++ b/controlplane/internal/kubernetes/init_k3d_log.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"io"
-	"os"
 	
 	"github.com/k3d-io/k3d/v5/pkg/logger"
 	"github.com/sirupsen/logrus"
@@ -10,24 +9,22 @@ import (
 )
 
 func init() {
-	// Check if we should suppress k3d logs
-	if os.Getenv("K3D_LOG_LEVEL") == "panic" || os.Getenv("LOGRUS_LEVEL") == "panic" {
-		// Suppress k3d's logger
-		if logger.Logger != nil {
-			logger.Logger.SetLevel(logrus.PanicLevel)
-			logger.Logger.SetOutput(io.Discard)
-		}
-		
-		// Suppress logrus completely
-		logrus.SetLevel(logrus.PanicLevel)
-		logrus.SetOutput(io.Discard)
-		logrus.StandardLogger().SetLevel(logrus.PanicLevel)
-		logrus.StandardLogger().SetOutput(io.Discard)
-		
-		// Disable all hooks
-		logrus.StandardLogger().Hooks = make(logrus.LevelHooks)
-		
-		// Also suppress klog which k3d might use
-		klog.SetOutput(io.Discard)
+	// Always suppress k3d logs for cleaner output
+	// Suppress k3d's logger
+	if logger.Logger != nil {
+		logger.Logger.SetLevel(logrus.PanicLevel)
+		logger.Logger.SetOutput(io.Discard)
 	}
+	
+	// Suppress logrus completely
+	logrus.SetLevel(logrus.PanicLevel)
+	logrus.SetOutput(io.Discard)
+	logrus.StandardLogger().SetLevel(logrus.PanicLevel)
+	logrus.StandardLogger().SetOutput(io.Discard)
+	
+	// Disable all hooks
+	logrus.StandardLogger().Hooks = make(logrus.LevelHooks)
+	
+	// Also suppress klog which k3d might use
+	klog.SetOutput(io.Discard)
 }

--- a/controlplane/internal/kubernetes/k3d_cluster_manager.go
+++ b/controlplane/internal/kubernetes/k3d_cluster_manager.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/k3d-io/k3d/v5/pkg/client"
 	"github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
-	"github.com/k3d-io/k3d/v5/pkg/logger"
 	"github.com/k3d-io/k3d/v5/pkg/runtimes"
 	"github.com/k3d-io/k3d/v5/pkg/runtimes/docker"
 	k3d "github.com/k3d-io/k3d/v5/pkg/types"
@@ -40,25 +38,6 @@ type K3dClusterManager struct {
 
 // NewK3dClusterManager creates a new k3d-based cluster manager
 func NewK3dClusterManager(cfg *ClusterManagerConfig) (*K3dClusterManager, error) {
-	// Apply log suppression if environment variables are set
-	if os.Getenv("K3D_LOG_LEVEL") == "panic" || os.Getenv("LOGRUS_LEVEL") == "panic" {
-		// Set k3d's logger to panic level
-		if logger.Logger != nil {
-			logger.Logger.SetLevel(logrus.PanicLevel)
-			logger.Logger.SetOutput(io.Discard)
-		}
-		
-		// Also set the standard logrus logger
-		logrus.SetLevel(logrus.PanicLevel)
-		logrus.SetOutput(io.Discard)
-		
-		// Also set the standard logger
-		logrus.StandardLogger().SetLevel(logrus.PanicLevel)
-		logrus.StandardLogger().SetOutput(io.Discard)
-		
-		// Disable all loggers
-		logrus.SetReportCaller(false)
-	}
 	
 	if cfg == nil {
 		cfg = &ClusterManagerConfig{


### PR DESCRIPTION
## Summary
- Suppress k3d INFO logs that appear during cluster creation
- Works in both verbose (`--verbose`) and default bubbletea modes
- Uses k3d's logger instance directly as intended by k3d Issue #583

## Implementation Details
- Configure k3d's `logger.Logger` instance to use panic level and discard output
- Removed unnecessary log suppression code and imports

## Testing
- Tested in verbose mode: k3d logs no longer appear
- Tested in bubbletea mode: k3d logs no longer appear
- All existing tests pass

## Before
```
INFO[0000] Prep: Network
INFO[0000] Created network 'k3d-kecs-instance'
INFO[0000] Starting node 'k3d-kecs-instance-server-0'
```

## After
Clean output without k3d INFO logs in both modes.

🤖 Generated with [Claude Code](https://claude.ai/code)