### PR TITLE
feat: Integrate TUI with KECS API for real-time resource display

### DIFF
--- a/controlplane/internal/controlplane/admin/server.go
+++ b/controlplane/internal/controlplane/admin/server.go
@@ -51,7 +51,10 @@ func NewServer(port int, storage storage.Storage) *Server {
 		s.instanceAPI = instanceAPI
 	}
 	
-	s.ecsProxy = NewECSProxy(cfg)
+	// Initialize ECS proxy with instance manager if available
+	if s.instanceAPI != nil && s.instanceAPI.manager != nil {
+		s.ecsProxy = NewECSProxy(cfg, s.instanceAPI.manager)
+	}
 
 	return s
 }

--- a/controlplane/internal/tui/command_palette.go
+++ b/controlplane/internal/tui/command_palette.go
@@ -254,11 +254,6 @@ func (cp *CommandPalette) initCommands() {
 					Status:    "ACTIVE",
 					Services:  0,
 					Tasks:     0,
-					CPUUsed:   0,
-					CPUTotal:  100,
-					MemoryUsed: "0 GB",
-					MemoryTotal: "16 GB",
-					Namespace: m.selectedInstance,
 					Age:       0,
 				}
 				m.clusters = append(m.clusters, newCluster)

--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -51,11 +51,6 @@ type Cluster struct {
 	Status     string
 	Services   int
 	Tasks      int
-	CPUUsed    float64
-	CPUTotal   float64
-	MemoryUsed string
-	MemoryTotal string
-	Namespace  string
 	Age        time.Duration
 }
 

--- a/controlplane/internal/tui/search.go
+++ b/controlplane/internal/tui/search.go
@@ -36,8 +36,7 @@ func (m Model) filterClusters(clusters []Cluster) []Cluster {
 
 	for _, cluster := range clusters {
 		if matchesSearch(cluster.Name, query) ||
-			matchesSearch(cluster.Status, query) ||
-			matchesSearch(cluster.Namespace, query) {
+			matchesSearch(cluster.Status, query) {
 			filtered = append(filtered, cluster)
 		}
 	}


### PR DESCRIPTION
## Summary
Integrates the Terminal User Interface (TUI) with the KECS API to display actual ECS resources from running instances.

## Motivation
Previously, the TUI was only displaying mock data. This PR connects the TUI to real KECS instances to show actual clusters, services, and tasks.

## Changes

### API Integration
- Modified TUI to directly call instance APIs instead of using mock data
- Implemented direct API calls to instance ports for ECS operations (ListClusters, DescribeClusters, ListServices, etc.)
- Added instance count fetching in both admin API and k3d provider

### UI Improvements
- Removed Kubernetes-specific columns (Namespace, CPU, Memory) from cluster view to align with ECS concepts
- Optimized column widths for better readability:
  - Service view: Increased TASK DEF column from 20% to 40%
  - Task view: Removed redundant SERVICE column, increased TASK ID from 20% to 45%
- Extract and display only task definition name:revision from full ARN for cleaner display

### Implementation Details
- ECSProxy now reads instance configuration from `~/.kecs/instances/{name}/config.yaml`
- K3dProvider fetches real cluster/service/task counts via API calls
- Replaced all `loadMockDataCmd()` calls with `loadDataFromAPI()`

## Testing
Successfully tested with running instance on port 8080:
- ✅ Real cluster data (default cluster)
- ✅ Actual services (single-task-nginx)
- ✅ Running tasks with full IDs displayed

## Screenshots
- Instance list with real resource counts
- Cluster view without Kubernetes-specific columns
- Service view with expanded task definition display
- Task view with full task IDs

## Related Issues
Part of TUI implementation and ECS API integration effort.

🤖 Generated with [Claude Code](https://claude.ai/code)