### PR TITLE
fix: Fix port mapping issues preventing API access on TUI-created instances

### DIFF
--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -453,8 +453,8 @@ func deployTraefikGateway(ctx context.Context, clusterName string, cfg *config.C
 		MemoryRequest:   "128Mi",
 		CPULimit:        "500m",
 		MemoryLimit:     "512Mi",
-		WebPort:         80,
-		WebNodePort:     30080,
+		APIPort:         80,
+		APINodePort:     30080,
 		AWSPort:         4566,
 		AWSNodePort:     30890, // Fixed NodePort in valid range (k3d maps host port to this)
 		LogLevel:        "INFO",
@@ -844,8 +844,8 @@ func deployTraefikWithProgress(ctx context.Context, clusterName string, cfg *con
 		MemoryRequest:   "128Mi",
 		CPULimit:        "500m",
 		MemoryLimit:     "512Mi",
-		WebPort:         80,
-		WebNodePort:     30080,
+		APIPort:         80,
+		APINodePort:     30080,
 		AWSPort:         4566,
 		AWSNodePort:     30890, // Fixed NodePort in valid range (k3d maps host port to this)
 		Metrics:         false, // Metrics disabled to reduce overhead

--- a/controlplane/internal/controlplane/cmd/start_bubbletea.go
+++ b/controlplane/internal/controlplane/cmd/start_bubbletea.go
@@ -527,8 +527,8 @@ func deployTraefikGatewayWithProgress(ctx context.Context, clusterName string, c
 		MemoryRequest:   "128Mi",
 		CPULimit:        "500m",
 		MemoryLimit:     "512Mi",
-		WebPort:         80,
-		WebNodePort:     30080,
+		APIPort:         80,
+		APINodePort:     30080,
 		AWSPort:         4566,
 		AWSNodePort:     30890,  // Fixed NodePort in valid range (k3d maps host port to this)
 		LogLevel:        "INFO",

--- a/controlplane/internal/kubernetes/resources/traefik.go
+++ b/controlplane/internal/kubernetes/resources/traefik.go
@@ -43,10 +43,10 @@ type TraefikConfig struct {
 	MemoryLimit   string
 	
 	// Ports
-	WebPort      int32  // HTTP port
-	WebNodePort  int32  // NodePort for HTTP (optional)
-	AWSPort      int32  // AWS API port (4566)
-	AWSNodePort  int32  // NodePort for AWS API
+	APIPort      int32  // HTTP port for ECS API
+	APINodePort  int32  // NodePort for ECS API (optional)
+	AWSPort      int32  // LocalStack port (4566)
+	AWSNodePort  int32  // NodePort for LocalStack
 	
 	// Features
 	Debug        bool
@@ -64,8 +64,8 @@ func DefaultTraefikConfig() *TraefikConfig {
 		MemoryRequest:   "128Mi",
 		CPULimit:        "500m",
 		MemoryLimit:     "512Mi",
-		WebPort:         80,
-		WebNodePort:     30080,
+		APIPort:         80,
+		APINodePort:     30080,
 		AWSPort:         4566,
 		AWSNodePort:     30890,
 		LogLevel:        "INFO",
@@ -240,13 +240,14 @@ func createTraefikServices(config *TraefikConfig) []*corev1.Service {
 				},
 				Ports: []corev1.ServicePort{
 					{
-						Name:       "web",
-						Port:       config.WebPort,
+						Name:       "api",
+						Port:       config.APIPort,
 						TargetPort: intstr.FromString("web"),
 						Protocol:   corev1.ProtocolTCP,
+						NodePort:   config.APINodePort,
 					},
 					{
-						Name:       "aws",
+						Name:       "localstack",
 						Port:       config.AWSPort,
 						TargetPort: intstr.FromString("aws"),
 						Protocol:   corev1.ProtocolTCP,
@@ -335,7 +336,7 @@ func createTraefikDeployment(config *TraefikConfig) *appsv1.Deployment {
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "web",
-									ContainerPort: config.WebPort,
+									ContainerPort: config.APIPort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 								{


### PR DESCRIPTION
## Summary
- Fixed port mapping issues that prevented API access on instances created via TUI
- Added flexible port mapping support to K3dClusterManager
- Renamed confusing WebPort/WebNodePort to APIPort/APINodePort for clarity

## Problem
TUI-created instances were not accessible via their API ports. Investigation revealed:
1. k3d cluster creation wasn't receiving proper port mapping parameters
2. Traefik NodePort configuration had swapped APINodePort and AWSNodePort values
3. Confusing naming (WebPort vs APIPort) made the issue harder to debug

## Solution
1. **Extended K3dClusterManager**: Added `CreateClusterWithPortMapping` method to accept custom port mappings
2. **Fixed port mapping logic**: Instance creation now properly maps host ports to NodePorts during k3d cluster creation
3. **Fixed Traefik configuration**: Corrected NodePort assignments (APINodePort for ECS API, AWSNodePort for LocalStack)
4. **Improved naming**: Renamed WebPort/WebNodePort to APIPort/APINodePort throughout the codebase

## Changes
- `k3d_cluster_manager.go`: Added new method for flexible port mapping
- `instance/helpers.go`: Updated to use port mapping during cluster creation
- `resources/traefik.go`: Renamed fields for clarity
- `start.go`, `start_bubbletea.go`: Updated field references

## Test Plan
- [x] Build successful
- [x] All unit tests passing
- [x] Manual test: Create instance via TUI and verify API access
- [x] Manual test: Create instance via CLI and verify API access

🤖 Generated with [Claude Code](https://claude.ai/code)