### PR TITLE
fix: Handle AWS API numeric Unix timestamps correctly

### DIFF
--- a/controlplane/internal/common/common_suite_test.go
+++ b/controlplane/internal/common/common_suite_test.go
@@ -1,0 +1,13 @@
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/controlplane/internal/common/unix_time.go
+++ b/controlplane/internal/common/unix_time.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+)
+
+// UnixTime is a custom time type that handles AWS API's numeric Unix timestamps
+// AWS APIs return timestamps as numbers (Unix epoch with fractional seconds)
+// rather than RFC3339 strings.
+type UnixTime struct {
+	time.Time
+}
+
+// UnmarshalJSON implements json.Unmarshaler for UnixTime
+// It can handle both numeric Unix timestamps and RFC3339 strings
+func (t *UnixTime) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as a number (Unix timestamp)
+	var timestamp float64
+	if err := json.Unmarshal(data, &timestamp); err == nil {
+		// Convert Unix timestamp to time.Time
+		// Round to millisecond precision to avoid floating point issues
+		// AWS typically provides timestamps with millisecond precision
+		millis := int64(math.Round(timestamp * 1000))
+		sec := millis / 1000
+		nsec := (millis % 1000) * 1e6
+		t.Time = time.Unix(sec, nsec)
+		return nil
+	}
+
+	// Fall back to string format (RFC3339)
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return fmt.Errorf("cannot unmarshal %s into UnixTime", data)
+	}
+
+	parsedTime, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return fmt.Errorf("cannot parse %s as RFC3339: %w", str, err)
+	}
+
+	t.Time = parsedTime
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for UnixTime
+// It marshals the time as a Unix timestamp (number) to match AWS API format
+func (t UnixTime) MarshalJSON() ([]byte, error) {
+	if t.Time.IsZero() {
+		return []byte("null"), nil
+	}
+
+	// Convert to Unix timestamp with fractional seconds
+	timestamp := float64(t.Time.Unix()) + float64(t.Time.Nanosecond())/1e9
+	
+	// Round to 3 decimal places to match AWS format
+	timestamp = math.Round(timestamp*1000) / 1000
+	
+	return json.Marshal(timestamp)
+}
+
+// NewUnixTime creates a new UnixTime from a time.Time
+func NewUnixTime(t time.Time) *UnixTime {
+	return &UnixTime{Time: t}
+}
+
+// ToTime converts UnixTime pointer to time.Time pointer
+func (t *UnixTime) ToTime() *time.Time {
+	if t == nil {
+		return nil
+	}
+	return &t.Time
+}
+
+// FromTime converts time.Time pointer to UnixTime pointer
+func FromTime(t *time.Time) *UnixTime {
+	if t == nil {
+		return nil
+	}
+	return &UnixTime{Time: *t}
+}

--- a/controlplane/internal/common/unix_time_test.go
+++ b/controlplane/internal/common/unix_time_test.go
@@ -1,0 +1,120 @@
+package common_test
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/common"
+)
+
+var _ = Describe("UnixTime", func() {
+	Describe("UnmarshalJSON", func() {
+		Context("when unmarshaling numeric Unix timestamp", func() {
+			It("should handle integer timestamp", func() {
+				data := []byte("1755005925")
+				var ut common.UnixTime
+				err := json.Unmarshal(data, &ut)
+				Expect(err).ToNot(HaveOccurred())
+				
+				// Check the time is correct (2025-08-11 13:18:45 UTC)
+				expectedTime := time.Unix(1755005925, 0)
+				Expect(ut.Time.Unix()).To(Equal(expectedTime.Unix()))
+			})
+
+			It("should handle timestamp with fractional seconds", func() {
+				data := []byte("1755005925.233")
+				var ut common.UnixTime
+				err := json.Unmarshal(data, &ut)
+				Expect(err).ToNot(HaveOccurred())
+				
+				// Check the time including nanoseconds
+				expectedTime := time.Unix(1755005925, 233000000)
+				Expect(ut.Time.UnixNano()).To(Equal(expectedTime.UnixNano()))
+			})
+
+			It("should handle LocalStack response format", func() {
+				// Actual LocalStack response
+				response := `{"LastModifiedDate": 1755005925.233, "Name": "/myapp/prod/database-url"}`
+				
+				type TestStruct struct {
+					LastModifiedDate *common.UnixTime `json:"LastModifiedDate,omitempty"`
+					Name             *string          `json:"Name,omitempty"`
+				}
+				
+				var result TestStruct
+				err := json.Unmarshal([]byte(response), &result)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.LastModifiedDate).ToNot(BeNil())
+				Expect(result.LastModifiedDate.Unix()).To(Equal(int64(1755005925)))
+			})
+		})
+
+		Context("when unmarshaling RFC3339 string", func() {
+			It("should handle RFC3339 format", func() {
+				data := []byte(`"2025-08-12T13:18:45Z"`)
+				var ut common.UnixTime
+				err := json.Unmarshal(data, &ut)
+				Expect(err).ToNot(HaveOccurred())
+				
+				// Parse the expected time to verify
+				expectedTime, _ := time.Parse(time.RFC3339, "2025-08-12T13:18:45Z")
+				Expect(ut.Time.Unix()).To(Equal(expectedTime.Unix()))
+			})
+		})
+
+		Context("when unmarshaling invalid data", func() {
+			It("should return error for invalid format", func() {
+				data := []byte(`{"invalid": "object"}`)
+				var ut common.UnixTime
+				err := json.Unmarshal(data, &ut)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cannot unmarshal"))
+			})
+		})
+	})
+
+	Describe("MarshalJSON", func() {
+		Context("when marshaling UnixTime", func() {
+			It("should marshal as numeric Unix timestamp", func() {
+				ut := common.UnixTime{Time: time.Unix(1755005925, 233000000)}
+				data, err := json.Marshal(ut)
+				Expect(err).ToNot(HaveOccurred())
+				
+				// Should be numeric format with 3 decimal places
+				Expect(string(data)).To(Equal("1755005925.233"))
+			})
+
+			It("should handle zero time", func() {
+				ut := common.UnixTime{}
+				data, err := json.Marshal(ut)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(data)).To(Equal("null"))
+			})
+		})
+	})
+
+	Describe("Helper functions", func() {
+		It("should convert between UnixTime and time.Time", func() {
+			now := time.Now()
+			ut := common.NewUnixTime(now)
+			Expect(ut.Time).To(Equal(now))
+			
+			timePtr := ut.ToTime()
+			Expect(*timePtr).To(Equal(now))
+			
+			utFromTime := common.FromTime(&now)
+			Expect(utFromTime.Time).To(Equal(now))
+		})
+
+		It("should handle nil pointers", func() {
+			var ut *common.UnixTime
+			Expect(ut.ToTime()).To(BeNil())
+			
+			var t *time.Time
+			Expect(common.FromTime(t)).To(BeNil())
+		})
+	})
+})

