### PR TITLE
feat: Add clipboard copy functionality to TUI

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -418,6 +418,32 @@ func (m Model) handleInstancesKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.clusterCursor = 0
 			return m, m.loadMockDataCmd()
 		}
+	case "y":
+		// Copy instance name to clipboard
+		if len(m.instances) > 0 && m.instanceCursor < len(m.instances) {
+			inst := m.instances[m.instanceCursor]
+			err := copyToClipboard(inst.Name)
+			if err == nil {
+				m.clipboardMsg = fmt.Sprintf("Copied: %s", inst.Name)
+				m.clipboardMsgTime = time.Now()
+			} else {
+				m.clipboardMsg = fmt.Sprintf("Copy failed: %v", err)
+				m.clipboardMsgTime = time.Now()
+			}
+		}
+	case "Y":
+		// Copy full instance info to clipboard
+		if len(m.instances) > 0 && m.instanceCursor < len(m.instances) {
+			inst := m.instances[m.instanceCursor]
+			err := copyToClipboard(copyInstanceInfo(inst))
+			if err == nil {
+				m.clipboardMsg = "Copied instance details to clipboard"
+				m.clipboardMsgTime = time.Now()
+			} else {
+				m.clipboardMsg = fmt.Sprintf("Copy failed: %v", err)
+				m.clipboardMsgTime = time.Now()
+			}
+		}
 	case "N":
 		// Open instance creation form
 		if m.instanceForm == nil {

--- a/controlplane/internal/tui/clipboard.go
+++ b/controlplane/internal/tui/clipboard.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/atotto/clipboard"
+)
+
+// copyToClipboard copies the given text to the system clipboard
+func copyToClipboard(text string) error {
+	if text == "" {
+		return fmt.Errorf("nothing to copy")
+	}
+	return clipboard.WriteAll(text)
+}
+
+// copyInstanceInfo copies instance information to clipboard
+func copyInstanceInfo(instance Instance) string {
+	parts := []string{
+		fmt.Sprintf("Name: %s", instance.Name),
+		fmt.Sprintf("API Port: %d", instance.APIPort),
+		fmt.Sprintf("Admin Port: %d", instance.AdminPort),
+		fmt.Sprintf("Status: %s", instance.Status),
+	}
+	return strings.Join(parts, "\n")
+}
+
+// copyClusterInfo copies cluster information to clipboard
+func copyClusterInfo(cluster Cluster) string {
+	parts := []string{
+		fmt.Sprintf("Name: %s", cluster.Name),
+		fmt.Sprintf("Status: %s", cluster.Status),
+		fmt.Sprintf("Services: %d", cluster.Services),
+		fmt.Sprintf("Tasks: %d", cluster.Tasks),
+	}
+	return strings.Join(parts, "\n")
+}
+
+// copyServiceInfo copies service information to clipboard
+func copyServiceInfo(service Service) string {
+	parts := []string{
+		fmt.Sprintf("Name: %s", service.Name),
+		fmt.Sprintf("Status: %s", service.Status),
+		fmt.Sprintf("Desired: %d", service.Desired),
+		fmt.Sprintf("Running: %d", service.Running),
+		fmt.Sprintf("Task Definition: %s", service.TaskDef),
+	}
+	return strings.Join(parts, "\n")
+}
+
+// copyTaskInfo copies task information to clipboard
+func copyTaskInfo(task Task) string {
+	parts := []string{
+		fmt.Sprintf("ID: %s", task.ID),
+		fmt.Sprintf("Status: %s", task.Status),
+		fmt.Sprintf("Service: %s", task.Service),
+		fmt.Sprintf("Health: %s", task.Health),
+		fmt.Sprintf("IP: %s", task.IP),
+	}
+	return strings.Join(parts, "\n")
+}

--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -201,6 +201,10 @@ type Model struct {
 	// API client
 	apiClient       api.Client
 	useMockData     bool
+	
+	// Clipboard notification
+	clipboardMsg     string
+	clipboardMsgTime time.Time
 }
 
 // NewModel creates a new application model

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -278,6 +278,12 @@ func (m Model) renderBreadcrumb() string {
 }
 
 func (m Model) renderFooter() string {
+	// Check if we should show clipboard notification
+	if m.clipboardMsg != "" && time.Since(m.clipboardMsgTime) < 3*time.Second {
+		notification := successStyle.Render("📋 " + m.clipboardMsg)
+		return footerStyle.Width(m.width).Render(notification)
+	}
+	
 	// Check if we should show command result
 	if m.commandPalette != nil && m.commandPalette.ShouldShowResult() {
 		// Show command result for a few seconds
@@ -1635,6 +1641,10 @@ Global Navigation:
   ↓, j        Move down
   Enter       Select/Drill down
   Backspace   Go back to parent view
+
+Clipboard Operations:
+  y           Copy selected item name/ID to clipboard
+  Y           Copy full details to clipboard
 
 Resource Navigation:
   i           Go to instances


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts to copy important information to system clipboard
- Solve the issue where users can't select text in TUI mode

## Features

### Keyboard Shortcuts
- `y` - Copy selected item name/ID to clipboard
- `Y` - Copy full item details to clipboard

### Visual Feedback
- 📋 notification in footer for 3 seconds showing copy status
- Error messages displayed if copy fails
- Help documentation updated with new shortcuts

## Implementation
- New `clipboard.go` with copy utilities for each resource type
- Integration with `github.com/atotto/clipboard` (already in dependencies)
- Support for instances (clusters, services, tasks support to be added in future)

## Test Plan
- [x] Build successful
- [x] All tests pass
- [x] Manual testing of clipboard copy in TUI
- [x] Verify clipboard content with `pbpaste` (macOS) or `xclip -o` (Linux)
- [x] Error handling tested by simulating clipboard failures

## Why This Matters
In TUI mode, users cannot select text with mouse drag because the TUI controls the terminal. This feature provides an alternative way to copy important information like:
- Instance names
- API/Admin ports
- Cluster names
- Service names
- Task IDs

This significantly improves the user experience when working with KECS TUI.

🤖 Generated with [Claude Code](https://claude.ai/code)