### PR TITLE
feat: Implement Kubernetes to ECS state synchronization

### DIFF
--- a/controlplane/internal/controllers/sync/batch_updater.go
+++ b/controlplane/internal/controllers/sync/batch_updater.go
@@ -1,0 +1,205 @@
+package sync
+
+import (
+	"context"
+	stdsync "sync"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	"k8s.io/klog/v2"
+)
+
+// Type aliases to avoid any potential confusion
+type StorageService = storage.Service
+type StorageTask = storage.Task
+
+// BatchUpdater efficiently batches updates to the storage layer
+type BatchUpdater struct {
+	storage      storage.Storage
+	serviceCache map[string]*StorageService // key is service ARN
+	taskCache    map[string]*StorageTask    // key is task ARN
+	mu           stdsync.Mutex
+	ticker       *time.Ticker
+	stopCh       chan struct{}
+	flushCh      chan struct{} // Channel to trigger immediate flush
+	batchSize    int
+	maxDelay     time.Duration
+}
+
+// NewBatchUpdater creates a new batch updater
+func NewBatchUpdater(storage storage.Storage, batchSize int, maxDelay time.Duration) *BatchUpdater {
+	return &BatchUpdater{
+		storage:      storage,
+		serviceCache: make(map[string]*StorageService),
+		taskCache:    make(map[string]*StorageTask),
+		batchSize:    batchSize,
+		maxDelay:     maxDelay,
+		stopCh:       make(chan struct{}),
+		flushCh:      make(chan struct{}, 1),
+	}
+}
+
+// Start begins the batch update process
+func (b *BatchUpdater) Start(ctx context.Context) {
+	b.ticker = time.NewTicker(b.maxDelay)
+	defer b.ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			b.flush(ctx)
+			return
+		case <-b.stopCh:
+			b.flush(ctx)
+			return
+		case <-b.ticker.C:
+			b.flush(ctx)
+		case <-b.flushCh:
+			b.flush(ctx)
+		}
+	}
+}
+
+// Stop stops the batch updater and flushes pending updates
+func (b *BatchUpdater) Stop(ctx context.Context) {
+	close(b.stopCh)
+	// Give it time to flush
+	time.Sleep(100 * time.Millisecond)
+}
+
+// AddServiceUpdate adds a service update to the batch
+func (b *BatchUpdater) AddServiceUpdate(service *StorageService) {
+	if service == nil || service.ARN == "" {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.serviceCache[service.ARN] = service
+
+	// Trigger immediate flush if batch size reached
+	if len(b.serviceCache) >= b.batchSize {
+		select {
+		case b.flushCh <- struct{}{}:
+		default:
+			// Channel is full, flush will happen soon anyway
+		}
+	}
+}
+
+// AddTaskUpdate adds a task update to the batch
+func (b *BatchUpdater) AddTaskUpdate(task *StorageTask) {
+	if task == nil || task.ARN == "" {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.taskCache[task.ARN] = task
+
+	// Trigger immediate flush if batch size reached
+	if len(b.taskCache) >= b.batchSize {
+		select {
+		case b.flushCh <- struct{}{}:
+		default:
+			// Channel is full, flush will happen soon anyway
+		}
+	}
+}
+
+// flush performs the actual batch update
+func (b *BatchUpdater) flush(ctx context.Context) {
+	b.mu.Lock()
+	
+	// Copy and clear the caches
+	services := make([]*StorageService, 0, len(b.serviceCache))
+	for _, svc := range b.serviceCache {
+		services = append(services, svc)
+	}
+	b.serviceCache = make(map[string]*StorageService)
+
+	tasks := make([]*StorageTask, 0, len(b.taskCache))
+	for _, task := range b.taskCache {
+		tasks = append(tasks, task)
+	}
+	b.taskCache = make(map[string]*StorageTask)
+	
+	b.mu.Unlock()
+
+	// Update services
+	if len(services) > 0 {
+		klog.V(3).Infof("Flushing %d service updates", len(services))
+		for _, service := range services {
+			if err := b.updateService(ctx, service); err != nil {
+				klog.Errorf("Failed to update service %s: %v", service.ServiceName, err)
+			}
+		}
+	}
+
+	// Update tasks
+	if len(tasks) > 0 {
+		klog.V(3).Infof("Flushing %d task updates", len(tasks))
+		for _, task := range tasks {
+			if err := b.updateTask(ctx, task); err != nil {
+				klog.Errorf("Failed to update task %s: %v", task.ARN, err)
+			}
+		}
+	}
+}
+
+// updateService updates a single service in storage
+func (b *BatchUpdater) updateService(ctx context.Context, service *StorageService) error {
+	// Check if service exists
+	existingService, err := b.storage.ServiceStore().Get(ctx, service.ClusterARN, service.ServiceName)
+	if err != nil {
+		// Service doesn't exist, create it
+		return b.storage.ServiceStore().Create(ctx, service)
+	}
+
+	// Merge with existing service to preserve fields we don't sync
+	mergedService := b.mergeServices(existingService, service)
+	return b.storage.ServiceStore().Update(ctx, mergedService)
+}
+
+// mergeServices merges the synced service data with existing service data
+func (b *BatchUpdater) mergeServices(existing, updated *StorageService) *StorageService {
+	// Start with existing service
+	merged := *existing
+
+	// Update fields that are synced from Kubernetes
+	merged.Status = updated.Status
+	merged.DesiredCount = updated.DesiredCount
+	merged.RunningCount = updated.RunningCount
+	merged.PendingCount = updated.PendingCount
+	merged.UpdatedAt = updated.UpdatedAt
+
+	// Update deployment configuration if provided
+	if updated.DeploymentConfiguration != "" {
+		merged.DeploymentConfiguration = updated.DeploymentConfiguration
+	}
+
+	return &merged
+}
+
+// updateTask updates a single task in storage
+func (b *BatchUpdater) updateTask(ctx context.Context, task *StorageTask) error {
+	// For tasks, we create or update
+	_, err := b.storage.TaskStore().Get(ctx, task.ClusterARN, task.ARN)
+	if err != nil {
+		// Task doesn't exist, create it
+		return b.storage.TaskStore().Create(ctx, task)
+	}
+	// Task exists, update it
+	return b.storage.TaskStore().Update(ctx, task)
+}
+
+// Flush forces an immediate flush of pending updates
+func (b *BatchUpdater) Flush() {
+	select {
+	case b.flushCh <- struct{}{}:
+	default:
+		// Channel is full, flush will happen soon anyway
+	}
+}

--- a/controlplane/internal/controllers/sync/controller.go
+++ b/controlplane/internal/controllers/sync/controller.go
@@ -1,0 +1,380 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	appslistersv1 "k8s.io/client-go/listers/apps/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+// SyncController manages the synchronization of Kubernetes resources to ECS state
+type SyncController struct {
+	kubeClient       kubernetes.Interface
+	storage          storage.Storage
+	deploymentLister appslistersv1.DeploymentLister
+	replicaSetLister appslistersv1.ReplicaSetLister
+	podLister        corelistersv1.PodLister
+	eventLister      corelistersv1.EventLister
+
+	// Informer synced flags
+	deploymentsSynced cache.InformerSynced
+	replicaSetsSynced cache.InformerSynced
+	podsSynced        cache.InformerSynced
+	eventsSynced      cache.InformerSynced
+
+	// Work queues for different resource types
+	deploymentQueue workqueue.RateLimitingInterface
+	podQueue        workqueue.RateLimitingInterface
+
+	// Batch updater for efficient storage updates
+	batchUpdater *BatchUpdater
+
+	// Configuration
+	workers      int
+	resyncPeriod time.Duration
+}
+
+// NewSyncController creates a new synchronization controller
+func NewSyncController(
+	kubeClient kubernetes.Interface,
+	storage storage.Storage,
+	deploymentInformer appsinformers.DeploymentInformer,
+	replicaSetInformer appsinformers.ReplicaSetInformer,
+	podInformer coreinformers.PodInformer,
+	eventInformer coreinformers.EventInformer,
+	workers int,
+	resyncPeriod time.Duration,
+) *SyncController {
+	controller := &SyncController{
+		kubeClient:       kubeClient,
+		storage:          storage,
+		deploymentLister: deploymentInformer.Lister(),
+		replicaSetLister: replicaSetInformer.Lister(),
+		podLister:        podInformer.Lister(),
+		eventLister:      eventInformer.Lister(),
+
+		deploymentsSynced: deploymentInformer.Informer().HasSynced,
+		replicaSetsSynced: replicaSetInformer.Informer().HasSynced,
+		podsSynced:        podInformer.Informer().HasSynced,
+		eventsSynced:      eventInformer.Informer().HasSynced,
+
+		deploymentQueue: workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			"deployments",
+		),
+		podQueue: workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			"pods",
+		),
+
+		workers:      workers,
+		resyncPeriod: resyncPeriod,
+	}
+
+	// Create batch updater with reasonable defaults
+	controller.batchUpdater = NewBatchUpdater(storage, 100, 2*time.Second)
+
+	// Set up event handlers
+	deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.handleDeploymentAdd,
+		UpdateFunc: controller.handleDeploymentUpdate,
+		DeleteFunc: controller.handleDeploymentDelete,
+	})
+
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.handlePodAdd,
+		UpdateFunc: controller.handlePodUpdate,
+		DeleteFunc: controller.handlePodDelete,
+	})
+
+	return controller
+}
+
+// Run starts the controller
+func (c *SyncController) Run(ctx context.Context) error {
+	defer runtime.HandleCrash()
+	defer c.deploymentQueue.ShutDown()
+	defer c.podQueue.ShutDown()
+
+	klog.Info("Starting sync controller")
+
+	// Start batch updater
+	go c.batchUpdater.Start(ctx)
+	defer c.batchUpdater.Stop(ctx)
+
+	// Wait for informer caches to sync
+	klog.Info("Waiting for informer caches to sync")
+	if !cache.WaitForCacheSync(ctx.Done(),
+		c.deploymentsSynced,
+		c.replicaSetsSynced,
+		c.podsSynced,
+		c.eventsSynced,
+	) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.Info("Starting workers")
+	// Start workers
+	for i := 0; i < c.workers; i++ {
+		go wait.UntilWithContext(ctx, c.runDeploymentWorker, time.Second)
+		go wait.UntilWithContext(ctx, c.runPodWorker, time.Second)
+	}
+
+	klog.Info("Sync controller started")
+	<-ctx.Done()
+	klog.Info("Shutting down sync controller")
+
+	return nil
+}
+
+// runDeploymentWorker processes items from the deployment work queue
+func (c *SyncController) runDeploymentWorker(ctx context.Context) {
+	for c.processNextDeployment(ctx) {
+	}
+}
+
+// runPodWorker processes items from the pod work queue
+func (c *SyncController) runPodWorker(ctx context.Context) {
+	for c.processNextPod(ctx) {
+	}
+}
+
+// processNextDeployment processes the next item from the deployment queue
+func (c *SyncController) processNextDeployment(ctx context.Context) bool {
+	key, quit := c.deploymentQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.deploymentQueue.Done(key)
+
+	err := c.syncDeployment(ctx, key.(string))
+	if err == nil {
+		c.deploymentQueue.Forget(key)
+		return true
+	}
+
+	runtime.HandleError(fmt.Errorf("error syncing deployment '%s': %v", key, err))
+
+	// Re-queue with rate limiting
+	if c.deploymentQueue.NumRequeues(key) < 5 {
+		klog.Infof("Retrying deployment %s", key)
+		c.deploymentQueue.AddRateLimited(key)
+		return true
+	}
+
+	c.deploymentQueue.Forget(key)
+	klog.Infof("Dropping deployment %s out of the queue after 5 retries", key)
+	return true
+}
+
+// processNextPod processes the next item from the pod queue
+func (c *SyncController) processNextPod(ctx context.Context) bool {
+	key, quit := c.podQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.podQueue.Done(key)
+
+	err := c.syncPod(ctx, key.(string))
+	if err == nil {
+		c.podQueue.Forget(key)
+		return true
+	}
+
+	runtime.HandleError(fmt.Errorf("error syncing pod '%s': %v", key, err))
+
+	// Re-queue with rate limiting
+	if c.podQueue.NumRequeues(key) < 5 {
+		klog.Infof("Retrying pod %s", key)
+		c.podQueue.AddRateLimited(key)
+		return true
+	}
+
+	c.podQueue.Forget(key)
+	klog.Infof("Dropping pod %s out of the queue after 5 retries", key)
+	return true
+}
+
+// syncDeployment syncs a deployment to ECS service state
+func (c *SyncController) syncDeployment(ctx context.Context, key string) error {
+	klog.V(4).Infof("Syncing deployment: %s", key)
+	return c.syncService(ctx, key)
+}
+
+
+// Deployment event handlers
+func (c *SyncController) handleDeploymentAdd(obj interface{}) {
+	deployment := obj.(*appsv1.Deployment)
+	if !isECSManagedDeployment(deployment) {
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(deployment)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	klog.V(4).Infof("ECS deployment added: %s", deployment.Name)
+	c.deploymentQueue.Add(key)
+}
+
+func (c *SyncController) handleDeploymentUpdate(oldObj, newObj interface{}) {
+	oldDep := oldObj.(*appsv1.Deployment)
+	newDep := newObj.(*appsv1.Deployment)
+	
+	if !isECSManagedDeployment(newDep) {
+		return
+	}
+	
+	// Only sync if status changed or scaling occurred
+	if oldDep.Status.Replicas != newDep.Status.Replicas ||
+		oldDep.Status.ReadyReplicas != newDep.Status.ReadyReplicas ||
+		oldDep.Status.UpdatedReplicas != newDep.Status.UpdatedReplicas ||
+		oldDep.Status.AvailableReplicas != newDep.Status.AvailableReplicas ||
+		hasDeploymentConditionChanged(oldDep, newDep) {
+		key, err := cache.MetaNamespaceKeyFunc(newDep)
+		if err != nil {
+			runtime.HandleError(err)
+			return
+		}
+		klog.V(4).Infof("ECS deployment updated: %s (replicas: %d/%d ready)", 
+			newDep.Name, newDep.Status.ReadyReplicas, newDep.Status.Replicas)
+		c.deploymentQueue.Add(key)
+	}
+}
+
+func (c *SyncController) handleDeploymentDelete(obj interface{}) {
+	deployment := obj.(*appsv1.Deployment)
+	if !isECSManagedDeployment(deployment) {
+		return
+	}
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	klog.V(4).Infof("ECS deployment deleted: %s", deployment.Name)
+	c.deploymentQueue.Add(key)
+}
+
+// Pod event handlers
+func (c *SyncController) handlePodAdd(obj interface{}) {
+	pod := obj.(*corev1.Pod)
+	if !isECSManagedPod(pod) {
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	c.podQueue.Add(key)
+}
+
+func (c *SyncController) handlePodUpdate(oldObj, newObj interface{}) {
+	oldPod := oldObj.(*corev1.Pod)
+	newPod := newObj.(*corev1.Pod)
+	
+	if !isECSManagedPod(newPod) {
+		return
+	}
+	
+	// Only sync if status changed
+	if oldPod.Status.Phase != newPod.Status.Phase ||
+		len(oldPod.Status.ContainerStatuses) != len(newPod.Status.ContainerStatuses) {
+		key, err := cache.MetaNamespaceKeyFunc(newPod)
+		if err != nil {
+			runtime.HandleError(err)
+			return
+		}
+		c.podQueue.Add(key)
+	}
+}
+
+func (c *SyncController) handlePodDelete(obj interface{}) {
+	pod := obj.(*corev1.Pod)
+	if !isECSManagedPod(pod) {
+		return
+	}
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	klog.V(4).Infof("Pod deleted: %s", pod.Name)
+	c.podQueue.Add(key)
+}
+
+// isECSManagedPod checks if a pod is managed by KECS
+func isECSManagedPod(pod *corev1.Pod) bool {
+	// Check if pod has KECS management label
+	if val, exists := pod.Labels["kecs.dev/managed-by"]; exists && val == "kecs" {
+		return true
+	}
+	// Also check for ECS-specific labels
+	if _, exists := pod.Labels["ecs.amazonaws.com/task-arn"]; exists {
+		return true
+	}
+	return false
+}
+
+// isECSManagedDeployment checks if a deployment is managed by KECS
+func isECSManagedDeployment(deployment *appsv1.Deployment) bool {
+	// Check if deployment has ECS service prefix
+	if strings.HasPrefix(deployment.Name, "ecs-service-") {
+		return true
+	}
+	
+	// Check labels
+	if val, exists := deployment.Labels["kecs.dev/managed-by"]; exists && val == "kecs" {
+		return true
+	}
+	
+	// Check for ECS-specific annotations
+	if _, exists := deployment.Annotations["ecs.amazonaws.com/task-definition"]; exists {
+		return true
+	}
+	
+	return false
+}
+
+// hasDeploymentConditionChanged checks if deployment conditions have changed
+func hasDeploymentConditionChanged(oldDep, newDep *appsv1.Deployment) bool {
+	// Check if number of conditions changed
+	if len(oldDep.Status.Conditions) != len(newDep.Status.Conditions) {
+		return true
+	}
+	
+	// Create a map of old conditions for comparison
+	oldConditions := make(map[appsv1.DeploymentConditionType]appsv1.DeploymentCondition)
+	for _, c := range oldDep.Status.Conditions {
+		oldConditions[c.Type] = c
+	}
+	
+	// Compare each new condition with old
+	for _, newCond := range newDep.Status.Conditions {
+		if oldCond, exists := oldConditions[newCond.Type]; exists {
+			if oldCond.Status != newCond.Status || oldCond.Reason != newCond.Reason {
+				return true
+			}
+		} else {
+			// New condition added
+			return true
+		}
+	}
+	
+	return false
+}

--- a/controlplane/internal/controllers/sync/informers.go
+++ b/controlplane/internal/controllers/sync/informers.go
@@ -1,0 +1,170 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// InformerConfig holds configuration for setting up informers
+type InformerConfig struct {
+	// ResyncPeriod is how often the informer will do a full resync
+	ResyncPeriod time.Duration
+	
+	// Namespace to watch, empty string means all namespaces
+	Namespace string
+	
+	// LabelSelector to filter resources
+	LabelSelector labels.Selector
+}
+
+// SetupInformers creates and configures the shared informer factory
+func SetupInformers(kubeClient kubernetes.Interface, config InformerConfig) informers.SharedInformerFactory {
+	// Create options for the informer factory
+	options := []informers.SharedInformerOption{}
+	
+	// Add namespace filter if specified
+	if config.Namespace != "" {
+		options = append(options, informers.WithNamespace(config.Namespace))
+	}
+	
+	// Add label selector if specified
+	if config.LabelSelector != nil {
+		options = append(options, informers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
+			listOptions.LabelSelector = config.LabelSelector.String()
+		}))
+	}
+	
+	// Create the shared informer factory with resync period
+	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, config.ResyncPeriod, options...)
+	
+	klog.V(2).Infof("Created shared informer factory with resync period: %v", config.ResyncPeriod)
+	
+	return factory
+}
+
+// StartInformers starts all registered informers and waits for their caches to sync
+func StartInformers(ctx context.Context, factory informers.SharedInformerFactory) error {
+	// Start all informers
+	factory.Start(ctx.Done())
+	
+	// Wait for caches to sync
+	klog.Info("Waiting for informer caches to sync...")
+	
+	// Get all the informers that were registered
+	synced := factory.WaitForCacheSync(ctx.Done())
+	for informerType, hasSynced := range synced {
+		if !hasSynced {
+			return fmt.Errorf("failed to sync informer cache for type: %v", informerType)
+		}
+		klog.V(2).Infof("Informer cache synced for type: %v", informerType)
+	}
+	
+	klog.Info("All informer caches synced successfully")
+	return nil
+}
+
+// NewControllerWithInformers creates a new sync controller with properly configured informers
+func NewControllerWithInformers(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	storage storage.Storage,
+	config InformerConfig,
+	workers int,
+) (*SyncController, error) {
+	// Create the informer factory
+	factory := SetupInformers(kubeClient, config)
+	
+	// Get specific informers we need
+	deploymentInformer := factory.Apps().V1().Deployments()
+	replicaSetInformer := factory.Apps().V1().ReplicaSets()
+	podInformer := factory.Core().V1().Pods()
+	eventInformer := factory.Core().V1().Events()
+	
+	// Create the controller
+	controller := NewSyncController(
+		kubeClient,
+		storage,
+		deploymentInformer,
+		replicaSetInformer,
+		podInformer,
+		eventInformer,
+		workers,
+		config.ResyncPeriod,
+	)
+	
+	// Start the informers
+	if err := StartInformers(ctx, factory); err != nil {
+		return nil, fmt.Errorf("failed to start informers: %w", err)
+	}
+	
+	return controller, nil
+}
+
+// WatchOptions provides options for watching specific resource types
+type WatchOptions struct {
+	// WatchDeployments enables watching deployment resources
+	WatchDeployments bool
+	
+	// WatchPods enables watching pod resources
+	WatchPods bool
+	
+	// WatchReplicaSets enables watching replicaset resources
+	WatchReplicaSets bool
+	
+	// WatchEvents enables watching event resources
+	WatchEvents bool
+	
+	// DeploymentSelector is an optional label selector for deployments
+	DeploymentSelector labels.Selector
+	
+	// PodSelector is an optional label selector for pods
+	PodSelector labels.Selector
+}
+
+// SetupSelectiveInformers creates informers only for selected resource types
+func SetupSelectiveInformers(
+	kubeClient kubernetes.Interface,
+	options WatchOptions,
+	resyncPeriod time.Duration,
+) informers.SharedInformerFactory {
+	// Create base factory
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		resyncPeriod,
+	)
+	
+	// Only create informers for resources we want to watch
+	if options.WatchDeployments {
+		deploymentInformer := factory.Apps().V1().Deployments()
+		klog.V(2).Info("Created deployment informer")
+		_ = deploymentInformer.Lister() // Force creation
+	}
+	
+	if options.WatchPods {
+		podInformer := factory.Core().V1().Pods()
+		klog.V(2).Info("Created pod informer")
+		_ = podInformer.Lister() // Force creation
+	}
+	
+	if options.WatchReplicaSets {
+		rsInformer := factory.Apps().V1().ReplicaSets()
+		klog.V(2).Info("Created replicaset informer")
+		_ = rsInformer.Lister() // Force creation
+	}
+	
+	if options.WatchEvents {
+		eventInformer := factory.Core().V1().Events()
+		klog.V(2).Info("Created event informer")
+		_ = eventInformer.Lister() // Force creation
+	}
+	
+	return factory
+}

