### PR TITLE
fix: Initialize SecretsController unconditionally at startup

### DIFF
--- a/controlplane/internal/controlplane/api/aws_proxy.go
+++ b/controlplane/internal/controlplane/api/aws_proxy.go
@@ -41,8 +41,8 @@ func NewAWSProxyHandler(localStackManager localstack.Manager) (*AWSProxyHandler,
 			endpoint, err := localStackManager.GetEndpoint()
 			if err != nil {
 				logging.Warn("Failed to get LocalStack endpoint", "error", err)
-				// Use default as last resort
-				endpoint = "http://localhost:4566"
+				// Use cluster-internal endpoint as fallback
+				endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
 			}
 			logging.Info("Using LocalStack endpoint", "endpoint", endpoint)
 			
@@ -119,8 +119,8 @@ func (h *AWSProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			endpoint, err = h.localStackManager.GetEndpoint()
 			if err != nil {
 				logging.Warn("Failed to get LocalStack endpoint", "error", err)
-				// Use default as last resort
-				endpoint = "http://localhost:4566"
+				// Use cluster-internal endpoint as last resort
+				endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
 			}
 			logging.Info("Initializing proxy with LocalStack endpoint", "endpoint", endpoint)
 		}

--- a/examples/service-with-secrets/task_def.json
+++ b/examples/service-with-secrets/task_def.json
@@ -32,15 +32,15 @@
       "secrets": [
         {
           "name": "DATABASE_URL",
-          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/database_url"
+          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/database-url"
         },
         {
           "name": "API_KEY",
-          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/api_key"
+          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/api-key"
         },
         {
           "name": "FEATURE_FLAGS",
-          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/feature_flags"
+          "valueFrom": "arn:aws:ssm:us-east-1:000000000000:parameter/myapp/prod/feature-flags"
         },
         {
           "name": "DB_PASSWORD",


### PR DESCRIPTION
## Summary
- Move SecretsController initialization outside LocalStack conditional block
- Add thread-safe setter methods for dynamic integration updates  
- Handle nil integrations gracefully with appropriate error messages
- Update integrations when LocalStack becomes available

## Problem
SecretsController was not being initialized at startup because it was inside the LocalStack initialization block with conditions that were not always met. This caused pods with secrets to fail with CreateContainerConfigError because the required ConfigMaps and Secrets were not being created from AWS SSM Parameter Store and Secrets Manager.

## Solution
- **Unconditional initialization**: SecretsController now starts immediately when the controlplane starts, regardless of LocalStack availability
- **Dynamic integration updates**: Added setter methods to allow SecretsController to receive SSM and Secrets Manager integrations after initialization
- **Thread-safe updates**: Used mutex to ensure thread-safe updates when integrations become available
- **Graceful nil handling**: Controller handles nil integrations gracefully and retries when they become available

## Test plan
- [x] SecretsController initializes at controlplane startup
- [x] Controller starts watching pods immediately
- [x] Integrations can be set dynamically when LocalStack becomes ready
- [x] Pods with secrets annotations are processed correctly
- [x] Secrets are synchronized to appropriate namespaces

🤖 Generated with [Claude Code](https://claude.ai/code)