### PR TITLE
fix: Allow TUI to exit during instance creation

### DIFF
--- a/controlplane/internal/tui/app/app.go
+++ b/controlplane/internal/tui/app/app.go
@@ -72,6 +72,7 @@ type App struct {
 	startupDialog   *startup.DialogModel
 	startupLogViewer *startup.LogViewerModel
 	startupState    StartupState
+	startupContext  *startup.StartupContext
 }
 
 // New creates a new TUI application

--- a/controlplane/internal/tui/app/startup_handler.go
+++ b/controlplane/internal/tui/app/startup_handler.go
@@ -16,6 +16,7 @@ package app
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nandemo-ya/kecs/controlplane/internal/tui/keys"
 	"github.com/nandemo-ya/kecs/controlplane/internal/tui/views/startup"
 )
 
@@ -41,6 +42,15 @@ func (a *App) handleStartupFlow(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, a.startupDialog.Init()
 		
 	case tea.KeyMsg:
+		// Check for global quit commands first
+		if keys.Matches(msg, a.keyMap.Quit) || keys.Matches(msg, a.keyMap.ForceQuit) {
+			// Cancel any ongoing startup
+			if a.startupContext != nil && a.startupContext.Cancel != nil {
+				a.startupContext.Cancel()
+			}
+			return a, tea.Quit
+		}
+		
 		// Handle key messages based on current state
 		switch a.startupState {
 		case StartupStateDialog:
@@ -81,6 +91,10 @@ func (a *App) handleStartupFlow(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, cmd
 			}
 		}
+	case startup.StartupContextMsg:
+		// Store the startup context for cancellation
+		a.startupContext = msg.Ctx
+		return a, nil
 	}
 	
 	// Handle other messages during startup

--- a/controlplane/internal/tui/views/startup/dialog.go
+++ b/controlplane/internal/tui/views/startup/dialog.go
@@ -63,6 +63,11 @@ func (m *DialogModel) Update(msg tea.Msg) (*DialogModel, tea.Cmd) {
 			m.cancelled = true
 			m.visible = false
 			return m, tea.Quit
+		case "ctrl+c":
+			// Always allow quitting with Ctrl+C
+			m.cancelled = true
+			m.visible = false
+			return m, tea.Quit
 		}
 	}
 

--- a/controlplane/internal/tui/views/startup/logviewer.go
+++ b/controlplane/internal/tui/views/startup/logviewer.go
@@ -103,6 +103,9 @@ func (m *LogViewerModel) Update(msg tea.Msg) (*LogViewerModel, tea.Cmd) {
 			if m.completed || m.failed {
 				return m, tea.Quit
 			}
+		case "ctrl+c":
+			// Always allow quitting with Ctrl+C
+			return m, tea.Quit
 		case "enter":
 			if m.completed {
 				// Continue to TUI
@@ -189,7 +192,7 @@ func (m *LogViewerModel) View() string {
 	// Footer
 	b.WriteString("\n")
 	if m.starting {
-		b.WriteString(styles.SubtleStyle.Render("Starting KECS... Please wait"))
+		b.WriteString(styles.SubtleStyle.Render("Starting KECS... Press Ctrl+C to cancel"))
 	} else if m.completed {
 		b.WriteString(styles.Info.Render("Press ENTER to continue"))
 	} else if m.failed {


### PR DESCRIPTION
## Summary
- Fixed issue where TUI could not be exited during instance creation
- Added context cancellation support for graceful shutdown
- Improved user experience with "Press Ctrl+C to cancel" indicator

## Test plan
- [x] Start TUI with `kecs tui`
- [x] Begin creating a new instance
- [x] Press Ctrl+C or 'q' during creation process
- [x] Verify TUI exits immediately and instance creation is cancelled
- [x] Verify no orphaned processes remain

🤖 Generated with [Claude Code](https://claude.ai/code)