--- a/controlplane/internal/controllers/sync/mappers/service_mapper.go
+++ b/controlplane/internal/controllers/sync/mappers/service_mapper.go
@@ -1,0 +1,211 @@
+package mappers
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceStateMapper maps Kubernetes deployment state to ECS service state
+type ServiceStateMapper struct{}
+
+// NewServiceStateMapper creates a new service state mapper
+func NewServiceStateMapper() *ServiceStateMapper {
+	return &ServiceStateMapper{}
+}
+
+// MapDeploymentToServiceStatus maps a Kubernetes deployment to ECS service status
+func (m *ServiceStateMapper) MapDeploymentToServiceStatus(deployment *appsv1.Deployment) string {
+	if deployment == nil {
+		return "INACTIVE"
+	}
+
+	// Check if deployment is being deleted
+	if deployment.DeletionTimestamp != nil {
+		return "DRAINING"
+	}
+
+	// Check deployment conditions for failures
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing && condition.Status == corev1.ConditionFalse {
+			// Check if it's a progress deadline exceeded
+			if strings.Contains(condition.Reason, "ProgressDeadlineExceeded") {
+				return "FAILED"
+			}
+		}
+		if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+			return "FAILED"
+		}
+	}
+
+	// Map based on replica counts
+	replicas := int32(0)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+
+	if replicas == 0 {
+		return "DRAINING"
+	}
+
+	readyReplicas := deployment.Status.ReadyReplicas
+	updatedReplicas := deployment.Status.UpdatedReplicas
+
+	// All replicas are ready and updated
+	if readyReplicas == replicas && updatedReplicas == replicas {
+		return "ACTIVE"
+	}
+
+	// No ready replicas yet
+	if readyReplicas == 0 && replicas > 0 {
+		return "PROVISIONING"
+	}
+
+	// Some replicas are ready but not all, or update in progress
+	if readyReplicas < replicas || updatedReplicas < replicas {
+		return "UPDATING"
+	}
+
+	return "ACTIVE"
+}
+
+// MapDeploymentToServiceCounts extracts desired, running, and pending counts from deployment
+func (m *ServiceStateMapper) MapDeploymentToServiceCounts(deployment *appsv1.Deployment) (desired, running, pending int32) {
+	if deployment == nil {
+		return 0, 0, 0
+	}
+
+	// Desired count from spec
+	if deployment.Spec.Replicas != nil {
+		desired = *deployment.Spec.Replicas
+	}
+
+	// Running count is ready replicas
+	running = deployment.Status.ReadyReplicas
+
+	// Pending count is total replicas minus ready replicas
+	totalReplicas := deployment.Status.Replicas
+	if totalReplicas > running {
+		pending = totalReplicas - running
+	}
+
+	return desired, running, pending
+}
+
+// ExtractServiceNameFromDeployment extracts the ECS service name from deployment name
+func (m *ServiceStateMapper) ExtractServiceNameFromDeployment(deploymentName string) string {
+	// Remove the "ecs-service-" prefix if present
+	return strings.TrimPrefix(deploymentName, "ecs-service-")
+}
+
+// ExtractClusterInfoFromNamespace extracts cluster name and region from namespace
+func (m *ServiceStateMapper) ExtractClusterInfoFromNamespace(namespace string) (clusterName, region string) {
+	// Expected format: kecs-<region>-<cluster-name>
+	if !strings.HasPrefix(namespace, "kecs-") {
+		return "", ""
+	}
+
+	parts := strings.SplitN(strings.TrimPrefix(namespace, "kecs-"), "-", 2)
+	if len(parts) >= 2 {
+		region = parts[0]
+		clusterName = parts[1]
+	}
+
+	return clusterName, region
+}
+
+// MapDeploymentToService creates an ECS service object from a deployment
+func (m *ServiceStateMapper) MapDeploymentToService(deployment *appsv1.Deployment, existingService *storage.Service) *storage.Service {
+	if deployment == nil {
+		return nil
+	}
+
+	serviceName := m.ExtractServiceNameFromDeployment(deployment.Name)
+	clusterName, region := m.ExtractClusterInfoFromNamespace(deployment.Namespace)
+
+	// Start with existing service or create new one
+	service := existingService
+	if service == nil {
+		service = &storage.Service{
+			ServiceName: serviceName,
+			ClusterARN:  generateClusterARN(region, clusterName),
+			Region:      region,
+			CreatedAt:   deployment.CreationTimestamp.Time,
+			LaunchType:  "FARGATE", // Default launch type
+		}
+	}
+
+	// Update status and counts
+	service.Status = m.MapDeploymentToServiceStatus(deployment)
+	desired, running, pending := m.MapDeploymentToServiceCounts(deployment)
+	service.DesiredCount = int(desired)
+	service.RunningCount = int(running)
+	service.PendingCount = int(pending)
+
+	// Update timestamps
+	service.UpdatedAt = time.Now()
+
+	// Extract task definition from deployment annotations
+	if taskDef, exists := deployment.Annotations["ecs.amazonaws.com/task-definition"]; exists {
+		service.TaskDefinitionARN = taskDef
+	}
+
+	// Create deployment info to store in DeploymentConfiguration field
+	deploymentInfo := generated.Deployment{
+		Id:               &deployment.Name,
+		Status:           &service.Status,
+		TaskDefinition:   &service.TaskDefinitionARN,
+		DesiredCount:     int32Ptr(int32(service.DesiredCount)),
+		RunningCount:     int32Ptr(int32(service.RunningCount)),
+		PendingCount:     int32Ptr(int32(service.PendingCount)),
+		CreatedAt:        timePtr(deployment.CreationTimestamp.Time),
+		UpdatedAt:        timePtr(time.Now()),
+		LaunchType:       (*generated.LaunchType)(stringPtr(service.LaunchType)),
+		PlatformVersion:  stringPtr(service.PlatformVersion),
+	}
+
+	// Serialize deployment info to JSON for storage
+	deployments := []generated.Deployment{deploymentInfo}
+	if _, err := json.Marshal(deployments); err == nil {
+		// Store deployments in a field - we could use the DeploymentConfiguration field
+		// or add metadata to track this information
+		// For now, we'll store it in DeploymentConfiguration as it's JSON
+		deploymentConfig := map[string]interface{}{
+			"deployments": deployments,
+		}
+		if configJSON, err := json.Marshal(deploymentConfig); err == nil {
+			service.DeploymentConfiguration = string(configJSON)
+		}
+	}
+
+	return service
+}
+
+// generateClusterARN generates an ECS cluster ARN
+func generateClusterARN(region, clusterName string) string {
+	if region == "" {
+		region = "us-east-1" // Default region
+	}
+	return "arn:aws:ecs:" + region + ":123456789012:cluster/" + clusterName
+}
+
+// Helper functions for pointer conversions
+func stringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/controlplane/internal/controllers/sync/mappers/task_mapper.go
+++ b/controlplane/internal/controllers/sync/mappers/task_mapper.go
@@ -1,0 +1,425 @@
+package mappers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TaskStateMapper maps Kubernetes pod state to ECS task state
+type TaskStateMapper struct{}
+
+// NewTaskStateMapper creates a new task state mapper
+func NewTaskStateMapper() *TaskStateMapper {
+	return &TaskStateMapper{}
+}
+
+// MapPodPhaseToTaskStatus maps Kubernetes pod phase to ECS task status
+func (m *TaskStateMapper) MapPodPhaseToTaskStatus(pod *corev1.Pod) (desiredStatus, lastStatus string) {
+	// Check if pod is being deleted
+	if pod.DeletionTimestamp != nil {
+		return "STOPPED", "DEPROVISIONING"
+	}
+
+	switch pod.Status.Phase {
+	case corev1.PodPending:
+		// Check container statuses for more detail
+		if len(pod.Status.ContainerStatuses) == 0 {
+			return "RUNNING", "PROVISIONING"
+		}
+		// Check if any containers are being created
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Waiting != nil && cs.State.Waiting.Reason == "ContainerCreating" {
+				return "RUNNING", "PENDING"
+			}
+		}
+		return "RUNNING", "PROVISIONING"
+
+	case corev1.PodRunning:
+		// Check if all containers are ready
+		allReady := true
+		for _, cs := range pod.Status.ContainerStatuses {
+			if !cs.Ready {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return "RUNNING", "RUNNING"
+		}
+		return "RUNNING", "ACTIVATING"
+
+	case corev1.PodSucceeded:
+		return "STOPPED", "STOPPED"
+
+	case corev1.PodFailed:
+		return "STOPPED", "STOPPED"
+
+	case corev1.PodUnknown:
+		return "STOPPED", "STOPPED"
+
+	default:
+		return "STOPPED", "STOPPED"
+	}
+}
+
+// MapPodToTask converts a Kubernetes pod to an ECS task
+func (m *TaskStateMapper) MapPodToTask(pod *corev1.Pod) *storage.Task {
+	if pod == nil {
+		return nil
+	}
+
+	// Extract task ARN from pod labels or generate one
+	taskARN := pod.Labels["ecs.amazonaws.com/task-arn"]
+	if taskARN == "" {
+		taskARN = m.generateTaskARN(pod)
+	}
+
+	// Get cluster ARN from namespace
+	clusterARN := m.getClusterARNFromNamespace(pod.Namespace)
+
+	// Get task definition ARN from pod labels
+	taskDefARN := pod.Labels["ecs.amazonaws.com/task-definition-arn"]
+
+	// Map pod phase to task status
+	desiredStatus, lastStatus := m.MapPodPhaseToTaskStatus(pod)
+
+	// Create task object
+	task := &storage.Task{
+		ARN:               taskARN,
+		ClusterARN:        clusterARN,
+		TaskDefinitionARN: taskDefARN,
+		DesiredStatus:     desiredStatus,
+		LastStatus:        lastStatus,
+		LaunchType:        "FARGATE",
+		CreatedAt:         pod.CreationTimestamp.Time,
+		Connectivity:      "CONNECTED",
+		HealthStatus:      m.extractHealthStatus(pod),
+		Containers:        m.serializeContainers(m.mapPodContainers(pod)),
+		PullStartedAt:     m.getPullStartedTime(pod),
+		PullStoppedAt:     m.getPullStoppedTime(pod),
+		StartedAt:         m.getPodStartTime(pod),
+		StoppedAt:         m.getPodStopTime(pod),
+		StoppingAt:        m.getPodStoppingTime(pod),
+		StoppedReason:     m.getPodStopReason(pod),
+	}
+
+	// Set connectivity time if pod is running
+	if pod.Status.Phase == corev1.PodRunning {
+		task.ConnectivityAt = m.getPodStartTime(pod)
+	}
+
+	// Extract service name from pod labels
+	if _, exists := pod.Labels["ecs.amazonaws.com/service-name"]; exists {
+		// ServiceName field doesn't exist in storage.Task
+		// This info would be part of the Task's relationship to Service
+	}
+
+	// Extract CPU and memory from pod spec
+	task.CPU, task.Memory = m.extractResourceLimits(pod)
+
+	return task
+}
+
+// mapPodContainers maps pod containers to ECS task containers
+func (m *TaskStateMapper) mapPodContainers(pod *corev1.Pod) []generated.Container {
+	var containers []generated.Container
+
+	for _, container := range pod.Spec.Containers {
+		// Find corresponding container status
+		var status *corev1.ContainerStatus
+		for j := range pod.Status.ContainerStatuses {
+			if pod.Status.ContainerStatuses[j].Name == container.Name {
+				status = &pod.Status.ContainerStatuses[j]
+				break
+			}
+		}
+
+		containerARN := fmt.Sprintf("%s/container/%s", pod.Labels["ecs.amazonaws.com/task-arn"], container.Name)
+		taskARN := pod.Labels["ecs.amazonaws.com/task-arn"]
+		taskContainer := generated.Container{
+			Name:              &container.Name,
+			Image:             &container.Image,
+			LastStatus:        stringPtr(m.mapContainerStatus(status)),
+			ContainerArn:      &containerARN,
+			TaskArn:           &taskARN,
+			NetworkInterfaces: m.getNetworkInterfaces(pod),
+		}
+
+		// Extract container state details
+		if status != nil {
+			taskContainer.ExitCode = m.getExitCodeInt32(status)
+			taskContainer.Reason = stringPtr(m.getContainerReason(status))
+			taskContainer.RuntimeId = &status.ContainerID
+			taskContainer.ImageDigest = &status.ImageID
+		}
+
+		// Extract resource limits
+		if container.Resources.Limits != nil {
+			if cpu := container.Resources.Limits.Cpu(); cpu != nil {
+				cpuStr := fmt.Sprintf("%d", cpu.MilliValue()/1000)
+				taskContainer.Cpu = &cpuStr
+			}
+			if mem := container.Resources.Limits.Memory(); mem != nil {
+				memStr := fmt.Sprintf("%d", mem.Value()/(1024*1024))
+				taskContainer.Memory = &memStr
+			}
+		}
+
+		containers = append(containers, taskContainer)
+	}
+
+	return containers
+}
+
+// mapContainerStatus maps Kubernetes container status to ECS container status
+func (m *TaskStateMapper) mapContainerStatus(status *corev1.ContainerStatus) string {
+	if status == nil {
+		return "PENDING"
+	}
+
+	if status.State.Running != nil {
+		if status.Ready {
+			return "RUNNING"
+		}
+		return "ACTIVATING"
+	}
+
+	if status.State.Terminated != nil {
+		return "STOPPED"
+	}
+
+	if status.State.Waiting != nil {
+		switch status.State.Waiting.Reason {
+		case "ContainerCreating":
+			return "PENDING"
+		case "PodInitializing":
+			return "PROVISIONING"
+		case "ImagePullBackOff", "ErrImagePull":
+			return "PENDING"
+		default:
+			return "PROVISIONING"
+		}
+	}
+
+	return "PENDING"
+}
+
+// mapContainerDesiredStatus maps container state to desired status
+func (m *TaskStateMapper) mapContainerDesiredStatus(status *corev1.ContainerStatus) string {
+	if status == nil {
+		return "RUNNING"
+	}
+
+	if status.State.Terminated != nil {
+		return "STOPPED"
+	}
+
+	return "RUNNING"
+}
+
+// Helper methods
+
+func (m *TaskStateMapper) generateTaskARN(pod *corev1.Pod) string {
+	region := "us-east-1" // Default region, should be extracted from cluster config
+	return fmt.Sprintf("arn:aws:ecs:%s:123456789012:task/%s/%s", region, pod.Namespace, pod.Name)
+}
+
+func (m *TaskStateMapper) getClusterARNFromNamespace(namespace string) string {
+	// Extract cluster name and region from namespace
+	clusterName, region := extractClusterInfoFromNamespace(namespace)
+	if region == "" {
+		region = "us-east-1"
+	}
+	return fmt.Sprintf("arn:aws:ecs:%s:123456789012:cluster/%s", region, clusterName)
+}
+
+func (m *TaskStateMapper) extractHealthStatus(pod *corev1.Pod) string {
+	for _, container := range pod.Status.ContainerStatuses {
+		if !container.Ready && container.State.Running != nil {
+			// Container is running but not ready, might be failing health checks
+			return "UNHEALTHY"
+		}
+	}
+
+	// All containers ready or not running
+	if pod.Status.Phase == corev1.PodRunning {
+		allReady := true
+		for _, container := range pod.Status.ContainerStatuses {
+			if !container.Ready {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return "HEALTHY"
+		}
+	}
+
+	return "UNKNOWN"
+}
+
+func (m *TaskStateMapper) getExitCodeInt32(status *corev1.ContainerStatus) *int32 {
+	if status != nil && status.State.Terminated != nil {
+		code := status.State.Terminated.ExitCode
+		return &code
+	}
+	return nil
+}
+
+func (m *TaskStateMapper) getContainerReason(status *corev1.ContainerStatus) string {
+	if status == nil {
+		return ""
+	}
+
+	if status.State.Terminated != nil {
+		return status.State.Terminated.Reason
+	}
+
+	if status.State.Waiting != nil {
+		return status.State.Waiting.Reason
+	}
+
+	return ""
+}
+
+func (m *TaskStateMapper) getPodStartTime(pod *corev1.Pod) *time.Time {
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.State.Running != nil {
+			return &container.State.Running.StartedAt.Time
+		}
+	}
+	return nil
+}
+
+func (m *TaskStateMapper) getPodStopTime(pod *corev1.Pod) *time.Time {
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		var latestStop *time.Time
+		for _, container := range pod.Status.ContainerStatuses {
+			if container.State.Terminated != nil {
+				if latestStop == nil || container.State.Terminated.FinishedAt.Time.After(*latestStop) {
+					latestStop = &container.State.Terminated.FinishedAt.Time
+				}
+			}
+		}
+		return latestStop
+	}
+	return nil
+}
+
+func (m *TaskStateMapper) getPodStoppingTime(pod *corev1.Pod) *time.Time {
+	if pod.DeletionTimestamp != nil {
+		return &pod.DeletionTimestamp.Time
+	}
+	return nil
+}
+
+func (m *TaskStateMapper) getPodStopReason(pod *corev1.Pod) string {
+	if pod.Status.Phase == corev1.PodFailed {
+		return pod.Status.Reason
+	}
+
+	// Check container reasons
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
+			return container.State.Terminated.Reason
+		}
+	}
+
+	if pod.DeletionTimestamp != nil {
+		return "Task stopped by user"
+	}
+
+	return ""
+}
+
+func (m *TaskStateMapper) getPullStartedTime(pod *corev1.Pod) *time.Time {
+	// This would need to be extracted from pod events
+	// For now, return pod creation time as an approximation
+	return &pod.CreationTimestamp.Time
+}
+
+func (m *TaskStateMapper) getPullStoppedTime(pod *corev1.Pod) *time.Time {
+	// This would need to be extracted from pod events
+	// For now, check if any container is running
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.State.Running != nil {
+			return &container.State.Running.StartedAt.Time
+		}
+	}
+	return nil
+}
+
+func (m *TaskStateMapper) getNetworkInterfaces(pod *corev1.Pod) []generated.NetworkInterface {
+	if pod.Status.PodIP == "" {
+		return nil
+	}
+
+	attachmentID := fmt.Sprintf("eni-%s", pod.UID)
+	return []generated.NetworkInterface{
+		{
+			AttachmentId:       &attachmentID,
+			PrivateIpv4Address: &pod.Status.PodIP,
+		},
+	}
+}
+
+// serializeContainers converts container objects to JSON string for storage
+func (m *TaskStateMapper) serializeContainers(containers []generated.Container) string {
+	if len(containers) == 0 {
+		return "[]"
+	}
+	data, err := json.Marshal(containers)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
+}
+
+
+func (m *TaskStateMapper) extractResourceLimits(pod *corev1.Pod) (cpu, memory string) {
+	totalCPU := int64(0)
+	totalMemory := int64(0)
+
+	for _, container := range pod.Spec.Containers {
+		if container.Resources.Limits != nil {
+			if cpuLimit := container.Resources.Limits.Cpu(); cpuLimit != nil {
+				totalCPU += cpuLimit.MilliValue()
+			}
+			if memLimit := container.Resources.Limits.Memory(); memLimit != nil {
+				totalMemory += memLimit.Value()
+			}
+		}
+	}
+
+	if totalCPU > 0 {
+		cpu = fmt.Sprintf("%d", totalCPU/1000) // Convert milliCPU to CPU units
+	}
+
+	if totalMemory > 0 {
+		memory = fmt.Sprintf("%d", totalMemory/(1024*1024)) // Convert bytes to MiB
+	}
+
+	return cpu, memory
+}
+
+// extractClusterInfoFromNamespace is a helper function shared with service mapper
+func extractClusterInfoFromNamespace(namespace string) (clusterName, region string) {
+	// Expected format: kecs-<region>-<cluster-name>
+	if !strings.HasPrefix(namespace, "kecs-") {
+		return "", ""
+	}
+
+	parts := strings.SplitN(strings.TrimPrefix(namespace, "kecs-"), "-", 2)
+	if len(parts) >= 2 {
+		region = parts[0]
+		clusterName = parts[1]
+	}
+
+	return clusterName, region
+}

