### PR TITLE
feat: Update Traefik to v3.5.0

### DIFF
--- a/controlplane/internal/instance/helpers.go
+++ b/controlplane/internal/instance/helpers.go
@@ -250,7 +250,7 @@ func (m *Manager) deployTraefik(ctx context.Context, instanceName string, cfg *c
 
 	// Create Traefik config
 	traefikConfig := &resources.TraefikConfig{
-		Image:           "traefik:v3.2",
+		Image:           "traefik:v3.5.0",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CPURequest:      "100m",
 		MemoryRequest:   "128Mi",

--- a/controlplane/internal/integrations/elbv2/integration_k8s.go
+++ b/controlplane/internal/integrations/elbv2/integration_k8s.go
@@ -641,7 +641,7 @@ func (i *k8sIntegration) createDeployment(ctx context.Context, namespace, traefi
 					Containers: []corev1.Container{
 						{
 							Name:  "traefik",
-							Image: "traefik:v3.0",
+							Image: "traefik:v3.5.0",
 							Args: []string{
 								"--configfile=/config/traefik.yml",
 							},

--- a/controlplane/internal/kubernetes/manifests/traefik.yaml
+++ b/controlplane/internal/kubernetes/manifests/traefik.yaml
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: traefik
       containers:
       - name: traefik
-        image: traefik:v3.0
+        image: traefik:v3.5.0
         args:
           - --configfile=/config/traefik.yml
         ports:

--- a/controlplane/internal/kubernetes/resources/traefik.go
+++ b/controlplane/internal/kubernetes/resources/traefik.go
@@ -58,7 +58,7 @@ type TraefikConfig struct {
 // DefaultTraefikConfig returns default configuration
 func DefaultTraefikConfig() *TraefikConfig {
 	return &TraefikConfig{
-		Image:           "traefik:v3.2",
+		Image:           "traefik:v3.5.0",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		CPURequest:      "100m",
 		MemoryRequest:   "128Mi",

--- a/controlplane/kecs.yaml.example
+++ b/controlplane/kecs.yaml.example
@@ -85,4 +85,4 @@ aws:
 localstack:
   enabled: false
   services: []
-  # Additional LocalStack configuration options...
+  # Additional LocalStack configuration options


### PR DESCRIPTION
## Summary
- Update Traefik image from v3.0/v3.2 to v3.5.0 across all configuration files

## Changes
- Update manifest files (traefik.yaml)
- Update integration code (elbv2/integration_k8s.go)
- Update resource configurations (helpers.go, traefik.go)

## Test plan
- [x] Build the project successfully
- [ ] Deploy and verify Traefik v3.5.0 is running
- [ ] Test routing functionality remains intact

🤖 Generated with Claude Code