### PR TITLE
fix: Remove k3d cluster readiness check and make service creation idempotent

### DIFF
--- a/controlplane/internal/kubernetes/service_manager.go
+++ b/controlplane/internal/kubernetes/service_manager.go
@@ -86,11 +86,6 @@ func (sm *ServiceManager) CreateService(
 		return nil
 	}
 
-	// Wait for cluster to be ready (with 60 second timeout)
-	if err := sm.clusterManager.WaitForClusterReady(cluster.K8sClusterName, 60*time.Second); err != nil {
-		return fmt.Errorf("cluster is not ready: %w", err)
-	}
-
 	// Get Kubernetes client for the cluster
 	kubeClient, err := sm.clusterManager.GetKubeClient(cluster.K8sClusterName)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove unnecessary k3d cluster readiness check in service creation
- Make CreateService idempotent by returning existing service instead of error

## Problem
1. **k3d cluster readiness check delay**: When creating a service, there was a "Waiting for k3d cluster to be ready" message with a 60-second timeout. This is unnecessary in the new architecture where controlplane always runs inside Kubernetes as a Pod.

2. **Duplicate service creation error**: When AWS CLI retries service creation (e.g., due to timeout), the second attempt would fail with a duplicate key constraint error, even though the service was successfully created on the first attempt.

## Solution
1. **Removed cluster readiness check**: Since controlplane runs inside the k3d cluster in the new architecture, there's no need to wait for cluster readiness.

2. **Made CreateService idempotent**: When a service with the same name already exists, return the existing service instead of an error. This handles AWS CLI's retry mechanism gracefully.

## Test plan
- [ ] Create a new service - should work without "Waiting for k3d cluster" delay
- [ ] Try creating the same service again - should succeed and return existing service
- [ ] Test with AWS CLI retries - should handle gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)