### PR TITLE
chore: Add Serena MCP cache and memory directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ qa-results/
 
 # MCP configuration
 .mcp.json
+
+# Serena MCP cache and memory
+.serena/cache/
+.serena/memory/


### PR DESCRIPTION
## Summary
- Add `.serena/cache/` and `.serena/memory/` directories to .gitignore
- Prevents Serena MCP's temporary files and memory files from being tracked by Git

## Test plan
- [x] Verified .gitignore entries are correctly formatted
- [x] All controlplane tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)