### PR TITLE
fix: Fix ECS service creation not deploying to Kubernetes

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_ecs_api.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api.go
@@ -76,7 +76,11 @@ func (api *DefaultECSAPI) CreateCluster(ctx context.Context, req *generated.Crea
 	if api.clusterManager != nil {
 		// For now, we'll use a simple approach - look for a k3d cluster
 		// In a real implementation, this should be passed from the server configuration
-		k8sClusterName = api.getKecsInstanceName()
+		instanceName := api.getKecsInstanceName()
+		if instanceName != "" {
+			// The k3d cluster name has "kecs-" prefix
+			k8sClusterName = fmt.Sprintf("kecs-%s", instanceName)
+		}
 	}
 	
 	if k8sClusterName == "" {


### PR DESCRIPTION
## Summary
- Fixed K8sClusterName format to include 'kecs-' prefix
- Updated ServiceManager to use single Kubernetes client for all ECS clusters
- Added proper handling for services in DRAINING/FAILED states

## Problem
ECS service creation was not creating corresponding Kubernetes Deployment and Pods. The issue was that:
1. The K8sClusterName stored in the database didn't have the correct format
2. ServiceManager was trying to get different Kubernetes clients for each ECS cluster, but in the new architecture there's only one k3d cluster

## Solution
- Fixed cluster creation to store the k3d cluster name with "kecs-" prefix
- Modified ServiceManager to use a single Kubernetes client that connects to the KECS instance
- Added handling to allow recreating services that are in DRAINING/FAILED states

## Test Plan
✅ Tested locally:
1. Started KECS instance: `kecs start --instance test-fix`
2. Created ECS cluster: `aws ecs create-cluster --cluster-name default`
3. Registered task definition: `aws ecs register-task-definition --cli-input-json file://examples/single-task-nginx/task_def.json`
4. Created service: `aws ecs create-service --cli-input-json file://examples/single-task-nginx/service_def.json`
5. Verified Kubernetes resources: `kubectl get all -n default-us-east-1`
6. Verified nginx is running: `kubectl exec -n default-us-east-1 deployment/ecs-service-nginx-new-image -- curl -s localhost`

## Related Issues
- Created #397 for the task synchronization issue (pods are created but ECS tasks are not tracked in storage)

🤖 Generated with [Claude Code](https://claude.ai/code)