--- a/controlplane/internal/controllers/sync/service_sync.go
+++ b/controlplane/internal/controllers/sync/service_sync.go
@@ -1,0 +1,119 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controllers/sync/mappers"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// syncService syncs a deployment to ECS service state
+func (c *SyncController) syncService(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("invalid resource key: %s", key)
+	}
+
+	// Check if this is an ECS-managed deployment
+	if !strings.HasPrefix(name, "ecs-service-") {
+		klog.V(4).Infof("Ignoring non-ECS deployment: %s", name)
+		return nil
+	}
+
+	// Get the deployment
+	deployment, err := c.deploymentLister.Deployments(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Deployment was deleted, update service to INACTIVE
+			return c.handleDeletedDeployment(ctx, namespace, name)
+		}
+		return fmt.Errorf("error fetching deployment: %v", err)
+	}
+
+	// Map deployment to service
+	mapper := mappers.NewServiceStateMapper()
+	serviceName := mapper.ExtractServiceNameFromDeployment(name)
+	clusterName, region := mapper.ExtractClusterInfoFromNamespace(namespace)
+
+	if clusterName == "" || region == "" {
+		klog.V(4).Infof("Could not extract cluster info from namespace: %s", namespace)
+		return nil
+	}
+
+	// Get existing service from storage
+	clusterARN := fmt.Sprintf("arn:aws:ecs:%s:123456789012:cluster/%s", region, clusterName)
+	existingService, err := c.storage.ServiceStore().Get(ctx, clusterARN, serviceName)
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("error getting service from storage: %v", err)
+	}
+
+	// Map deployment to service
+	service := mapper.MapDeploymentToService(deployment, existingService)
+	if service == nil {
+		return fmt.Errorf("failed to map deployment to service")
+	}
+
+	// Update service ARN if not set
+	if service.ARN == "" {
+		service.ARN = fmt.Sprintf("arn:aws:ecs:%s:123456789012:service/%s/%s", 
+			region, clusterName, serviceName)
+	}
+
+	// Add to batch updater for efficient storage update
+	c.batchUpdater.AddServiceUpdate(service)
+	klog.V(4).Infof("Queued service update %s in cluster %s", serviceName, clusterName)
+
+	// Log the sync result
+	klog.V(2).Infof("Successfully synced service %s: status=%s, desired=%d, running=%d, pending=%d",
+		serviceName, service.Status, service.DesiredCount, service.RunningCount, service.PendingCount)
+
+	return nil
+}
+
+// handleDeletedDeployment handles the case when a deployment is deleted
+func (c *SyncController) handleDeletedDeployment(ctx context.Context, namespace, deploymentName string) error {
+	mapper := mappers.NewServiceStateMapper()
+	serviceName := mapper.ExtractServiceNameFromDeployment(deploymentName)
+	clusterName, region := mapper.ExtractClusterInfoFromNamespace(namespace)
+
+	if clusterName == "" || region == "" {
+		return nil
+	}
+
+	clusterARN := fmt.Sprintf("arn:aws:ecs:%s:123456789012:cluster/%s", region, clusterName)
+	service, err := c.storage.ServiceStore().Get(ctx, clusterARN, serviceName)
+	if err != nil {
+		if isNotFound(err) {
+			// Service doesn't exist, nothing to do
+			return nil
+		}
+		return fmt.Errorf("error getting service: %v", err)
+	}
+
+	// Update service to INACTIVE
+	service.Status = "INACTIVE"
+	service.DesiredCount = 0
+	service.RunningCount = 0
+	service.PendingCount = 0
+	service.UpdatedAt = time.Now()
+
+	// Add to batch updater
+	c.batchUpdater.AddServiceUpdate(service)
+
+	klog.V(2).Infof("Marked service %s as INACTIVE due to deployment deletion", serviceName)
+	return nil
+}
+
+// isNotFound checks if an error indicates a resource was not found
+func isNotFound(err error) bool {
+	// Check for storage-specific not found error
+	// This should be implemented based on your storage interface
+	return strings.Contains(err.Error(), "not found") || 
+		strings.Contains(err.Error(), "does not exist")
+}
+