--- a/controlplane/internal/integrations/secretsmanager/integration.go
+++ b/controlplane/internal/integrations/secretsmanager/integration.go
@@ -136,7 +136,7 @@ func (i *integration) GetSecret(ctx context.Context, secretName string) (*Secret
 		Name:         getString(result.Name),
 		VersionId:    getString(result.VersionId),
 		VersionStage: result.VersionStages,
-		CreatedDate:  getTime(result.CreatedDate),
+		CreatedDate:  getTime(result.CreatedDate.ToTime()),
 	}
 
 	// Handle string vs binary secret

--- a/controlplane/internal/integrations/ssm/integration.go
+++ b/controlplane/internal/integrations/ssm/integration.go
@@ -143,7 +143,7 @@ func (i *integration) GetParameter(ctx context.Context, parameterName string) (*
 		Value:        getString(result.Parameter.Value),
 		Type:         getParameterType(result.Parameter.Type),
 		Version:      getInt64(result.Parameter.Version),
-		LastModified: getTime(result.Parameter.LastModifiedDate),
+		LastModified: getTime(result.Parameter.LastModifiedDate.ToTime()),
 	}
 
 	// Cache the parameter

--- a/controlplane/internal/secretsmanager/generated/types.go
+++ b/controlplane/internal/secretsmanager/generated/types.go
@@ -4,6 +4,8 @@ package generated
 
 import (
 	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/common"
 )
 
 // Unit represents an empty response
