### PR TITLE
fix: Remove localhost:4566 references from controlplane

### DIFF
--- a/controlplane/internal/controlplane/api/aws_proxy.go
+++ b/controlplane/internal/controlplane/api/aws_proxy.go
@@ -41,8 +41,8 @@ func NewAWSProxyHandler(localStackManager localstack.Manager) (*AWSProxyHandler,
 			endpoint, err := localStackManager.GetEndpoint()
 			if err != nil {
 				logging.Warn("Failed to get LocalStack endpoint", "error", err)
-				// Use default as last resort
-				endpoint = "http://localhost:4566"
+				// Use cluster-internal endpoint as fallback
+				endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
 			}
 			logging.Info("Using LocalStack endpoint", "endpoint", endpoint)
 			
@@ -119,8 +119,8 @@ func (h *AWSProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			endpoint, err = h.localStackManager.GetEndpoint()
 			if err != nil {
 				logging.Warn("Failed to get LocalStack endpoint", "error", err)
-				// Use default as last resort
-				endpoint = "http://localhost:4566"
+				// Use cluster-internal endpoint as last resort
+				endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
 			}
 			logging.Info("Initializing proxy with LocalStack endpoint", "endpoint", endpoint)
 		}

--- a/examples/service-with-secrets/task_def.json
+++ b/examples/service-with-secrets/task_def.json
@@ -32,15 +32,15 @@
       "secrets": [
         {
           "name": "DATABASE_URL",
-          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/database_url"
+          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/database-url"
         },
         {
           "name": "API_KEY",
-          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/api_key"
+          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/api-key"
         },
         {
           "name": "FEATURE_FLAGS",
-          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/feature_flags"
+          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/feature-flags"
         },
         {
           "name": "DB_PASSWORD",


### PR DESCRIPTION
## Summary
- Remove all `localhost:4566` references from controlplane integration configs
- Since controlplane always runs inside k3d cluster, it should always use cluster-internal DNS
- Fixes connection refused errors when syncing secrets from LocalStack

## Problem
The controlplane was trying to connect to LocalStack using `localhost:4566`, which doesn't work from inside the k3d cluster. This caused all secret synchronization to fail with "connection refused" errors.

## Solution
- Update all integration configs in `server.go` to use empty `LocalStackEndpoint` (lets them use default cluster-internal endpoint)
- Update `aws_proxy.go` fallback endpoints to use cluster-internal DNS
- All LocalStack connections now use `localstack.kecs-system.svc.cluster.local:4566`

## Changes
- `server.go`: Set empty `LocalStackEndpoint` for all integrations (IAM, CloudWatch, SSM, Secrets Manager, S3)
- `aws_proxy.go`: Update two fallback endpoints from `localhost:4566` to cluster-internal DNS
- `examples/service-with-secrets/task_def.json`: Update SSM parameter names to use hyphens (Kubernetes naming requirement)

## Test Plan
- [x] Build and deploy updated controlplane
- [x] Create SSM parameters and Secrets Manager secrets in LocalStack
- [x] Run ECS task with secret references
- [ ] Verify secrets are synced to kecs-system namespace
- [ ] Verify pods can access the secrets

## Related Issues
- Continues work from #458 (centralized secrets architecture)
- Fixes the LocalStack connection issues that were preventing secret synchronization

🤖 Generated with Claude Code