### PR TITLE
fix: Fix TUI instance creation timeout and NodePort issues

### DIFF
--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -160,7 +160,8 @@ func (m Model) createInstanceCmd(opts api.CreateInstanceOptions) tea.Cmd {
 	}
 
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		// Increase timeout to 3 minutes for LocalStack and other components to start
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 
 		instance, err := m.apiClient.CreateInstance(ctx, opts)
@@ -196,6 +197,20 @@ type dataLoadedMsg struct {
 
 type instanceCreatedMsg struct {
 	instance Instance
+}
+
+// Instance creation status messages
+type instanceCreationStatusMsg struct {
+	steps   []CreationStep
+	elapsed string
+}
+
+type instanceCreationTimeoutMsg struct {
+	elapsed string
+}
+
+type instanceCreationContinueMsg struct {
+	continueWaiting bool // true to continue, false to abort
 }
 
 type errMsg struct {

--- a/controlplane/internal/tui/instance_form.go
+++ b/controlplane/internal/tui/instance_form.go
@@ -22,6 +22,12 @@ const (
 	FieldCancel
 )
 
+// CreationStep represents each step in instance creation
+type CreationStep struct {
+	Name   string
+	Status string // "pending", "running", "done", "failed"
+}
+
 // InstanceForm represents the instance creation form state
 type InstanceForm struct {
 	// Form fields
@@ -37,6 +43,11 @@ type InstanceForm struct {
 	errorMsg     string
 	successMsg   string
 	isCreating   bool
+	
+	// Creation status tracking
+	creationSteps    []CreationStep
+	creationElapsed  string     // Time elapsed
+	showTimeoutPrompt bool      // Show continue/abort prompt on timeout
 	
 	// Validation state
 	nameError    string


### PR DESCRIPTION
## Summary
- Fix Traefik NodePort mapping to use valid Kubernetes range (30000-32767)
- Extend instance creation timeout from 30s to 3 minutes for LocalStack
- Prepare UI structure for better creation status display

## Problem
1. **NodePort Error**: Traefik service creation failed with "Invalid value: 8080: provided port is not in the valid range. The range of valid ports is 30000-32767"
2. **LocalStack Timeout**: LocalStack creation timed out with "context deadline exceeded" especially on first run when downloading images

## Solution
### NodePort Mapping
- Add logic to map API ports to valid NodePort range
- Ports < 30000 are mapped by adding 22000 (e.g., 8080 → 30080, 8090 → 30090)
- Fallback to 30080 if resulting port is still out of range

### Timeout Extension
- Increase TUI instance creation timeout from 30 seconds to 3 minutes
- LocalStack needs time to download images on first run (~500MB)
- Prevents premature timeout errors

### UI Improvements (Foundation)
- Added structure for step-by-step progress display with checkmarks
- Prepared timeout warning and continue/abort prompt capability
- Added elapsed time tracking during creation
- Note: Actual step updates require further refactoring of the instance manager

## Test plan
- [x] Build successful
- [x] All controlplane tests pass
- [x] Test creating new instance via TUI with LocalStack enabled
- [x] Verify Traefik service creates successfully with proper NodePort
- [x] Confirm LocalStack starts without timeout on first run

🤖 Generated with [Claude Code](https://claude.ai/code)