### PR TITLE
fix: sync controller to use account ID from configuration

### DIFF
--- a/controlplane/internal/controlplane/api/task_ecs_api.go
+++ b/controlplane/internal/controlplane/api/task_ecs_api.go
@@ -431,10 +431,12 @@ func (api *DefaultECSAPI) ListTasks(ctx context.Context, req *generated.ListTask
 	}
 
 	// List tasks
+	logging.Info("ListTasks called", "clusterARN", cluster.ARN, "filters", filters)
 	tasks, err := api.storage.TaskStore().List(ctx, cluster.ARN, filters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tasks: %w", err)
 	}
+	logging.Info("ListTasks result", "count", len(tasks))
 
 	// Convert to ARNs
 	taskArns := make([]string, 0, len(tasks))


### PR DESCRIPTION
## Summary
- Fix sync controller to use account ID from configuration instead of hardcoded values
- Update service and task mappers to accept account ID as parameter
- Add debug logging to batch updater and sync operations

## Problem
The sync controller was using a hardcoded account ID (123456789012) while the ECS API used the configured account ID (000000000000). This mismatch prevented tasks from being retrieved via the ECS API even though they were stored in the database.

## Solution
- Modified sync controller to read account ID and region from configuration
- Updated all mappers to accept account ID as a parameter
- Removed all hardcoded account IDs throughout the sync code
- Fixed namespace parsing to correctly extract cluster name and region

## Test plan
- [x] Build and run KECS locally
- [x] Create an ECS service
- [x] Verify that Kubernetes deployment and pods are created
- [x] Verify that sync controller updates task status from Pending to Running
- [x] Verify that  and  return correct status

🤖 Generated with [Claude Code](https://claude.ai/code)