@@ -147,7 +149,7 @@ type DeleteSecretRequest struct {
 type DeleteSecretResponse struct {
 	ARN *string `json:"ARN,omitempty"`
 
-	DeletionDate *time.Time `json:"DeletionDate,omitempty"`
+	DeletionDate *common.UnixTime `json:"DeletionDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 }
@@ -167,23 +169,23 @@ type DescribeSecretRequest struct {
 type DescribeSecretResponse struct {
 	ARN *string `json:"ARN,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
-	DeletedDate *time.Time `json:"DeletedDate,omitempty"`
+	DeletedDate *common.UnixTime `json:"DeletedDate,omitempty"`
 
 	Description *string `json:"Description,omitempty"`
 
 	KmsKeyId *string `json:"KmsKeyId,omitempty"`
 
-	LastAccessedDate *time.Time `json:"LastAccessedDate,omitempty"`
+	LastAccessedDate *common.UnixTime `json:"LastAccessedDate,omitempty"`
 
-	LastChangedDate *time.Time `json:"LastChangedDate,omitempty"`
+	LastChangedDate *common.UnixTime `json:"LastChangedDate,omitempty"`
 
-	LastRotatedDate *time.Time `json:"LastRotatedDate,omitempty"`
+	LastRotatedDate *common.UnixTime `json:"LastRotatedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
-	NextRotationDate *time.Time `json:"NextRotationDate,omitempty"`
+	NextRotationDate *common.UnixTime `json:"NextRotationDate,omitempty"`
 
 	OwningService *string `json:"OwningService,omitempty"`
 
@@ -316,7 +318,7 @@ type GetSecretValueRequest struct {
 type GetSecretValueResponse struct {
 	ARN *string `json:"ARN,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -671,7 +673,7 @@ type ReplicationStatusListType []ReplicationStatusType
 type ReplicationStatusType struct {
 	KmsKeyId *string `json:"KmsKeyId,omitempty"`
 
-	LastAccessedDate *time.Time `json:"LastAccessedDate,omitempty"`
+	LastAccessedDate *common.UnixTime `json:"LastAccessedDate,omitempty"`
 
 	Region *string `json:"Region,omitempty"`
 
@@ -794,23 +796,23 @@ type SecretIdType string
 type SecretListEntry struct {
 	ARN *string `json:"ARN,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
-	DeletedDate *time.Time `json:"DeletedDate,omitempty"`
+	DeletedDate *common.UnixTime `json:"DeletedDate,omitempty"`
 
 	Description *string `json:"Description,omitempty"`
 
 	KmsKeyId *string `json:"KmsKeyId,omitempty"`
 
-	LastAccessedDate *time.Time `json:"LastAccessedDate,omitempty"`
+	LastAccessedDate *common.UnixTime `json:"LastAccessedDate,omitempty"`
 
-	LastChangedDate *time.Time `json:"LastChangedDate,omitempty"`
+	LastChangedDate *common.UnixTime `json:"LastChangedDate,omitempty"`
 
-	LastRotatedDate *time.Time `json:"LastRotatedDate,omitempty"`
+	LastRotatedDate *common.UnixTime `json:"LastRotatedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
-	NextRotationDate *time.Time `json:"NextRotationDate,omitempty"`
+	NextRotationDate *common.UnixTime `json:"NextRotationDate,omitempty"`
 
 	OwningService *string `json:"OwningService,omitempty"`
 
@@ -840,7 +842,7 @@ type SecretStringType string
 type SecretValueEntry struct {
 	ARN *string `json:"ARN,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -867,11 +869,11 @@ type SecretVersionStagesType []string
 
 // SecretVersionsListEntry represents the SecretVersionsListEntry structure
 type SecretVersionsListEntry struct {
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	KmsKeyIds []string `json:"KmsKeyIds,omitempty"`
 
-	LastAccessedDate *time.Time `json:"LastAccessedDate,omitempty"`
+	LastAccessedDate *common.UnixTime `json:"LastAccessedDate,omitempty"`
 
 	VersionId *string `json:"VersionId,omitempty"`
 

--- a/controlplane/internal/ssm/generated/types.go
+++ b/controlplane/internal/ssm/generated/types.go
@@ -4,6 +4,8 @@ package generated
 
 import (
 	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/common"
 )
 
 // Unit represents an empty response
@@ -64,13 +66,13 @@ type Accounts []string
 type Activation struct {
 	ActivationId *string `json:"ActivationId,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	DefaultInstanceName *string `json:"DefaultInstanceName,omitempty"`
 
 	Description *string `json:"Description,omitempty"`
 
-	ExpirationDate *time.Time `json:"ExpirationDate,omitempty"`
+	ExpirationDate *common.UnixTime `json:"ExpirationDate,omitempty"`
 
 	Expired *bool `json:"Expired,omitempty"`
 
@@ -229,7 +231,7 @@ type Association struct {
 
 	InstanceId *string `json:"InstanceId,omitempty"`
 
-	LastExecutionDate *time.Time `json:"LastExecutionDate,omitempty"`
+	LastExecutionDate *common.UnixTime `json:"LastExecutionDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -281,7 +283,7 @@ type AssociationDescription struct {
 
 	ComplianceSeverity *AssociationComplianceSeverity `json:"ComplianceSeverity,omitempty"`
 
-	Date *time.Time `json:"Date,omitempty"`
+	Date *common.UnixTime `json:"Date,omitempty"`
 
 	DocumentVersion *string `json:"DocumentVersion,omitempty"`
 
@@ -289,11 +291,11 @@ type AssociationDescription struct {
 
 	InstanceId *string `json:"InstanceId,omitempty"`
 
-	LastExecutionDate *time.Time `json:"LastExecutionDate,omitempty"`
+	LastExecutionDate *common.UnixTime `json:"LastExecutionDate,omitempty"`
 
-	LastSuccessfulExecutionDate *time.Time `json:"LastSuccessfulExecutionDate,omitempty"`
+	LastSuccessfulExecutionDate *common.UnixTime `json:"LastSuccessfulExecutionDate,omitempty"`
 
-	LastUpdateAssociationDate *time.Time `json:"LastUpdateAssociationDate,omitempty"`
+	LastUpdateAssociationDate *common.UnixTime `json:"LastUpdateAssociationDate,omitempty"`
 
 	MaxConcurrency *string `json:"MaxConcurrency,omitempty"`
 
@@ -355,13 +357,13 @@ type AssociationExecution struct {
 
 	AssociationVersion *string `json:"AssociationVersion,omitempty"`
 
-	CreatedTime *time.Time `json:"CreatedTime,omitempty"`
+	CreatedTime *common.UnixTime `json:"CreatedTime,omitempty"`
 
 	DetailedStatus *string `json:"DetailedStatus,omitempty"`
 
 	ExecutionId *string `json:"ExecutionId,omitempty"`
 
-	LastExecutionDate *time.Time `json:"LastExecutionDate,omitempty"`
+	LastExecutionDate *common.UnixTime `json:"LastExecutionDate,omitempty"`
 
 	ResourceCountByStatus *string `json:"ResourceCountByStatus,omitempty"`
 
@@ -418,7 +420,7 @@ type AssociationExecutionTarget struct {
 
 	ExecutionId *string `json:"ExecutionId,omitempty"`
 
-	LastExecutionDate *time.Time `json:"LastExecutionDate,omitempty"`
+	LastExecutionDate *common.UnixTime `json:"LastExecutionDate,omitempty"`
 
 	OutputSource *OutputSource `json:"OutputSource,omitempty"`
 
@@ -538,7 +540,7 @@ type AssociationVersionInfo struct {
 
 	ComplianceSeverity *AssociationComplianceSeverity `json:"ComplianceSeverity,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	DocumentVersion *string `json:"DocumentVersion,omitempty"`
 
@@ -737,9 +739,9 @@ type AutomationExecution struct {
 
 	ExecutedBy *string `json:"ExecutedBy,omitempty"`
 
-	ExecutionEndTime *time.Time `json:"ExecutionEndTime,omitempty"`
+	ExecutionEndTime *common.UnixTime `json:"ExecutionEndTime,omitempty"`
 
-	ExecutionStartTime *time.Time `json:"ExecutionStartTime,omitempty"`
+	ExecutionStartTime *common.UnixTime `json:"ExecutionStartTime,omitempty"`
 
 	FailureMessage *string `json:"FailureMessage,omitempty"`
 
@@ -763,7 +765,7 @@ type AutomationExecution struct {
 
 	Runbooks []Runbook `json:"Runbooks,omitempty"`
 
-	ScheduledTime *time.Time `json:"ScheduledTime,omitempty"`
+	ScheduledTime *common.UnixTime `json:"ScheduledTime,omitempty"`
 
 	StepExecutions []StepExecution `json:"StepExecutions,omitempty"`
 
@@ -866,9 +868,9 @@ type AutomationExecutionMetadata struct {
 
 	ExecutedBy *string `json:"ExecutedBy,omitempty"`
 
-	ExecutionEndTime *time.Time `json:"ExecutionEndTime,omitempty"`
+	ExecutionEndTime *common.UnixTime `json:"ExecutionEndTime,omitempty"`
 
-	ExecutionStartTime *time.Time `json:"ExecutionStartTime,omitempty"`
+	ExecutionStartTime *common.UnixTime `json:"ExecutionStartTime,omitempty"`
 
 	FailureMessage *string `json:"FailureMessage,omitempty"`
 
@@ -890,7 +892,7 @@ type AutomationExecutionMetadata struct {
 
 	Runbooks []Runbook `json:"Runbooks,omitempty"`
 
-	ScheduledTime *time.Time `json:"ScheduledTime,omitempty"`
+	ScheduledTime *common.UnixTime `json:"ScheduledTime,omitempty"`
 
 	Target *string `json:"Target,omitempty"`
 
@@ -1090,7 +1092,7 @@ type Command struct {
 
 	ErrorCount *int32 `json:"ErrorCount,omitempty"`
 
-	ExpiresAfter *time.Time `json:"ExpiresAfter,omitempty"`
+	ExpiresAfter *common.UnixTime `json:"ExpiresAfter,omitempty"`
 
 	InstanceIds []string `json:"InstanceIds,omitempty"`
 
@@ -1108,7 +1110,7 @@ type Command struct {
 
 	Parameters map[string][]string `json:"Parameters,omitempty"`
 
-	RequestedDateTime *time.Time `json:"RequestedDateTime,omitempty"`
+	RequestedDateTime *common.UnixTime `json:"RequestedDateTime,omitempty"`
 
 	ServiceRole *string `json:"ServiceRole,omitempty"`
 
@@ -1161,7 +1163,7 @@ type CommandInvocation struct {
 
 	NotificationConfig *NotificationConfig `json:"NotificationConfig,omitempty"`
 
-	RequestedDateTime *time.Time `json:"RequestedDateTime,omitempty"`
+	RequestedDateTime *common.UnixTime `json:"RequestedDateTime,omitempty"`
 
 	ServiceRole *string `json:"ServiceRole,omitempty"`
 
@@ -1199,9 +1201,9 @@ type CommandPlugin struct {
 
 	ResponseCode *int32 `json:"ResponseCode,omitempty"`
 
-	ResponseFinishDateTime *time.Time `json:"ResponseFinishDateTime,omitempty"`
+	ResponseFinishDateTime *common.UnixTime `json:"ResponseFinishDateTime,omitempty"`
 
-	ResponseStartDateTime *time.Time `json:"ResponseStartDateTime,omitempty"`
+	ResponseStartDateTime *common.UnixTime `json:"ResponseStartDateTime,omitempty"`
 
 	StandardErrorUrl *string `json:"StandardErrorUrl,omitempty"`
 
@@ -1384,7 +1386,7 @@ type CreateActivationRequest struct {
 
 	Description *string `json:"Description,omitempty"`
 
-	ExpirationDate *time.Time `json:"ExpirationDate,omitempty"`
+	ExpirationDate *common.UnixTime `json:"ExpirationDate,omitempty"`
 
 	IamRole string `json:"IamRole"`
 
@@ -1574,9 +1576,9 @@ type CreateMaintenanceWindowResult struct {
 type CreateOpsItemRequest struct {
 	AccountId *string `json:"AccountId,omitempty"`
 
-	ActualEndTime *time.Time `json:"ActualEndTime,omitempty"`
+	ActualEndTime *common.UnixTime `json:"ActualEndTime,omitempty"`
 
-	ActualStartTime *time.Time `json:"ActualStartTime,omitempty"`
+	ActualStartTime *common.UnixTime `json:"ActualStartTime,omitempty"`
 
 	Category *string `json:"Category,omitempty"`
 
@@ -1588,9 +1590,9 @@ type CreateOpsItemRequest struct {
 
 	OpsItemType *string `json:"OpsItemType,omitempty"`
 
-	PlannedEndTime *time.Time `json:"PlannedEndTime,omitempty"`
+	PlannedEndTime *common.UnixTime `json:"PlannedEndTime,omitempty"`
 
-	PlannedStartTime *time.Time `json:"PlannedStartTime,omitempty"`
+	PlannedStartTime *common.UnixTime `json:"PlannedStartTime,omitempty"`
 
 	Priority *int32 `json:"Priority,omitempty"`
 
@@ -2589,7 +2591,7 @@ type DocumentDescription struct {
 
 	CategoryEnum []string `json:"CategoryEnum,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	DefaultVersion *string `json:"DefaultVersion,omitempty"`
 
@@ -2663,7 +2665,7 @@ type DocumentHash string
 type DocumentIdentifier struct {
 	Author *string `json:"Author,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	DisplayName *string `json:"DisplayName,omitempty"`
 
@@ -2825,13 +2827,13 @@ type DocumentReviewerResponseList []DocumentReviewerResponseSource
 type DocumentReviewerResponseSource struct {
 	Comment []DocumentReviewCommentSource `json:"Comment,omitempty"`
 
-	CreateTime *time.Time `json:"CreateTime,omitempty"`
+	CreateTime *common.UnixTime `json:"CreateTime,omitempty"`
 
 	ReviewStatus *ReviewStatus `json:"ReviewStatus,omitempty"`
 
 	Reviewer *string `json:"Reviewer,omitempty"`
 
-	UpdatedTime *time.Time `json:"UpdatedTime,omitempty"`
+	UpdatedTime *common.UnixTime `json:"UpdatedTime,omitempty"`
 }
 
 // DocumentReviews represents the DocumentReviews structure
@@ -2855,7 +2857,7 @@ type DocumentVersion string
 
 // DocumentVersionInfo represents the DocumentVersionInfo structure
 type DocumentVersionInfo struct {
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	DisplayName *string `json:"DisplayName,omitempty"`
 
@@ -3221,7 +3223,7 @@ type GetDocumentResult struct {
 
 	Content *string `json:"Content,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	DisplayName *string `json:"DisplayName,omitempty"`
 
@@ -3251,7 +3253,7 @@ type GetExecutionPreviewRequest struct {
 
 // GetExecutionPreviewResponse represents the GetExecutionPreviewResponse structure
 type GetExecutionPreviewResponse struct {
-	EndedAt *time.Time `json:"EndedAt,omitempty"`
+	EndedAt *common.UnixTime `json:"EndedAt,omitempty"`
 
 	ExecutionPreview *ExecutionPreview `json:"ExecutionPreview,omitempty"`
 
@@ -3312,9 +3314,9 @@ type GetMaintenanceWindowExecutionRequest struct {
 
 // GetMaintenanceWindowExecutionResult represents the GetMaintenanceWindowExecutionResult structure
 type GetMaintenanceWindowExecutionResult struct {
-	EndTime *time.Time `json:"EndTime,omitempty"`
+	EndTime *common.UnixTime `json:"EndTime,omitempty"`
 
-	StartTime *time.Time `json:"StartTime,omitempty"`
+	StartTime *common.UnixTime `json:"StartTime,omitempty"`
 
 	Status *MaintenanceWindowExecutionStatus `json:"Status,omitempty"`
 
@@ -3336,7 +3338,7 @@ type GetMaintenanceWindowExecutionTaskInvocationRequest struct {
 
 // GetMaintenanceWindowExecutionTaskInvocationResult represents the GetMaintenanceWindowExecutionTaskInvocationResult structure
 type GetMaintenanceWindowExecutionTaskInvocationResult struct {
-	EndTime *time.Time `json:"EndTime,omitempty"`
+	EndTime *common.UnixTime `json:"EndTime,omitempty"`
 
 	ExecutionId *string `json:"ExecutionId,omitempty"`
 
@@ -3346,7 +3348,7 @@ type GetMaintenanceWindowExecutionTaskInvocationResult struct {
 
 	Parameters *string `json:"Parameters,omitempty"`
 
-	StartTime *time.Time `json:"StartTime,omitempty"`
+	StartTime *common.UnixTime `json:"StartTime,omitempty"`
 
 	Status *MaintenanceWindowExecutionStatus `json:"Status,omitempty"`
 
@@ -3372,7 +3374,7 @@ type GetMaintenanceWindowExecutionTaskRequest struct {
 type GetMaintenanceWindowExecutionTaskResult struct {
 	AlarmConfiguration *AlarmConfiguration `json:"AlarmConfiguration,omitempty"`
 
-	EndTime *time.Time `json:"EndTime,omitempty"`
+	EndTime *common.UnixTime `json:"EndTime,omitempty"`
 
 	MaxConcurrency *string `json:"MaxConcurrency,omitempty"`
 
@@ -3382,7 +3384,7 @@ type GetMaintenanceWindowExecutionTaskResult struct {
 
 	ServiceRole *string `json:"ServiceRole,omitempty"`
 
-	StartTime *time.Time `json:"StartTime,omitempty"`
+	StartTime *common.UnixTime `json:"StartTime,omitempty"`
 
 	Status *MaintenanceWindowExecutionStatus `json:"Status,omitempty"`
 
@@ -3410,7 +3412,7 @@ type GetMaintenanceWindowRequest struct {
 type GetMaintenanceWindowResult struct {
 	AllowUnassociatedTargets *bool `json:"AllowUnassociatedTargets,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	Cutoff *int32 `json:"Cutoff,omitempty"`
 
@@ -3422,7 +3424,7 @@ type GetMaintenanceWindowResult struct {
 
 	EndDate *string `json:"EndDate,omitempty"`
 
-	ModifiedDate *time.Time `json:"ModifiedDate,omitempty"`
+	ModifiedDate *common.UnixTime `json:"ModifiedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -3640,13 +3642,13 @@ type GetPatchBaselineResult struct {
 
 	BaselineId *string `json:"BaselineId,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	Description *string `json:"Description,omitempty"`
 
 	GlobalFilters *PatchFilterGroup `json:"GlobalFilters,omitempty"`
 
-	ModifiedDate *time.Time `json:"ModifiedDate,omitempty"`
+	ModifiedDate *common.UnixTime `json:"ModifiedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -3845,7 +3847,7 @@ type InstanceAssociationStatusInfo struct {
 
 	ErrorCode *string `json:"ErrorCode,omitempty"`
 
-	ExecutionDate *time.Time `json:"ExecutionDate,omitempty"`
+	ExecutionDate *common.UnixTime `json:"ExecutionDate,omitempty"`
 
 	ExecutionSummary *string `json:"ExecutionSummary,omitempty"`
 
@@ -3913,11 +3915,11 @@ type InstanceInformation struct {
 
 	IsLatestVersion *bool `json:"IsLatestVersion,omitempty"`
 
-	LastAssociationExecutionDate *time.Time `json:"LastAssociationExecutionDate,omitempty"`
+	LastAssociationExecutionDate *common.UnixTime `json:"LastAssociationExecutionDate,omitempty"`
 
-	LastPingDateTime *time.Time `json:"LastPingDateTime,omitempty"`
+	LastPingDateTime *common.UnixTime `json:"LastPingDateTime,omitempty"`
 
-	LastSuccessfulAssociationExecutionDate *time.Time `json:"LastSuccessfulAssociationExecutionDate,omitempty"`
+	LastSuccessfulAssociationExecutionDate *common.UnixTime `json:"LastSuccessfulAssociationExecutionDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -3929,7 +3931,7 @@ type InstanceInformation struct {
 
 	PlatformVersion *string `json:"PlatformVersion,omitempty"`
 
-	RegistrationDate *time.Time `json:"RegistrationDate,omitempty"`
+	RegistrationDate *common.UnixTime `json:"RegistrationDate,omitempty"`
 
 	ResourceType *ResourceType `json:"ResourceType,omitempty"`
 
@@ -3995,7 +3997,7 @@ type InstancePatchState struct {
 
 	InstanceId string `json:"InstanceId"`
 
-	LastNoRebootInstallOperationTime *time.Time `json:"LastNoRebootInstallOperationTime,omitempty"`
+	LastNoRebootInstallOperationTime *common.UnixTime `json:"LastNoRebootInstallOperationTime,omitempty"`
 
 	MissingCount *int32 `json:"MissingCount,omitempty"`
 
@@ -4080,13 +4082,13 @@ type InstanceProperty struct {
 
 	KeyName *string `json:"KeyName,omitempty"`
 
-	LastAssociationExecutionDate *time.Time `json:"LastAssociationExecutionDate,omitempty"`
+	LastAssociationExecutionDate *common.UnixTime `json:"LastAssociationExecutionDate,omitempty"`
 
-	LastPingDateTime *time.Time `json:"LastPingDateTime,omitempty"`
+	LastPingDateTime *common.UnixTime `json:"LastPingDateTime,omitempty"`
 
-	LastSuccessfulAssociationExecutionDate *time.Time `json:"LastSuccessfulAssociationExecutionDate,omitempty"`
+	LastSuccessfulAssociationExecutionDate *common.UnixTime `json:"LastSuccessfulAssociationExecutionDate,omitempty"`
 
-	LaunchTime *time.Time `json:"LaunchTime,omitempty"`
+	LaunchTime *common.UnixTime `json:"LaunchTime,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -4098,7 +4100,7 @@ type InstanceProperty struct {
 
 	PlatformVersion *string `json:"PlatformVersion,omitempty"`
 
-	RegistrationDate *time.Time `json:"RegistrationDate,omitempty"`
+	RegistrationDate *common.UnixTime `json:"RegistrationDate,omitempty"`
 
 	ResourceType *string `json:"ResourceType,omitempty"`
 
@@ -5202,7 +5204,7 @@ type InventoryDeletionStartTime time.Time
 type InventoryDeletionStatusItem struct {
 	DeletionId *string `json:"DeletionId,omitempty"`
 
-	DeletionStartTime *time.Time `json:"DeletionStartTime,omitempty"`
+	DeletionStartTime *common.UnixTime `json:"DeletionStartTime,omitempty"`
 
 	DeletionSummary *InventoryDeletionSummary `json:"DeletionSummary,omitempty"`
 
@@ -5210,7 +5212,7 @@ type InventoryDeletionStatusItem struct {
 
 	LastStatusMessage *string `json:"LastStatusMessage,omitempty"`
 
-	LastStatusUpdateTime *time.Time `json:"LastStatusUpdateTime,omitempty"`
+	LastStatusUpdateTime *common.UnixTime `json:"LastStatusUpdateTime,omitempty"`
 
 	TypeName *string `json:"TypeName,omitempty"`
 }
@@ -5846,9 +5848,9 @@ type MaintenanceWindowEnabled bool
 
 // MaintenanceWindowExecution represents the MaintenanceWindowExecution structure
 type MaintenanceWindowExecution struct {
-	EndTime *time.Time `json:"EndTime,omitempty"`
+	EndTime *common.UnixTime `json:"EndTime,omitempty"`
 
-	StartTime *time.Time `json:"StartTime,omitempty"`
+	StartTime *common.UnixTime `json:"StartTime,omitempty"`
 
 	Status *MaintenanceWindowExecutionStatus `json:"Status,omitempty"`
 
@@ -5881,9 +5883,9 @@ type MaintenanceWindowExecutionTaskIdList []string
 type MaintenanceWindowExecutionTaskIdentity struct {
 	AlarmConfiguration *AlarmConfiguration `json:"AlarmConfiguration,omitempty"`
 
-	EndTime *time.Time `json:"EndTime,omitempty"`
+	EndTime *common.UnixTime `json:"EndTime,omitempty"`
 
-	StartTime *time.Time `json:"StartTime,omitempty"`
+	StartTime *common.UnixTime `json:"StartTime,omitempty"`
 
 	Status *MaintenanceWindowExecutionStatus `json:"Status,omitempty"`
 
@@ -5908,7 +5910,7 @@ type MaintenanceWindowExecutionTaskInvocationId string
 
 // MaintenanceWindowExecutionTaskInvocationIdentity represents the MaintenanceWindowExecutionTaskInvocationIdentity structure
 type MaintenanceWindowExecutionTaskInvocationIdentity struct {
-	EndTime *time.Time `json:"EndTime,omitempty"`
+	EndTime *common.UnixTime `json:"EndTime,omitempty"`
 
 	ExecutionId *string `json:"ExecutionId,omitempty"`
 
@@ -5918,7 +5920,7 @@ type MaintenanceWindowExecutionTaskInvocationIdentity struct {
 
 	Parameters *string `json:"Parameters,omitempty"`
 
-	StartTime *time.Time `json:"StartTime,omitempty"`
+	StartTime *common.UnixTime `json:"StartTime,omitempty"`
 
 	Status *MaintenanceWindowExecutionStatus `json:"Status,omitempty"`
 
@@ -6277,7 +6279,7 @@ type NextToken string
 
 // Node represents the Node structure
 type Node struct {
-	CaptureTime *time.Time `json:"CaptureTime,omitempty"`
+	CaptureTime *common.UnixTime `json:"CaptureTime,omitempty"`
 
 	Id *string `json:"Id,omitempty"`
 
@@ -6482,21 +6484,21 @@ type OpsFilterValueList []string
 
 // OpsItem represents the OpsItem structure
 type OpsItem struct {
-	ActualEndTime *time.Time `json:"ActualEndTime,omitempty"`
+	ActualEndTime *common.UnixTime `json:"ActualEndTime,omitempty"`
 
-	ActualStartTime *time.Time `json:"ActualStartTime,omitempty"`
+	ActualStartTime *common.UnixTime `json:"ActualStartTime,omitempty"`
 
 	Category *string `json:"Category,omitempty"`
 
 	CreatedBy *string `json:"CreatedBy,omitempty"`
 
-	CreatedTime *time.Time `json:"CreatedTime,omitempty"`
+	CreatedTime *common.UnixTime `json:"CreatedTime,omitempty"`
 
 	Description *string `json:"Description,omitempty"`
 
 	LastModifiedBy *string `json:"LastModifiedBy,omitempty"`
 
-	LastModifiedTime *time.Time `json:"LastModifiedTime,omitempty"`
+	LastModifiedTime *common.UnixTime `json:"LastModifiedTime,omitempty"`
 
 	Notifications []OpsItemNotification `json:"Notifications,omitempty"`
 
@@ -6508,9 +6510,9 @@ type OpsItem struct {
 
 	OpsItemType *string `json:"OpsItemType,omitempty"`
 
-	PlannedEndTime *time.Time `json:"PlannedEndTime,omitempty"`
+	PlannedEndTime *common.UnixTime `json:"PlannedEndTime,omitempty"`
 
-	PlannedStartTime *time.Time `json:"PlannedStartTime,omitempty"`
+	PlannedStartTime *common.UnixTime `json:"PlannedStartTime,omitempty"`
 
 	Priority *int32 `json:"Priority,omitempty"`
 
@@ -6642,7 +6644,7 @@ type OpsItemEventSummaries []OpsItemEventSummary
 type OpsItemEventSummary struct {
 	CreatedBy *OpsItemIdentity `json:"CreatedBy,omitempty"`
 
-	CreatedTime *time.Time `json:"CreatedTime,omitempty"`
+	CreatedTime *common.UnixTime `json:"CreatedTime,omitempty"`
 
 	Detail *string `json:"Detail,omitempty"`
 
@@ -6839,11 +6841,11 @@ type OpsItemRelatedItemSummary struct {
 
 	CreatedBy *OpsItemIdentity `json:"CreatedBy,omitempty"`
 
-	CreatedTime *time.Time `json:"CreatedTime,omitempty"`
+	CreatedTime *common.UnixTime `json:"CreatedTime,omitempty"`
 
 	LastModifiedBy *OpsItemIdentity `json:"LastModifiedBy,omitempty"`
 
-	LastModifiedTime *time.Time `json:"LastModifiedTime,omitempty"`
+	LastModifiedTime *common.UnixTime `json:"LastModifiedTime,omitempty"`
 
 	OpsItemId *string `json:"OpsItemId,omitempty"`
 
@@ -6884,19 +6886,19 @@ type OpsItemSummaries []OpsItemSummary
 
 // OpsItemSummary represents the OpsItemSummary structure
 type OpsItemSummary struct {
-	ActualEndTime *time.Time `json:"ActualEndTime,omitempty"`
+	ActualEndTime *common.UnixTime `json:"ActualEndTime,omitempty"`
 
-	ActualStartTime *time.Time `json:"ActualStartTime,omitempty"`
+	ActualStartTime *common.UnixTime `json:"ActualStartTime,omitempty"`
 
 	Category *string `json:"Category,omitempty"`
 
 	CreatedBy *string `json:"CreatedBy,omitempty"`
 
-	CreatedTime *time.Time `json:"CreatedTime,omitempty"`
+	CreatedTime *common.UnixTime `json:"CreatedTime,omitempty"`
 
 	LastModifiedBy *string `json:"LastModifiedBy,omitempty"`
 
-	LastModifiedTime *time.Time `json:"LastModifiedTime,omitempty"`
+	LastModifiedTime *common.UnixTime `json:"LastModifiedTime,omitempty"`
 
 	OperationalData map[string]OpsItemDataValue `json:"OperationalData,omitempty"`
 
@@ -6904,9 +6906,9 @@ type OpsItemSummary struct {
 
 	OpsItemType *string `json:"OpsItemType,omitempty"`
 
-	PlannedEndTime *time.Time `json:"PlannedEndTime,omitempty"`
+	PlannedEndTime *common.UnixTime `json:"PlannedEndTime,omitempty"`
 
-	PlannedStartTime *time.Time `json:"PlannedStartTime,omitempty"`
+	PlannedStartTime *common.UnixTime `json:"PlannedStartTime,omitempty"`
 
 	Priority *int32 `json:"Priority,omitempty"`
 
@@ -6927,9 +6929,9 @@ type OpsItemType string
 
 // OpsMetadata represents the OpsMetadata structure
 type OpsMetadata struct {
-	CreationDate *time.Time `json:"CreationDate,omitempty"`
+	CreationDate *common.UnixTime `json:"CreationDate,omitempty"`
 
-	LastModifiedDate *time.Time `json:"LastModifiedDate,omitempty"`
+	LastModifiedDate *common.UnixTime `json:"LastModifiedDate,omitempty"`
 
 	LastModifiedUser *string `json:"LastModifiedUser,omitempty"`
 
@@ -7128,7 +7130,7 @@ type Parameter struct {
 
 	DataType *string `json:"DataType,omitempty"`
 
-	LastModifiedDate *time.Time `json:"LastModifiedDate,omitempty"`
+	LastModifiedDate *common.UnixTime `json:"LastModifiedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 
@@ -7181,7 +7183,7 @@ type ParameterHistory struct {
 
 	Labels []string `json:"Labels,omitempty"`
 
-	LastModifiedDate *time.Time `json:"LastModifiedDate,omitempty"`
+	LastModifiedDate *common.UnixTime `json:"LastModifiedDate,omitempty"`
 
 	LastModifiedUser *string `json:"LastModifiedUser,omitempty"`
 
@@ -7274,7 +7276,7 @@ type ParameterMetadata struct {
 
 	KeyId *string `json:"KeyId,omitempty"`
 
-	LastModifiedDate *time.Time `json:"LastModifiedDate,omitempty"`
+	LastModifiedDate *common.UnixTime `json:"LastModifiedDate,omitempty"`
 
 	LastModifiedUser *string `json:"LastModifiedUser,omitempty"`
 
@@ -7482,7 +7484,7 @@ type Patch struct {
 
 	Release *string `json:"Release,omitempty"`
 
-	ReleaseDate *time.Time `json:"ReleaseDate,omitempty"`
+	ReleaseDate *common.UnixTime `json:"ReleaseDate,omitempty"`
 
 	Repository *string `json:"Repository,omitempty"`
 
@@ -7754,7 +7756,7 @@ type PatchSourceProductList []string
 
 // PatchStatus represents the PatchStatus structure
 type PatchStatus struct {
-	ApprovalDate *time.Time `json:"ApprovalDate,omitempty"`
+	ApprovalDate *common.UnixTime `json:"ApprovalDate,omitempty"`
 
 	ComplianceLevel *PatchComplianceLevel `json:"ComplianceLevel,omitempty"`
 
@@ -8219,17 +8221,17 @@ func (e ResourceDataSyncInvalidConfigurationException) ErrorFault() string {
 type ResourceDataSyncItem struct {
 	LastStatus *LastResourceDataSyncStatus `json:"LastStatus,omitempty"`
 
-	LastSuccessfulSyncTime *time.Time `json:"LastSuccessfulSyncTime,omitempty"`
+	LastSuccessfulSyncTime *common.UnixTime `json:"LastSuccessfulSyncTime,omitempty"`
 
 	LastSyncStatusMessage *string `json:"LastSyncStatusMessage,omitempty"`
 
-	LastSyncTime *time.Time `json:"LastSyncTime,omitempty"`
+	LastSyncTime *common.UnixTime `json:"LastSyncTime,omitempty"`
 
 	S3Destination *ResourceDataSyncS3Destination `json:"S3Destination,omitempty"`
 
-	SyncCreatedTime *time.Time `json:"SyncCreatedTime,omitempty"`
+	SyncCreatedTime *common.UnixTime `json:"SyncCreatedTime,omitempty"`
 
-	SyncLastModifiedTime *time.Time `json:"SyncLastModifiedTime,omitempty"`
+	SyncLastModifiedTime *common.UnixTime `json:"SyncLastModifiedTime,omitempty"`
 
 	SyncName *string `json:"SyncName,omitempty"`
 
@@ -8534,7 +8536,7 @@ type ResumeSessionResponse struct {
 
 // ReviewInformation represents the ReviewInformation structure
 type ReviewInformation struct {
-	ReviewedTime *time.Time `json:"ReviewedTime,omitempty"`
+	ReviewedTime *common.UnixTime `json:"ReviewedTime,omitempty"`
 
 	Reviewer *string `json:"Reviewer,omitempty"`
 
@@ -8704,7 +8706,7 @@ type ServiceRole string
 type ServiceSetting struct {
 	ARN *string `json:"ARN,omitempty"`
 
-	LastModifiedDate *time.Time `json:"LastModifiedDate,omitempty"`
+	LastModifiedDate *common.UnixTime `json:"LastModifiedDate,omitempty"`
 
 	LastModifiedUser *string `json:"LastModifiedUser,omitempty"`
 
@@ -8749,7 +8751,7 @@ type Session struct {
 
 	DocumentName *string `json:"DocumentName,omitempty"`
 
-	EndDate *time.Time `json:"EndDate,omitempty"`
+	EndDate *common.UnixTime `json:"EndDate,omitempty"`
 
 	MaxSessionDuration *string `json:"MaxSessionDuration,omitempty"`
 
@@ -8761,7 +8763,7 @@ type Session struct {
 
 	SessionId *string `json:"SessionId,omitempty"`
 
-	StartDate *time.Time `json:"StartDate,omitempty"`
+	StartDate *common.UnixTime `json:"StartDate,omitempty"`
 
 	Status *SessionStatus `json:"Status,omitempty"`
 
@@ -8940,9 +8942,9 @@ type StartChangeRequestExecutionRequest struct {
 
 	Runbooks []Runbook `json:"Runbooks"`
 
-	ScheduledEndTime *time.Time `json:"ScheduledEndTime,omitempty"`
+	ScheduledEndTime *common.UnixTime `json:"ScheduledEndTime,omitempty"`
 
-	ScheduledTime *time.Time `json:"ScheduledTime,omitempty"`
+	ScheduledTime *common.UnixTime `json:"ScheduledTime,omitempty"`
 
 	Tags []Tag `json:"Tags,omitempty"`
 }
@@ -9021,9 +9023,9 @@ func (e StatusUnchanged) ErrorFault() string {
 type StepExecution struct {
 	Action *string `json:"Action,omitempty"`
 
-	ExecutionEndTime *time.Time `json:"ExecutionEndTime,omitempty"`
+	ExecutionEndTime *common.UnixTime `json:"ExecutionEndTime,omitempty"`
 
-	ExecutionStartTime *time.Time `json:"ExecutionStartTime,omitempty"`
+	ExecutionStartTime *common.UnixTime `json:"ExecutionStartTime,omitempty"`
 
 	FailureDetails *FailureDetails `json:"FailureDetails,omitempty"`
 
@@ -9841,9 +9843,9 @@ type UpdateManagedInstanceRoleResult struct {
 
 // UpdateOpsItemRequest represents the UpdateOpsItemRequest structure
 type UpdateOpsItemRequest struct {
-	ActualEndTime *time.Time `json:"ActualEndTime,omitempty"`
+	ActualEndTime *common.UnixTime `json:"ActualEndTime,omitempty"`
 
-	ActualStartTime *time.Time `json:"ActualStartTime,omitempty"`
+	ActualStartTime *common.UnixTime `json:"ActualStartTime,omitempty"`
 
 	Category *string `json:"Category,omitempty"`
 
@@ -9859,9 +9861,9 @@ type UpdateOpsItemRequest struct {
 
 	OpsItemId string `json:"OpsItemId"`
 
-	PlannedEndTime *time.Time `json:"PlannedEndTime,omitempty"`
+	PlannedEndTime *common.UnixTime `json:"PlannedEndTime,omitempty"`
 
-	PlannedStartTime *time.Time `json:"PlannedStartTime,omitempty"`
+	PlannedStartTime *common.UnixTime `json:"PlannedStartTime,omitempty"`
 
 	Priority *int32 `json:"Priority,omitempty"`
 
@@ -9935,13 +9937,13 @@ type UpdatePatchBaselineResult struct {
 
 	BaselineId *string `json:"BaselineId,omitempty"`
 
-	CreatedDate *time.Time `json:"CreatedDate,omitempty"`
+	CreatedDate *common.UnixTime `json:"CreatedDate,omitempty"`
 
 	Description *string `json:"Description,omitempty"`
 
 	GlobalFilters *PatchFilterGroup `json:"GlobalFilters,omitempty"`
 
-	ModifiedDate *time.Time `json:"ModifiedDate,omitempty"`
+	ModifiedDate *common.UnixTime `json:"ModifiedDate,omitempty"`
 
 	Name *string `json:"Name,omitempty"`
 


### PR DESCRIPTION
## Summary
- Fixed JSON unmarshaling errors when retrieving SSM parameters and Secrets Manager secrets
- AWS APIs return timestamps as numeric Unix timestamps rather than RFC3339 strings
- Added custom UnixTime type to handle both numeric and string timestamp formats

## Problem
The secrets synchronization controller was failing with:
```
Time.UnmarshalJSON: input is not a JSON string
```

This occurred because LocalStack (correctly mimicking AWS) returns timestamps as numbers:
```json
{
  "LastModifiedDate": 1755005925.233,
  "Name": "/myapp/prod/database-url"
}
```

But the auto-generated code expected RFC3339 strings.

## Solution
1. Created a custom `UnixTime` type with flexible `UnmarshalJSON` that handles:
   - Numeric Unix timestamps with millisecond precision (AWS format)
   - RFC3339 strings (fallback)

2. Updated generated types for SSM and Secrets Manager to use `UnixTime` instead of `time.Time`

3. Updated integration layers to use the `ToTime()` conversion method

## Test Plan
- [x] Unit tests for UnixTime type pass
- [x] Successfully deployed and tested service-with-secrets example
- [x] Pods running without CrashLoopBackOff
- [ ] Integration tests need updating for the new type (separate PR)

🤖 Generated with [Claude Code](https://claude.ai/code)