### PR TITLE
fix: Correct JSON field capitalization for AWS API compatibility

### DIFF
--- a/controlplane/internal/secretsmanager/generated/types.go
+++ b/controlplane/internal/secretsmanager/generated/types.go
@@ -324,11 +324,11 @@ type GetResourcePolicyResponse struct {
 
 // GetSecretValueRequest represents the GetSecretValueRequest structure
 type GetSecretValueRequest struct {
-	SecretId string `json:"secretId"`
+	SecretId string `json:"SecretId"`
 
-	VersionId *string `json:"versionId,omitempty"`
+	VersionId *string `json:"VersionId,omitempty"`
 
-	VersionStage *string `json:"versionStage,omitempty"`
+	VersionStage *string `json:"VersionStage,omitempty"`
 }
 
 // GetSecretValueResponse represents the GetSecretValueResponse structure

--- a/controlplane/internal/secretsmanager/generated_example_test.go
+++ b/controlplane/internal/secretsmanager/generated_example_test.go
@@ -18,7 +18,7 @@ func TestGeneratedTypes(t *testing.T) {
 var _ = Describe("Secrets Manager Generated Types", func() {
 	Describe("GetSecretValueRequest", func() {
 		Context("when marshaling to JSON", func() {
-			It("should use camelCase field names", func() {
+			It("should use PascalCase field names for AWS API compatibility", func() {
 				req := &sm.GetSecretValueRequest{
 					SecretId:     "my-secret",
 					VersionId:    stringPtr("v1"),
@@ -29,14 +29,14 @@ var _ = Describe("Secrets Manager Generated Types", func() {
 				data, err := json.Marshal(req)
 				Expect(err).NotTo(HaveOccurred())
 
-				// Verify JSON has camelCase fields
+				// Verify JSON has PascalCase fields (AWS standard)
 				var jsonMap map[string]interface{}
 				err = json.Unmarshal(data, &jsonMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(jsonMap["secretId"]).To(Equal("my-secret"))
-				Expect(jsonMap["versionId"]).To(Equal("v1"))
-				Expect(jsonMap["versionStage"]).To(Equal("AWSCURRENT"))
+				Expect(jsonMap["SecretId"]).To(Equal("my-secret"))
+				Expect(jsonMap["VersionId"]).To(Equal("v1"))
+				Expect(jsonMap["VersionStage"]).To(Equal("AWSCURRENT"))
 			})
 		})
 	})

--- a/controlplane/internal/ssm/generated/types.go
+++ b/controlplane/internal/ssm/generated/types.go
@@ -4091,9 +4091,9 @@ type GetParameterHistoryResult struct {
 
 // GetParameterRequest represents the GetParameterRequest structure
 type GetParameterRequest struct {
-	Name string `json:"name"`
+	Name string `json:"Name"`
 
-	WithDecryption *bool `json:"withDecryption,omitempty"`
+	WithDecryption *bool `json:"WithDecryption,omitempty"`
 }
 
 // GetParameterResult represents the GetParameterResult structure
@@ -4128,9 +4128,9 @@ type GetParametersByPathResult struct {
 
 // GetParametersRequest represents the GetParametersRequest structure
 type GetParametersRequest struct {
-	Names []string `json:"names"`
+	Names []string `json:"Names"`
 
-	WithDecryption *bool `json:"withDecryption,omitempty"`
+	WithDecryption *bool `json:"WithDecryption,omitempty"`
 }
 
 // GetParametersResult represents the GetParametersResult structure


### PR DESCRIPTION
## Summary
Fixed JSON struct tags in generated types to use proper AWS API field names for LocalStack compatibility.

## Problem
- LocalStack integration was failing with errors like "NoneType object has no attribute 'split'" 
- Root cause: JSON field names were using camelCase instead of PascalCase (AWS standard)

## Changes
- **SSM types**: 
  - `GetParameterRequest`: name → Name, withDecryption → WithDecryption
  - `GetParametersRequest`: names → Names, withDecryption → WithDecryption
- **Secrets Manager types**:
  - `GetSecretValueRequest`: secretId → SecretId, versionId → VersionId, versionStage → VersionStage
- Updated test to expect PascalCase fields for AWS API compatibility

## Test Plan
- [x] Unit tests pass
- [x] Verified JSON marshaling produces correct field names
- [ ] Test with LocalStack integration

🤖 Generated with [Claude Code](https://claude.ai/code)