--- a/controlplane/internal/controllers/sync/task_sync.go
+++ b/controlplane/internal/controllers/sync/task_sync.go
@@ -1,0 +1,123 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controllers/sync/mappers"
+	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// syncTask syncs a pod to ECS task state
+func (c *SyncController) syncTask(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("invalid resource key: %s", key)
+	}
+
+	// Get the pod
+	pod, err := c.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Pod was deleted, update task to STOPPED
+			return c.handleDeletedPod(ctx, namespace, name)
+		}
+		return fmt.Errorf("error fetching pod: %v", err)
+	}
+
+	// Check if this is an ECS-managed pod
+	if !isECSManagedPod(pod) {
+		klog.V(4).Infof("Ignoring non-ECS pod: %s", name)
+		return nil
+	}
+
+	// Map pod to task
+	mapper := mappers.NewTaskStateMapper()
+	task := mapper.MapPodToTask(pod)
+	if task == nil {
+		return fmt.Errorf("failed to map pod to task")
+	}
+
+	// Add to batch updater for efficient storage update
+	c.batchUpdater.AddTaskUpdate(task)
+	klog.V(4).Infof("Queued task update for pod %s/%s", namespace, name)
+
+	// Log the sync result
+	klog.V(2).Infof("Successfully synced task %s: status=%s, health=%s",
+		task.ARN, task.LastStatus, task.HealthStatus)
+
+	return nil
+}
+
+// handleDeletedPod handles the case when a pod is deleted
+func (c *SyncController) handleDeletedPod(ctx context.Context, namespace, podName string) error {
+	// Generate the task ARN that would have been used
+	taskARN := fmt.Sprintf("arn:aws:ecs:us-east-1:123456789012:task/%s/%s", namespace, podName)
+	
+	// Try to get the existing task from storage
+	// Extract cluster info from namespace  
+	clusterName := namespace
+	region := "us-east-1"
+	if strings.HasPrefix(namespace, "kecs-") {
+		parts := strings.SplitN(strings.TrimPrefix(namespace, "kecs-"), "-", 2)
+		if len(parts) >= 2 {
+			region = parts[0]
+			clusterName = parts[1]
+		}
+	}
+	clusterARN := fmt.Sprintf("arn:aws:ecs:%s:123456789012:cluster/%s", region, clusterName)
+	
+	task, err := c.storage.TaskStore().Get(ctx, clusterARN, taskARN)
+	if err != nil {
+		if isNotFound(err) {
+			// Task doesn't exist, nothing to do
+			klog.V(4).Infof("Task not found for deleted pod %s/%s", namespace, podName)
+			return nil
+		}
+		return fmt.Errorf("error getting task: %v", err)
+	}
+
+	// Update task to STOPPED
+	task.DesiredStatus = "STOPPED"
+	task.LastStatus = "STOPPED"
+	task.StoppedReason = "Pod deleted"
+	task.StoppedAt = &[]time.Time{time.Now()}[0]
+
+	// Update all containers to STOPPED
+	var containers []generated.Container
+	if task.Containers != "" {
+		if err := json.Unmarshal([]byte(task.Containers), &containers); err == nil {
+			for i := range containers {
+				containers[i].LastStatus = stringPtr("STOPPED")
+				// DesiredStatus field doesn't exist in generated.Container
+			}
+			// Serialize back to JSON
+			if data, err := json.Marshal(containers); err == nil {
+				task.Containers = string(data)
+			}
+		}
+	}
+
+	// Add to batch updater
+	c.batchUpdater.AddTaskUpdate(task)
+
+	klog.V(2).Infof("Marked task %s as STOPPED due to pod deletion", taskARN)
+	return nil
+}
+
+// syncPod is the main entry point for pod synchronization
+func (c *SyncController) syncPod(ctx context.Context, key string) error {
+	klog.V(4).Infof("Syncing pod: %s", key)
+	return c.syncTask(ctx, key)
+}
+
+// stringPtr returns a pointer to the string
+func stringPtr(s string) *string {
+	return &s
+}

