### PR TITLE
fix: Implement UPSERT functionality to avoid duplicate key errors in DuckDB (#408)

### DIFF
--- a/controlplane/internal/controlplane/api/mocks/storage.go
+++ b/controlplane/internal/controlplane/api/mocks/storage.go
@@ -515,6 +515,15 @@ func (m *MockTaskStore) GetByARNs(ctx context.Context, arns []string) ([]*storag
 	return results, nil
 }
 
+func (m *MockTaskStore) CreateOrUpdate(ctx context.Context, task *storage.Task) error {
+	if m.tasks == nil {
+		m.tasks = make(map[string]*storage.Task)
+	}
+	key := fmt.Sprintf("%s:%s", task.ClusterARN, task.ID)
+	m.tasks[key] = task
+	return nil
+}
+
 // MockTaskSetStore implements storage.TaskSetStore for testing
 type MockTaskSetStore struct {
 	taskSets map[string]*storage.TaskSet

--- a/controlplane/internal/storage/interfaces.go
+++ b/controlplane/internal/storage/interfaces.go
@@ -374,6 +374,9 @@ type TaskStore interface {
 
 	// Get tasks by ARNs
 	GetByARNs(ctx context.Context, arns []string) ([]*Task, error)
+
+	// CreateOrUpdate creates a new task or updates if it already exists
+	CreateOrUpdate(ctx context.Context, task *Task) error
 }
 
 // TaskFilters defines filters for listing tasks


### PR DESCRIPTION
## Summary
- Implements atomic UPSERT functionality using DuckDB's ON CONFLICT clause to fix race conditions in task updates
- Replaces the problematic Get+Create/Update pattern in the batch updater
- Ensures thread-safe task updates when multiple goroutines sync the same task

## Changes
- Add `CreateOrUpdate` method to `TaskStore` interface for atomic upsert operations
- Implement `CreateOrUpdate` in DuckDB using `INSERT ... ON CONFLICT` syntax
- Update batch updater to use `CreateOrUpdate` instead of separate Get+Create/Update calls
- Add `CreateOrUpdate` to cached storage and mock implementations for consistency
- Replace klog with slog for consistent logging throughout the codebase

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] E2E tests verify no duplicate key errors occur during task synchronization

## Related Issues
Fixes #408

🤖 Generated with [Claude Code](https://claude.ai/code)