### PR TITLE
feat: Enable k3d registry automatically when DevMode is enabled

### DIFF
--- a/controlplane/internal/instance/helpers.go
+++ b/controlplane/internal/instance/helpers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes/resources"
 	"github.com/nandemo-ya/kecs/controlplane/internal/localstack"
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
 	"github.com/nandemo-ya/kecs/controlplane/internal/utils"
 )
 
@@ -57,6 +58,16 @@ func (m *Manager) createCluster(ctx context.Context, instanceName string, cfg *c
 	if cfg.LocalStack.Enabled {
 		// LocalStack always uses fixed NodePort 30566
 		portMappings[4566] = 30566
+	}
+
+	// Update k3dManager configuration based on DevMode
+	// Note: This modifies the shared k3dManager config, but it's safe because
+	// each instance creation is sequential
+	if opts.DevMode {
+		logging.Info("DevMode enabled, enabling k3d registry for hot reload support")
+		m.k3dManager.SetEnableRegistry(true)
+	} else {
+		m.k3dManager.SetEnableRegistry(false)
 	}
 
 	// Create cluster with port mappings

--- a/controlplane/internal/kubernetes/k3d_cluster_manager.go
+++ b/controlplane/internal/kubernetes/k3d_cluster_manager.go
@@ -61,6 +61,11 @@ func NewK3dClusterManager(cfg *ClusterManagerConfig) (*K3dClusterManager, error)
 	}, nil
 }
 
+// SetEnableRegistry sets whether to enable k3d registry for the cluster
+func (k *K3dClusterManager) SetEnableRegistry(enable bool) {
+	k.config.EnableRegistry = enable
+}
+
 // CreateCluster creates a new k3d cluster with optimizations based on environment
 func (k *K3dClusterManager) CreateCluster(ctx context.Context, clusterName string) error {
 	// Use optimized creation for test mode or when explicitly requested


### PR DESCRIPTION
## Summary
- Add automatic k3d registry creation when DevMode (`--dev`) flag is used with TUI instances
- Registry is dynamically enabled based on the DevMode flag for each instance

## Problem
When creating KECS instances through TUI with `--dev` flag, the registry was not being created even though DevMode was enabled. This prevented hot reload functionality from working.

## Solution
1. Added `SetEnableRegistry()` method to `K3dClusterManager` to dynamically set registry configuration
2. Check `opts.DevMode` flag in `createCluster()` and enable/disable registry accordingly
3. Leverage the auto-creation functionality from PR #466

## Test Results
✅ Tested with `kecs start --instance devtest --dev --api-port 8091`:
- Registry container (`k3d-kecs-registry.localhost`) was automatically created
- Images can be pushed to the registry
- Hot reload functionality works (after fixing kubeconfig)

## Test plan
- [x] Create instance with DevMode: `kecs start --instance test --dev`
- [x] Verify registry is created: `docker ps | grep registry`
- [x] Test hot reload: `KECS_INSTANCE=test make hot-reload`
- [x] Create instance without DevMode: `kecs start --instance test2`
- [x] Verify registry is not created for non-dev instances

🤖 Generated with [Claude Code](https://claude.ai/code)