### PR TITLE
docs: Remove manual ecsTaskExecutionRole creation from examples

### DIFF
--- a/examples/batch-job-simple/README.md
+++ b/examples/batch-job-simple/README.md
@@ -65,35 +65,7 @@ aws logs create-log-group \
   --endpoint-url http://localhost:8080
 ```
 
-### 4. Create IAM Roles
-
-```bash
-# Task Execution Role
-aws iam create-role \
-  --role-name ecsTaskExecutionRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-
-# Task Role
-aws iam create-role \
-  --role-name ecsTaskRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-```
+Note: The `ecsTaskExecutionRole` is automatically created by KECS when it starts LocalStack. No need to create it manually.
 
 ## Running Batch Jobs
 

--- a/examples/microservice-with-elb/README.md
+++ b/examples/microservice-with-elb/README.md
@@ -86,35 +86,7 @@ aws logs create-log-group \
   --endpoint-url http://localhost:8080
 ```
 
-### 4. Create IAM Roles
-
-```bash
-# Task Execution Role
-aws iam create-role \
-  --role-name ecsTaskExecutionRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-
-# Task Role
-aws iam create-role \
-  --role-name ecsTaskRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-```
+Note: The `ecsTaskExecutionRole` is automatically created by KECS when it starts LocalStack. No need to create it manually.
 
 ### 5. Create Load Balancer Resources
 

--- a/examples/multi-container-webapp/README.md
+++ b/examples/multi-container-webapp/README.md
@@ -69,41 +69,7 @@ aws logs create-log-group \
   --endpoint-url http://localhost:8080
 ```
 
-### 4. Create IAM Roles
-
-```bash
-# Task Execution Role
-aws iam create-role \
-  --role-name ecsTaskExecutionRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-
-# Attach policy for ECR and CloudWatch Logs
-aws iam attach-role-policy \
-  --role-name ecsTaskExecutionRole \
-  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy \
-  --endpoint-url http://localhost:8080
-
-# Task Role
-aws iam create-role \
-  --role-name ecsTaskRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-```
+Note: The `ecsTaskExecutionRole` is automatically created by KECS when it starts LocalStack. No need to create it manually.
 
 ## Deployment
 
@@ -282,13 +248,7 @@ aws logs delete-log-group \
   --endpoint-url http://localhost:8080
 
 # Delete IAM roles (if created for this example)
-aws iam detach-role-policy \
-  --role-name ecsTaskExecutionRole \
-  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy \
-  --endpoint-url http://localhost:8080
-
-aws iam delete-role --role-name ecsTaskExecutionRole --endpoint-url http://localhost:8080
-aws iam delete-role --role-name ecsTaskRole --endpoint-url http://localhost:8080
+# Note: ecsTaskExecutionRole is managed by KECS, no need to delete it
 ```
 
 ## Advanced Testing

--- a/examples/service-with-secrets/README.md
+++ b/examples/service-with-secrets/README.md
@@ -150,20 +150,9 @@ aws secretsmanager list-secrets \
 
 ### 5. Create IAM Roles with Proper Permissions
 
-```bash
-# Create Task Execution Role
-aws iam create-role \
-  --role-name ecsTaskExecutionRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:4566
+Note: The `ecsTaskExecutionRole` is automatically created by KECS when it starts LocalStack.
 
+```bash
 # Create policy for accessing secrets
 aws iam create-policy \
   --policy-name ECSSecretsPolicy \
@@ -202,6 +191,7 @@ aws iam create-policy \
   --endpoint-url http://localhost:4566
 
 # Attach policies to execution role
+# Note: ecsTaskExecutionRole is auto-created by KECS, we just need to attach additional policies
 aws iam attach-role-policy \
   --role-name ecsTaskExecutionRole \
   --policy-arn arn:aws:iam::000000000000:policy/ECSSecretsPolicy \
@@ -448,6 +438,7 @@ aws ssm delete-parameter \
   --endpoint-url http://localhost:4566
 
 # Delete IAM resources
+# Note: Only detach the policy from ecsTaskExecutionRole, don't delete the role itself as it's managed by KECS
 aws iam detach-role-policy \
   --role-name ecsTaskExecutionRole \
   --policy-arn arn:aws:iam::000000000000:policy/ECSSecretsPolicy \
@@ -455,10 +446,6 @@ aws iam detach-role-policy \
 
 aws iam delete-policy \
   --policy-arn arn:aws:iam::000000000000:policy/ECSSecretsPolicy \
-  --endpoint-url http://localhost:4566
-
-aws iam delete-role \
-  --role-name ecsTaskExecutionRole \
   --endpoint-url http://localhost:4566
 
 aws iam delete-role \

--- a/examples/single-task-nginx/README.md
+++ b/examples/single-task-nginx/README.md
@@ -40,35 +40,7 @@ aws logs create-log-group \
   --endpoint-url http://localhost:8080
 ```
 
-### 4. Create IAM Roles (if using LocalStack)
-
-```bash
-# Task Execution Role
-aws iam create-role \
-  --role-name ecsTaskExecutionRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-
-# Task Role
-aws iam create-role \
-  --role-name ecsTaskRole \
-  --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-      "Action": "sts:AssumeRole"
-    }]
-  }' \
-  --endpoint-url http://localhost:8080
-```
+Note: The `ecsTaskExecutionRole` is automatically created by KECS when it starts LocalStack. No need to create it manually.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
Updated all example READMEs to reflect that `ecsTaskExecutionRole` is now automatically created by KECS when it starts LocalStack.

## Changes
- Removed manual IAM role creation steps from all example setup instructions
- Added notes explaining the auto-creation feature
- Updated cleanup sections to not delete the managed role
- The service-with-secrets example still creates custom policies and attaches them to the auto-created role

## Related
This follows up on PR #388 which added automatic `ecsTaskExecutionRole` creation.

## Test plan
- [ ] Review documentation changes for accuracy
- [ ] Verify examples still work with the updated instructions

🤖 Generated with [Claude Code](https://claude.ai/code)