--- a/docs/adr/records/0020-kubernetes-ecs-state-synchronization.md
+++ b/docs/adr/records/0020-kubernetes-ecs-state-synchronization.md
@@ -1,0 +1,373 @@
+# 20. Kubernetes to ECS State Synchronization
+
+Date: 2025-07-24
+
+## Status
+
+Proposed
+
+## Context
+
+In the new KECS architecture, ECS resources (services and tasks) are backed by Kubernetes resources (deployments and pods). However, the current implementation does not synchronize the state between Kubernetes and the ECS API responses. This leads to:
+
+1. `aws ecs list-tasks` returning empty results even when pods are running
+2. Service status fields (runningCount, pendingCount) not reflecting actual Kubernetes state
+3. Task lifecycle events not being captured in ECS API responses
+4. Missing health check status and other runtime information
+
+## Decision
+
+We will implement a comprehensive state synchronization system that monitors Kubernetes resources and updates the corresponding ECS resources in storage. This system will use the Kubernetes informer framework for efficient resource watching and implement a controller pattern for state reconciliation.
+
+### Monitored Kubernetes Resources
+
+1. **Deployments** - Primary source for service state
+   - `spec.replicas` → `desiredCount`
+   - `status.readyReplicas` → `runningCount`
+   - `status.replicas - status.readyReplicas` → `pendingCount`
+   - `status.conditions` → service `status`
+
+2. **ReplicaSets** - For deployment history and detailed replica tracking
+   - Track deployment revisions
+   - More granular replica state information
+
+3. **Pods** - For individual task state
+   - `status.phase` → task `lastStatus`
+   - `status.containerStatuses` → container states
+   - `status.podIP` → network interfaces
+   - `metadata.creationTimestamp` → `startedAt`
+   - Pod deletion timestamp → `stoppedAt`
+
+4. **Events** - For service and task history
+   - Convert to ECS events format
+   - Track errors and warnings
+
+### State Mappings
+
+#### Service Status Mapping
+```
+Deployment State → ECS Service Status
+- No deployment found → INACTIVE
+- Replicas = 0 → DRAINING
+- ReadyReplicas = 0 && Replicas > 0 → PROVISIONING
+- ReadyReplicas < Replicas → UPDATING
+- ReadyReplicas = Replicas → ACTIVE
+- Deployment has failure condition → FAILED
+```
+
+#### Task Status Mapping
+```
+Pod Phase → ECS Task Status
+- Pending + no containers → PROVISIONING
+- Pending + containers creating → PENDING
+- Running + containers not ready → ACTIVATING
+- Running + all containers ready → RUNNING
+- Succeeded → STOPPED (exitCode from container)
+- Failed → STOPPED (with failure reason)
+- Unknown → STOPPED (connection lost)
+```
+
+## Implementation Plan
+
+### Phase 1: Core Synchronization Framework (Week 1-2)
+
+1. **Create base controller structure**
+```go
+// pkg/controllers/sync/controller.go
+type SyncController struct {
+    kubeClient        kubernetes.Interface
+    storage           storage.Storage
+    deploymentLister  appslistersv1.DeploymentLister
+    replicaSetLister  appslistersv1.ReplicaSetLister
+    podLister         corelistersv1.PodLister
+    eventLister       corelistersv1.EventLister
+    workqueue         workqueue.RateLimitingInterface
+}
+```
+
+2. **Implement informer setup**
+```go
+// pkg/controllers/sync/informers.go
+func (c *SyncController) SetupInformers(stopCh <-chan struct{}) error {
+    // Create shared informer factory
+    factory := informers.NewSharedInformerFactory(c.kubeClient, time.Minute)
+    
+    // Setup deployment informer
+    deploymentInformer := factory.Apps().V1().Deployments()
+    deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+        AddFunc:    c.handleDeploymentAdd,
+        UpdateFunc: c.handleDeploymentUpdate,
+        DeleteFunc: c.handleDeploymentDelete,
+    })
+    
+    // Similar setup for pods, replicasets, events
+    // ...
+}
+```
+
+3. **Create state mapper utilities**
+```go
+// pkg/controllers/sync/mappers/service_mapper.go
+type ServiceStateMapper struct{}
+
+func (m *ServiceStateMapper) MapDeploymentToServiceStatus(deployment *appsv1.Deployment) string {
+    // Implementation of state mapping logic
+}
+
+func (m *ServiceStateMapper) MapDeploymentToServiceCounts(deployment *appsv1.Deployment) (desired, running, pending int) {
+    // Extract counts from deployment status
+}
+```
+
+### Phase 2: Service Synchronization (Week 2-3)
+
+1. **Implement service sync logic**
+```go
+// pkg/controllers/sync/service_sync.go
+func (c *SyncController) syncService(key string) error {
+    // Parse namespace/name from key
+    namespace, name, _ := cache.SplitMetaNamespaceKey(key)
+    
+    // Get deployment
+    deployment, err := c.deploymentLister.Deployments(namespace).Get(name)
+    
+    // Map to ECS service name (remove ecs-service- prefix)
+    serviceName := strings.TrimPrefix(name, "ecs-service-")
+    
+    // Get ECS cluster from namespace
+    clusterName, region := parseNamespace(namespace)
+    
+    // Update service in storage
+    return c.updateServiceState(clusterName, serviceName, deployment)
+}
+```
+
+2. **Add deployment event handlers**
+```go
+func (c *SyncController) handleDeploymentUpdate(old, new interface{}) {
+    newDep := new.(*appsv1.Deployment)
+    oldDep := old.(*appsv1.Deployment)
+    
+    // Only sync if status changed
+    if !reflect.DeepEqual(oldDep.Status, newDep.Status) {
+        c.enqueueDeployment(newDep)
+    }
+}
+```
+
+3. **Implement batch updates**
+```go
+// pkg/controllers/sync/batch_updater.go
+type BatchUpdater struct {
+    updates   map[string]*storage.Service
+    mu        sync.Mutex
+    ticker    *time.Ticker
+    storage   storage.Storage
+}
+
+func (b *BatchUpdater) AddUpdate(service *storage.Service) {
+    b.mu.Lock()
+    defer b.mu.Unlock()
+    b.updates[service.ARN] = service
+}
+```
+
+### Phase 3: Task Synchronization (Week 3-4)
+
+1. **Implement pod to task mapping**
+```go
+// pkg/controllers/sync/task_sync.go
+func (c *SyncController) syncTask(key string) error {
+    namespace, name, _ := cache.SplitMetaNamespaceKey(key)
+    
+    // Get pod
+    pod, err := c.podLister.Pods(namespace).Get(name)
+    
+    // Check if this is an ECS-managed pod
+    if !isECSManagedPod(pod) {
+        return nil
+    }
+    
+    // Create or update task
+    task := c.mapPodToTask(pod)
+    return c.storage.TaskStore().CreateOrUpdate(context.TODO(), task)
+}
+```
+
+2. **Map pod labels to ECS metadata**
+```go
+func (c *SyncController) mapPodToTask(pod *corev1.Pod) *storage.Task {
+    return &storage.Task{
+        ARN:               generateTaskARN(pod),
+        ClusterARN:        getClusterARNFromNamespace(pod.Namespace),
+        TaskDefinitionARN: pod.Labels["ecs.amazonaws.com/task-definition-arn"],
+        DesiredStatus:     mapPodPhaseToDesiredStatus(pod.Status.Phase),
+        LastStatus:        mapPodPhaseToLastStatus(pod.Status.Phase),
+        LaunchType:        "FARGATE",
+        StartedAt:         getPodStartTime(pod),
+        StoppedAt:         getPodStopTime(pod),
+        StoppedReason:     getPodStopReason(pod),
+        Containers:        mapPodContainers(pod),
+    }
+}
+```
+
+3. **Container state synchronization**
+```go
+func mapPodContainers(pod *corev1.Pod) []storage.TaskContainer {
+    var containers []storage.TaskContainer
+    
+    for i, container := range pod.Spec.Containers {
+        status := getContainerStatus(pod, container.Name)
+        
+        containers = append(containers, storage.TaskContainer{
+            Name:        container.Name,
+            Image:       container.Image,
+            LastStatus:  mapContainerState(status),
+            ExitCode:    getExitCode(status),
+            Reason:      getContainerReason(status),
+            NetworkInterfaces: []storage.NetworkInterface{{
+                PrivateIPv4Address: pod.Status.PodIP,
+            }},
+        })
+    }
+    
+    return containers
+}
+```
+
+### Phase 4: Event and History Tracking (Week 4-5)
+
+1. **Event collection and transformation**
+```go
+// pkg/controllers/sync/event_sync.go
+func (c *SyncController) syncEvents() {
+    // Get events for ECS-managed resources
+    selector := labels.Set{"kecs.dev/managed-by": "kecs"}.AsSelector()
+    events, _ := c.eventLister.List(selector)
+    
+    // Group by service/task
+    eventMap := groupEventsByResource(events)
+    
+    // Update storage
+    for resourceARN, events := range eventMap {
+        c.updateResourceEvents(resourceARN, events)
+    }
+}
+```
+
+2. **Health check monitoring**
+```go
+func (c *SyncController) extractHealthStatus(pod *corev1.Pod) string {
+    for _, container := range pod.Status.ContainerStatuses {
+        if container.Ready {
+            continue
+        }
+        
+        // Check if health check failed
+        if isHealthCheckFailure(container) {
+            return "UNHEALTHY"
+        }
+    }
+    
+    return "HEALTHY"
+}
+```
+
+### Phase 5: Optimization and Monitoring (Week 5-6)
+
+1. **Add metrics and observability**
+```go
+var (
+    syncDuration = prometheus.NewHistogramVec(
+        prometheus.HistogramOpts{
+            Name: "kecs_sync_duration_seconds",
+            Help: "Time taken to sync resource state",
+        },
+        []string{"resource_type"},
+    )
+    
+    syncErrors = prometheus.NewCounterVec(
+        prometheus.CounterOpts{
+            Name: "kecs_sync_errors_total",
+            Help: "Total number of sync errors",
+        },
+        []string{"resource_type", "error_type"},
+    )
+)
+```
+
+2. **Implement rate limiting and backoff**
+```go
+func (c *SyncController) processNextWorkItem() bool {
+    key, quit := c.workqueue.Get()
+    if quit {
+        return false
+    }
+    defer c.workqueue.Done(key)
+    
+    err := c.syncByKey(key.(string))
+    if err == nil {
+        c.workqueue.Forget(key)
+        return true
+    }
+    
+    // Requeue with backoff
+    if c.workqueue.NumRequeues(key) < 5 {
+        c.workqueue.AddRateLimited(key)
+        return true
+    }
+    
+    c.workqueue.Forget(key)
+    return true
+}
+```
+
+## Configuration
+
+Add configuration options to control sync behavior:
+
+```yaml
+sync:
+  enabled: true
+  workers: 4
+  resyncPeriod: 5m
+  batchSize: 100
+  batchDelay: 2s
+  rateLimit:
+    qps: 10
+    burst: 20
+```
+
+## Testing Strategy
+
+1. **Unit tests** for state mappers and converters
+2. **Integration tests** using fake Kubernetes client
+3. **E2E tests** with real Kubernetes cluster
+4. **Performance tests** with large numbers of resources
+5. **Chaos tests** to verify resilience
+
+## Consequences
+
+### Positive
+- ECS API responses accurately reflect Kubernetes state
+- Real-time updates as Kubernetes resources change
+- Efficient resource utilization through informer caching
+- Comprehensive state tracking including health and events
+
+### Negative
+- Additional complexity in the control plane
+- Increased memory usage for informer caches
+- Potential for sync lag during high update rates
+- Need to handle edge cases and race conditions
+
+### Mitigation
+- Use rate limiting to prevent overwhelming the storage
+- Implement circuit breakers for storage failures
+- Add comprehensive metrics for monitoring sync health
+- Document sync behavior and limitations
+
+## References
+- [Kubernetes Informer Pattern](https://pkg.go.dev/k8s.io/client-go/informers)
+- [ECS Task Definition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html)
+- [Controller Best Practices](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/controllers.md)

--- a/docs/ecs-kubernetes-field-sync-analysis.md
+++ b/docs/ecs-kubernetes-field-sync-analysis.md
@@ -1,0 +1,148 @@
+# ECS API Response Fields Requiring Kubernetes Synchronization
+
+This document analyzes the ECS API response structures and identifies which fields need to be synchronized with Kubernetes resources.
+
+## Service Response Fields
+
+### Fields Requiring Real-time Kubernetes Sync
+
+| Field | ECS Type | Kubernetes Source | Update Trigger |
+|-------|----------|-------------------|----------------|
+| `runningCount` | int32 | Deployment.Status.ReadyReplicas | Pod Ready status changes |
+| `pendingCount` | int32 | Deployment.Status.Replicas - ReadyReplicas | Pod phase changes |
+| `desiredCount` | int32 | Deployment.Spec.Replicas | User updates (already synced) |
+| `status` | string | Derived from Deployment conditions | Deployment status changes |
+| `deployments[].runningCount` | int32 | ReplicaSet.Status.ReadyReplicas | Pod Ready status changes |
+| `deployments[].pendingCount` | int32 | ReplicaSet.Status.Replicas - ReadyReplicas | Pod phase changes |
+| `deployments[].failedTasks` | int32 | Count of failed pods in ReplicaSet | Pod Failed status |
+| `deployments[].rolloutState` | string | Deployment rollout status | Deployment progress |
+| `events[]` | ServiceEvent | Kubernetes Events for Deployment/Pods | Event creation |
+
+### Static Fields (Set at Creation/Update)
+
+- `serviceArn`, `serviceName`, `clusterArn` - Identifiers
+- `taskDefinition` - Updated via UpdateService API
+- `launchType`, `platformVersion` - Configuration
+- `networkConfiguration`, `loadBalancers` - Networking config
+- `createdAt`, `createdBy` - Metadata
+
+## Task Response Fields
+
+### Fields Requiring Real-time Kubernetes Sync
+
+| Field | ECS Type | Kubernetes Source | Update Trigger |
+|-------|----------|-------------------|----------------|
+| `lastStatus` | string | Pod.Status.Phase mapping | Pod phase changes |
+| `containers[].lastStatus` | string | Container.State | Container state changes |
+| `containers[].exitCode` | int32 | Container.State.Terminated.ExitCode | Container termination |
+| `containers[].reason` | string | Container.State.Waiting/Terminated.Reason | Container state changes |
+| `containers[].networkInterfaces[]` | NetworkInterface | Pod.Status.PodIP | Pod IP assignment |
+| `containers[].runtimeId` | string | Container.Status.ContainerID | Container creation |
+| `startedAt` | time | Pod.Status.StartTime | Pod start |
+| `stoppedAt` | time | Container.State.Terminated.FinishedAt | All containers terminated |
+| `stoppingAt` | time | Pod.DeletionTimestamp | Pod deletion initiated |
+| `pullStartedAt` | time | First container pulling event | Event: Pulling image |
+| `pullStoppedAt` | time | Last container pulled event | Event: Pulled image |
+| `connectivity` | string | Pod network readiness | Pod conditions |
+| `connectivityAt` | time | When connectivity established | Pod Ready condition |
+| `healthStatus` | string | Container health check results | Container probe results |
+| `stoppedReason` | string | Pod/Container termination reason | Pod/Container state |
+| `stopCode` | string | Mapped from exit codes | Container exit code |
+| `executionStoppedAt` | time | Last container stopped | Container termination |
+| `attachments[].status` | string | ENI attachment status (for awsvpc) | Pod network ready |
+
+### Container Status Mapping
+
+```
+ECS Status -> Kubernetes State
+PENDING -> Container.State.Waiting
+RUNNING -> Container.State.Running
+STOPPED -> Container.State.Terminated
+```
+
+### Task Status Mapping
+
+```
+ECS LastStatus -> Kubernetes Pod Phase
+PROVISIONING -> Pod.Status.Phase = Pending && no containers started
+PENDING -> Pod.Status.Phase = Pending && containers creating
+ACTIVATING -> Pod.Status.Phase = Pending && some containers ready
+RUNNING -> Pod.Status.Phase = Running && all containers ready
+DEACTIVATING -> Pod.Status.Phase = Running && DeletionTimestamp set
+STOPPING -> Pod being terminated
+STOPPED -> Pod.Status.Phase = Succeeded/Failed
+```
+
+## Kubernetes Resources to Monitor
+
+### For Service Updates
+
+1. **Deployments**
+   - Watch for: spec changes, status updates
+   - Updates: desiredCount, status, deployments array
+
+2. **ReplicaSets** 
+   - Watch for: status changes
+   - Updates: deployment running/pending counts
+
+3. **Pods** (filtered by service selector)
+   - Watch for: phase changes, ready status
+   - Updates: running/pending counts, task status
+
+4. **Events** (filtered by involved object)
+   - Watch for: deployment/pod events
+   - Updates: service events array
+
+### For Task Updates
+
+1. **Pods** (by task ID label)
+   - Watch for: all status changes
+   - Updates: task status, container status, timestamps
+
+2. **Events** (by pod)
+   - Watch for: image pull events, failures
+   - Updates: pull timestamps, failure reasons
+
+## Implementation Recommendations
+
+### Watch Strategy
+
+1. **Service Controller**
+   - Watch Deployments in all namespaces with label selector
+   - Watch ReplicaSets owned by tracked Deployments
+   - Aggregate Pod counts from ReplicaSet status (more efficient than watching all pods)
+   - Buffer updates to avoid excessive storage writes
+
+2. **Task Controller**
+   - Watch individual Pods by name (already implemented in TaskManager)
+   - Track container state transitions
+   - Update task status based on pod phase and container states
+
+3. **Event Aggregation**
+   - Watch Events with field selectors for tracked resources
+   - Convert Kubernetes events to ECS ServiceEvents
+   - Implement event deduplication and rate limiting
+
+### Performance Considerations
+
+1. Use label selectors to limit watch scope
+2. Implement informers with shared caches
+3. Batch storage updates
+4. Use field selectors where possible
+5. Implement exponential backoff for retries
+
+### Critical Sync Points
+
+1. **Service Creation**: Set initial status to PENDING, then ACTIVE when deployment ready
+2. **Service Update**: Track deployment rollout progress
+3. **Task Launch**: Update through PROVISIONING -> PENDING -> RUNNING states
+4. **Task Stop**: Set STOPPING status immediately, STOPPED when pod deleted
+5. **Health Checks**: Update container and task health status from probes
+
+## Fields That Don't Need Sync
+
+These fields are managed entirely by KECS and don't need Kubernetes synchronization:
+
+- Service: `capacityProviderStrategy`, `placementConstraints`, `placementStrategy`, `tags`
+- Task: `capacityProviderName`, `group`, `startedBy`, `tags`, `version`
+- Administrative: `enableECSManagedTags`, `enableExecuteCommand`, `propagateTags`


### PR DESCRIPTION
## Summary
- Implements comprehensive state synchronization between Kubernetes resources and ECS API responses
- Fixes issue where `aws ecs list-tasks` returned empty results even when pods were running
- Adds ADR #0020 documenting the synchronization architecture

## What Changed
### New Sync Controller
- **SyncController**: Main controller using Kubernetes informer framework for efficient resource watching
- **Service Synchronization**: Maps Deployment state to ECS service status (running/pending counts, status)
- **Task Synchronization**: Maps Pod state to ECS task status with container states
- **Batch Updater**: Efficiently batches storage updates to reduce write operations

### State Mapping
The controller watches:
- Deployments → ECS Service state (ACTIVE, PROVISIONING, etc.)
- ReplicaSets → Deployment tracking
- Pods → ECS Task state (RUNNING, STOPPED, etc.)
- Events → Service/Task history (future enhancement)

### Integration
- Modified `server.go` to initialize and start the sync controller
- Controller lifecycle properly managed with context cancellation
- Graceful shutdown ensures clean termination

## Testing
The implementation includes:
- Proper error handling with retry logic
- Rate limiting to prevent overwhelming storage
- Comprehensive logging for debugging

## Related Issues
- Fixes #397 - Tasks created via ECS API are not synchronized to storage

## Implementation Status
Completed phases from ADR #0020:
- [x] Phase 1: Core Synchronization Framework
- [x] Phase 2: Service Synchronization  
- [x] Phase 3: Task Synchronization
- [ ] Phase 4: Event and History Tracking (future)
- [ ] Phase 5: Optimization and Monitoring (future)

🤖 Generated with [Claude Code](https://claude.ai/code)