### PR TITLE
feat: Add enhanced scrolling for task definition JSON view in TUI

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -651,6 +651,11 @@ func (m Model) handleClustersKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		if m.selectedCluster != "" {
 			m.currentView = ViewServices
 		}
+	case "d":
+		// Go to task definitions view
+		m.currentView = ViewTaskDefinitionFamilies
+		m.taskDefFamilyCursor = 0
+		return m, m.loadTaskDefinitionFamiliesCmd()
 	case "/":
 		m.searchMode = true
 		m.searchQuery = ""
@@ -1381,7 +1386,7 @@ func (m Model) handleTaskDefinitionRevisionsKeys(msg tea.KeyMsg) (Model, tea.Cmd
 	case "D":
 		// Enter diff mode
 		// TODO: Implement diff mode
-	case "ctrl+u":
+	case "ctrl+u", "pgup":
 		// Scroll JSON up half page
 		if m.showTaskDefJSON {
 			m.taskDefJSONScroll -= 10
@@ -1389,10 +1394,34 @@ func (m Model) handleTaskDefinitionRevisionsKeys(msg tea.KeyMsg) (Model, tea.Cmd
 				m.taskDefJSONScroll = 0
 			}
 		}
-	case "ctrl+d":
+	case "ctrl+d", "pgdown":
 		// Scroll JSON down half page
 		if m.showTaskDefJSON {
 			m.taskDefJSONScroll += 10
+		}
+	case "g":
+		// Go to top of JSON
+		if m.showTaskDefJSON {
+			m.taskDefJSONScroll = 0
+		}
+	case "G":
+		// Go to bottom of JSON
+		if m.showTaskDefJSON {
+			// Will be adjusted in render to max value
+			m.taskDefJSONScroll = 99999
+		}
+	case "J":
+		// Scroll JSON down one line
+		if m.showTaskDefJSON {
+			m.taskDefJSONScroll++
+		}
+	case "K":
+		// Scroll JSON up one line
+		if m.showTaskDefJSON {
+			m.taskDefJSONScroll--
+			if m.taskDefJSONScroll < 0 {
+				m.taskDefJSONScroll = 0
+			}
 		}
 	case "/":
 		m.searchMode = true

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -1958,10 +1958,15 @@ func (m Model) renderTaskDefJSON(maxHeight int, width int) string {
 	
 	// Add scroll indicator if needed
 	lines := strings.Split(jsonContent, "\n")
-	visibleLines := maxHeight - 2
+	visibleLines := maxHeight - 4 // Leave room for scroll indicator
 	
-	if m.taskDefJSONScroll > len(lines)-visibleLines {
-		m.taskDefJSONScroll = len(lines) - visibleLines
+	// Adjust scroll position
+	maxScroll := len(lines) - visibleLines
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.taskDefJSONScroll > maxScroll {
+		m.taskDefJSONScroll = maxScroll
 	}
 	if m.taskDefJSONScroll < 0 {
 		m.taskDefJSONScroll = 0
@@ -1973,6 +1978,23 @@ func (m Model) renderTaskDefJSON(maxHeight int, width int) string {
 	}
 	
 	visibleJSON := strings.Join(lines[m.taskDefJSONScroll:endLine], "\n")
+	
+	// Add scroll indicator
+	if len(lines) > visibleLines {
+		scrollPercent := 0
+		if maxScroll > 0 {
+			scrollPercent = (m.taskDefJSONScroll * 100) / maxScroll
+		}
+		scrollInfo := fmt.Sprintf(" Lines %d-%d of %d (%d%%) | Scroll: J/K, PgUp/PgDn, g/G, Ctrl+U/D ",
+			m.taskDefJSONScroll+1, endLine, len(lines), scrollPercent)
+		
+		scrollStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#888888")).
+			Align(lipgloss.Center).
+			Width(width-2)
+		
+		visibleJSON = visibleJSON + "\n" + scrollStyle.Render(scrollInfo)
+	}
 	
 	return jsonStyle.Render(visibleJSON)
 }


### PR DESCRIPTION
## Summary
- Enhanced the task definition JSON view with intuitive scrolling controls and visual indicators
- Improved user experience when viewing large task definition JSON files in the TUI

## Changes
- **Added new scroll key bindings:**
  - `J/K` - Scroll one line down/up
  - `PgUp/PgDown` - Page scrolling  
  - `g/G` - Jump to top/bottom of JSON content
  - `Ctrl+U/Ctrl+D` - Half-page scrolling (existing)
  
- **Added scroll position indicator:**
  - Displays current line range (e.g., "Lines 1-50 of 200")
  - Shows scroll percentage for quick position reference
  - Lists available scroll shortcuts for discoverability

- **Added shortcut navigation:**
  - Added 'd' key from clusters view to navigate directly to task definitions

## Test Plan
- [x] Build and run KECS TUI
- [x] Navigate to task definitions view (press 'd' from clusters)
- [x] Select a family and view revisions
- [x] Press Enter to view JSON and test all scroll controls
- [x] Verify scroll indicator updates correctly
- [x] Test with large and small JSON files

🤖 Generated with [Claude Code](https://claude.ai/code)