### PR TITLE
fix: Generate ECS-compatible task IDs for service-managed pods

### DIFF
--- a/controlplane/internal/controllers/sync/mappers/task_mapper.go
+++ b/controlplane/internal/controllers/sync/mappers/task_mapper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	"github.com/nandemo-ya/kecs/controlplane/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -126,11 +127,12 @@ func (m *TaskStateMapper) MapPodToTask(pod *corev1.Pod) *storage.Task {
 		startedBy = fmt.Sprintf("ecs-svc/%s", serviceName)
 	}
 
-	// Get task ID from pod label or use pod name as fallback
+	// Get task ID from pod label or generate from pod name
 	taskID := pod.Labels["kecs.dev/task-id"]
 	if taskID == "" {
-		// Fallback to pod name for compatibility with existing pods
-		taskID = pod.Name
+		// Generate deterministic task ID from pod name for service-created pods
+		// This ensures the same pod always gets the same ECS-compatible task ID
+		taskID = utils.GenerateTaskIDFromString(pod.Name)
 	}
 
 	// Create task object
@@ -286,11 +288,12 @@ func (m *TaskStateMapper) generateTaskARN(pod *corev1.Pod) string {
 		clusterName = "default"
 	}
 	
-	// Get task ID from pod label or use pod name as fallback
+	// Get task ID from pod label or generate from pod name
 	taskID := pod.Labels["kecs.dev/task-id"]
 	if taskID == "" {
-		// Fallback to pod name for compatibility with existing pods
-		taskID = pod.Name
+		// Generate deterministic task ID from pod name for service-created pods
+		// This ensures the same pod always gets the same ECS-compatible task ID
+		taskID = utils.GenerateTaskIDFromString(pod.Name)
 	}
 	
 	return fmt.Sprintf("arn:aws:ecs:%s:%s:task/%s/%s", region, m.accountID, clusterName, taskID)

--- a/controlplane/internal/utils/taskid.go
+++ b/controlplane/internal/utils/taskid.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 )
@@ -17,4 +18,15 @@ func GenerateTaskID() (string, error) {
 	
 	// Convert to hexadecimal string (32 characters)
 	return hex.EncodeToString(bytes), nil
+}
+
+// GenerateTaskIDFromString generates a deterministic task ID from a string (e.g., pod name)
+// This ensures that the same pod name always generates the same task ID
+// Returns a 32-character hexadecimal string
+func GenerateTaskIDFromString(input string) string {
+	// Create SHA256 hash of the input
+	hash := sha256.Sum256([]byte(input))
+	
+	// Take first 16 bytes and convert to hex (32 characters)
+	return hex.EncodeToString(hash[:16])
 }


### PR DESCRIPTION
## Summary
- Fixed task ID format for pods created by services (via Deployments)
- Added deterministic task ID generation from pod names
- Ensures all tasks have proper 32-character hexadecimal IDs

## Problem
Pods created by services through Deployments didn't have the `kecs.dev/task-id` label, resulting in task ARNs using the raw pod name instead of an ECS-compatible task ID:
- Before: `arn:aws:ecs:us-east-1:000000000000:task/default/ecs-service-single-task-nginx-6b48b86448-bqrhm`
- After: `arn:aws:ecs:us-east-1:000000000000:task/default/a3f4b5c6d7e8f9012345678...` (32-char hex)

## Changes
1. **GenerateTaskIDFromString()**: Generate deterministic 32-char hex IDs from pod names using SHA256
2. **TaskStateMapper**: Use generated task IDs when `kecs.dev/task-id` label is missing
3. Ensures consistent ECS-compatible task IDs for all pods, including those from Deployments

## Test Plan
- [x] Build passes without errors
- [x] Unit tests pass
- [ ] Service-created pods get proper task IDs
- [ ] Task ARNs use correct format in `aws ecs list-tasks`

## Related
- Builds on PR #449 (task ARN format fix)
- Completes the task ID standardization for all pod types

🤖 Generated with [Claude Code](https://claude.ai/code)