### PR TITLE
feat: Add ECS health check to Kubernetes probe conversion

### DIFF
--- a/controlplane/internal/converters/service_converter_health_test.go
+++ b/controlplane/internal/converters/service_converter_health_test.go
@@ -1,0 +1,223 @@
+package converters_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/converters"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+var _ = Describe("ServiceConverter Health Check", func() {
+	var (
+		converter *converters.ServiceConverter
+		service   *storage.Service
+		cluster   *storage.Cluster
+	)
+
+	BeforeEach(func() {
+		converter = converters.NewServiceConverter("us-east-1", "123456789012")
+		service = &storage.Service{
+			ServiceName:  "test-service",
+			DesiredCount: 1,
+			LaunchType:   "FARGATE",
+			ARN:          "arn:aws:ecs:us-east-1:123456789012:service/test-service",
+		}
+		cluster = &storage.Cluster{
+			Name:   "test-cluster",
+			Region: "us-east-1",
+		}
+	})
+
+	Context("when task definition has health check", func() {
+		It("should convert CMD-SHELL health check to exec probe", func() {
+			taskDef := &storage.TaskDefinition{
+				Family:   "test-family",
+				Revision: 1,
+				ContainerDefinitions: mustMarshal([]map[string]interface{}{
+					{
+						"name":  "app",
+						"image": "nginx:latest",
+						"healthCheck": map[string]interface{}{
+							"command":     []interface{}{"CMD-SHELL", "wget -q -O - http://localhost:8080/health || exit 1"},
+							"interval":    float64(30),
+							"timeout":     float64(5),
+							"retries":     float64(3),
+							"startPeriod": float64(30),
+						},
+					},
+				}),
+			}
+
+			deployment, _, err := converter.ConvertServiceToDeployment(service, taskDef, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment).NotTo(BeNil())
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+
+			// Check liveness probe
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec.Command).To(Equal([]string{
+				"sh", "-c", "wget -q -O - http://localhost:8080/health || exit 1",
+			}))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(30)))
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(5)))
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(30)))
+
+			// Check readiness probe
+			Expect(container.ReadinessProbe).NotTo(BeNil())
+			Expect(container.ReadinessProbe.Exec).NotTo(BeNil())
+			Expect(container.ReadinessProbe.InitialDelaySeconds).To(Equal(int32(10))) // Shorter for readiness
+		})
+
+		It("should convert HTTP health check to HTTP probe", func() {
+			taskDef := &storage.TaskDefinition{
+				Family:   "test-family",
+				Revision: 1,
+				ContainerDefinitions: mustMarshal([]map[string]interface{}{
+					{
+						"name":  "app",
+						"image": "nginx:latest",
+						"healthCheck": map[string]interface{}{
+							"command":     []interface{}{"HTTP", "/health", "8080"},
+							"interval":    float64(15),
+							"timeout":     float64(3),
+							"retries":     float64(2),
+							"startPeriod": float64(60),
+						},
+					},
+				}),
+			}
+
+			deployment, _, err := converter.ConvertServiceToDeployment(service, taskDef, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+
+			// Check liveness probe
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.HTTPGet).NotTo(BeNil())
+			Expect(container.LivenessProbe.HTTPGet.Path).To(Equal("/health"))
+			Expect(container.LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromInt(8080)))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(15)))
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(2)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(60)))
+		})
+
+		It("should convert CMD health check to exec probe", func() {
+			taskDef := &storage.TaskDefinition{
+				Family:   "test-family",
+				Revision: 1,
+				ContainerDefinitions: mustMarshal([]map[string]interface{}{
+					{
+						"name":  "app",
+						"image": "nginx:latest",
+						"healthCheck": map[string]interface{}{
+							"command":  []interface{}{"CMD", "curl", "-f", "http://localhost/health"},
+							"interval": float64(20),
+						},
+					},
+				}),
+			}
+
+			deployment, _, err := converter.ConvertServiceToDeployment(service, taskDef, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+
+			// Check liveness probe
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec.Command).To(Equal([]string{
+				"curl", "-f", "http://localhost/health",
+			}))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(20)))
+			// Check defaults
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(5)))
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(30)))
+		})
+
+		It("should handle containers without health check", func() {
+			taskDef := &storage.TaskDefinition{
+				Family:   "test-family",
+				Revision: 1,
+				ContainerDefinitions: mustMarshal([]map[string]interface{}{
+					{
+						"name":  "app",
+						"image": "nginx:latest",
+						// No healthCheck field
+					},
+				}),
+			}
+
+			deployment, _, err := converter.ConvertServiceToDeployment(service, taskDef, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+
+			// Check no probes are set
+			Expect(container.LivenessProbe).To(BeNil())
+			Expect(container.ReadinessProbe).To(BeNil())
+		})
+
+		It("should handle multiple containers with different health checks", func() {
+			taskDef := &storage.TaskDefinition{
+				Family:   "test-family",
+				Revision: 1,
+				ContainerDefinitions: mustMarshal([]map[string]interface{}{
+					{
+						"name":  "app",
+						"image": "app:latest",
+						"healthCheck": map[string]interface{}{
+							"command":  []interface{}{"CMD-SHELL", "curl -f http://localhost:3000/health"},
+							"interval": float64(30),
+						},
+					},
+					{
+						"name":  "sidecar",
+						"image": "sidecar:latest",
+						"healthCheck": map[string]interface{}{
+							"command":  []interface{}{"HTTP", "/ready", "9090"},
+							"interval": float64(10),
+						},
+					},
+				}),
+			}
+
+			deployment, _, err := converter.ConvertServiceToDeployment(service, taskDef, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(2))
+
+			// Check app container
+			appContainer := deployment.Spec.Template.Spec.Containers[0]
+			Expect(appContainer.LivenessProbe).NotTo(BeNil())
+			Expect(appContainer.LivenessProbe.Exec).NotTo(BeNil())
+			Expect(appContainer.LivenessProbe.Exec.Command).To(Equal([]string{
+				"sh", "-c", "curl -f http://localhost:3000/health",
+			}))
+
+			// Check sidecar container
+			sidecarContainer := deployment.Spec.Template.Spec.Containers[1]
+			Expect(sidecarContainer.LivenessProbe).NotTo(BeNil())
+			Expect(sidecarContainer.LivenessProbe.HTTPGet).NotTo(BeNil())
+			Expect(sidecarContainer.LivenessProbe.HTTPGet.Path).To(Equal("/ready"))
+			Expect(sidecarContainer.LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromInt(9090)))
+		})
+	})
+})
+
+func mustMarshal(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/controlplane/internal/converters/task_converter_health_test.go
+++ b/controlplane/internal/converters/task_converter_health_test.go
@@ -1,0 +1,278 @@
+package converters_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/converters"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	"github.com/nandemo-ya/kecs/controlplane/internal/types"
+)
+
+var _ = Describe("TaskConverter Health Check", func() {
+	var (
+		converter *converters.TaskConverter
+		cluster   *storage.Cluster
+	)
+
+	BeforeEach(func() {
+		converter = converters.NewTaskConverter("us-east-1", "123456789012")
+		cluster = &storage.Cluster{
+			Name:   "test-cluster",
+			Region: "us-east-1",
+			Status: "ACTIVE",
+		}
+	})
+
+	Context("when task definition has health check", func() {
+		It("should convert CMD-SHELL health check to exec probe", func() {
+			containerDef := types.ContainerDefinition{
+				Name:  strPtr("app"),
+				Image: strPtr("nginx:latest"),
+				HealthCheck: &types.HealthCheck{
+					Command:     []string{"CMD-SHELL", "wget -q -O - http://localhost/health || exit 1"},
+					Interval:    int32Ptr(30),
+					Timeout:     int32Ptr(5),
+					Retries:     int32Ptr(3),
+					StartPeriod: int32Ptr(60),
+				},
+			}
+
+			taskDef := &storage.TaskDefinition{
+				Family:               "test-family",
+				Revision:             1,
+				ContainerDefinitions: mustMarshalContainerDefs([]types.ContainerDefinition{containerDef}),
+			}
+
+			pod, err := converter.ConvertTaskToPod(taskDef, []byte("{}"), cluster, "test-task-123")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pod).NotTo(BeNil())
+			Expect(pod.Spec.Containers).To(HaveLen(1))
+
+			container := pod.Spec.Containers[0]
+
+			// Check liveness probe
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec.Command).To(Equal([]string{
+				"sh", "-c", "wget -q -O - http://localhost/health || exit 1",
+			}))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(30)))
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(5)))
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(60)))
+
+			// Check readiness probe
+			Expect(container.ReadinessProbe).NotTo(BeNil())
+			Expect(container.ReadinessProbe.Exec).NotTo(BeNil())
+			// Readiness probe should have shorter initial delay
+			Expect(container.ReadinessProbe.InitialDelaySeconds).To(Equal(int32(10)))
+			Expect(container.ReadinessProbe.PeriodSeconds).To(Equal(int32(30)))
+		})
+
+		It("should convert HTTP health check to HTTP probe", func() {
+			containerDef := types.ContainerDefinition{
+				Name:  strPtr("app"),
+				Image: strPtr("nginx:latest"),
+				HealthCheck: &types.HealthCheck{
+					Command:     []string{"HTTP", "/health", "8080"},
+					Interval:    int32Ptr(15),
+					Timeout:     int32Ptr(3),
+					Retries:     int32Ptr(2),
+					StartPeriod: int32Ptr(45),
+				},
+			}
+
+			taskDef := &storage.TaskDefinition{
+				Family:               "test-family",
+				Revision:             1,
+				ContainerDefinitions: mustMarshalContainerDefs([]types.ContainerDefinition{containerDef}),
+			}
+
+			pod, err := converter.ConvertTaskToPod(taskDef, []byte("{}"), cluster, "test-task-123")
+			Expect(err).NotTo(HaveOccurred())
+
+			container := pod.Spec.Containers[0]
+
+			// Check liveness probe
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.HTTPGet).NotTo(BeNil())
+			Expect(container.LivenessProbe.HTTPGet.Path).To(Equal("/health"))
+			Expect(container.LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromInt(8080)))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(15)))
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(2)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(45)))
+
+			// Check readiness probe
+			Expect(container.ReadinessProbe).NotTo(BeNil())
+			Expect(container.ReadinessProbe.HTTPGet).NotTo(BeNil())
+			Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/health"))
+			Expect(container.ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromInt(8080)))
+			Expect(container.ReadinessProbe.InitialDelaySeconds).To(Equal(int32(10))) // Shorter for readiness
+		})
+
+		It("should convert CMD health check to exec probe", func() {
+			containerDef := types.ContainerDefinition{
+				Name:  strPtr("app"),
+				Image: strPtr("nginx:latest"),
+				HealthCheck: &types.HealthCheck{
+					Command:  []string{"CMD", "/bin/health-check", "--verbose"},
+					Interval: int32Ptr(20),
+					Timeout:  int32Ptr(10),
+				},
+			}
+
+			taskDef := &storage.TaskDefinition{
+				Family:               "test-family",
+				Revision:             1,
+				ContainerDefinitions: mustMarshalContainerDefs([]types.ContainerDefinition{containerDef}),
+			}
+
+			pod, err := converter.ConvertTaskToPod(taskDef, []byte("{}"), cluster, "test-task-123")
+			Expect(err).NotTo(HaveOccurred())
+
+			container := pod.Spec.Containers[0]
+
+			// Check liveness probe
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec).NotTo(BeNil())
+			Expect(container.LivenessProbe.Exec.Command).To(Equal([]string{
+				"/bin/health-check", "--verbose",
+			}))
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(20)))
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(10)))
+			// Check defaults
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(30)))
+		})
+
+		It("should handle containers without health check", func() {
+			containerDef := types.ContainerDefinition{
+				Name:  strPtr("app"),
+				Image: strPtr("nginx:latest"),
+				// No HealthCheck field
+			}
+
+			taskDef := &storage.TaskDefinition{
+				Family:               "test-family",
+				Revision:             1,
+				ContainerDefinitions: mustMarshalContainerDefs([]types.ContainerDefinition{containerDef}),
+			}
+
+			pod, err := converter.ConvertTaskToPod(taskDef, []byte("{}"), cluster, "test-task-123")
+			Expect(err).NotTo(HaveOccurred())
+
+			container := pod.Spec.Containers[0]
+
+			// Check no probes are set
+			Expect(container.LivenessProbe).To(BeNil())
+			Expect(container.ReadinessProbe).To(BeNil())
+		})
+
+		It("should use defaults when timing parameters are not specified", func() {
+			containerDef := types.ContainerDefinition{
+				Name:  strPtr("app"),
+				Image: strPtr("nginx:latest"),
+				HealthCheck: &types.HealthCheck{
+					Command: []string{"CMD-SHELL", "echo ok"},
+					// No timing parameters specified
+				},
+			}
+
+			taskDef := &storage.TaskDefinition{
+				Family:               "test-family",
+				Revision:             1,
+				ContainerDefinitions: mustMarshalContainerDefs([]types.ContainerDefinition{containerDef}),
+			}
+
+			pod, err := converter.ConvertTaskToPod(taskDef, []byte("{}"), cluster, "test-task-123")
+			Expect(err).NotTo(HaveOccurred())
+
+			container := pod.Spec.Containers[0]
+
+			// Check liveness probe uses defaults
+			Expect(container.LivenessProbe).NotTo(BeNil())
+			Expect(container.LivenessProbe.PeriodSeconds).To(Equal(int32(30)))
+			Expect(container.LivenessProbe.TimeoutSeconds).To(Equal(int32(5)))
+			Expect(container.LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(container.LivenessProbe.InitialDelaySeconds).To(Equal(int32(30)))
+			Expect(container.LivenessProbe.SuccessThreshold).To(Equal(int32(1)))
+		})
+
+		It("should handle multiple containers with different health checks", func() {
+			containerDefs := []types.ContainerDefinition{
+				{
+					Name:  strPtr("app"),
+					Image: strPtr("app:latest"),
+					HealthCheck: &types.HealthCheck{
+						Command:  []string{"CMD-SHELL", "curl -f http://localhost:3000/health"},
+						Interval: int32Ptr(30),
+					},
+				},
+				{
+					Name:  strPtr("sidecar"),
+					Image: strPtr("sidecar:latest"),
+					HealthCheck: &types.HealthCheck{
+						Command:  []string{"HTTP", "/status", "9090"},
+						Interval: int32Ptr(10),
+					},
+				},
+				{
+					Name:  strPtr("no-health"),
+					Image: strPtr("simple:latest"),
+					// No health check
+				},
+			}
+
+			taskDef := &storage.TaskDefinition{
+				Family:               "test-family",
+				Revision:             1,
+				ContainerDefinitions: mustMarshalContainerDefs(containerDefs),
+			}
+
+			pod, err := converter.ConvertTaskToPod(taskDef, []byte("{}"), cluster, "test-task-123")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pod.Spec.Containers).To(HaveLen(3))
+
+			// Check app container
+			appContainer := pod.Spec.Containers[0]
+			Expect(appContainer.LivenessProbe).NotTo(BeNil())
+			Expect(appContainer.LivenessProbe.Exec).NotTo(BeNil())
+			Expect(appContainer.LivenessProbe.Exec.Command).To(Equal([]string{
+				"sh", "-c", "curl -f http://localhost:3000/health",
+			}))
+
+			// Check sidecar container
+			sidecarContainer := pod.Spec.Containers[1]
+			Expect(sidecarContainer.LivenessProbe).NotTo(BeNil())
+			Expect(sidecarContainer.LivenessProbe.HTTPGet).NotTo(BeNil())
+			Expect(sidecarContainer.LivenessProbe.HTTPGet.Path).To(Equal("/status"))
+			Expect(sidecarContainer.LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromInt(9090)))
+
+			// Check no-health container
+			noHealthContainer := pod.Spec.Containers[2]
+			Expect(noHealthContainer.LivenessProbe).To(BeNil())
+			Expect(noHealthContainer.ReadinessProbe).To(BeNil())
+		})
+	})
+})
+
+func strPtr(v string) *string {
+	return &v
+}
+
+func int32Ptr(v int) *int {
+	return &v
+}
+
+func mustMarshalContainerDefs(defs []types.ContainerDefinition) string {
+	data, err := json.Marshal(defs)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
- Implement health check to probe conversion in ServiceConverter
- Enhance existing health check conversion in TaskConverter  
- Support CMD-SHELL, CMD, and HTTP health check formats

## Details
This PR adds comprehensive conversion of ECS health checks to Kubernetes Liveness and Readiness probes. The implementation properly handles all three ECS health check formats and maps timing parameters appropriately.

### Changes
- **ServiceConverter**: Added `convertHealthCheckToProbe()` method to convert ECS health checks from task definitions
- **TaskConverter**: Enhanced existing `convertHealthCheck()` method with support for all command formats
- Both converters now create Liveness and Readiness probes from a single health check definition
- Readiness probes use shorter initial delay (10s) for faster container startup

### Health Check Format Support
- **CMD-SHELL**: Converts to exec probe with `sh -c` wrapper
- **CMD**: Converts to direct exec probe with command array
- **HTTP**: Converts to HTTP probe with path and port extraction

### Parameter Mapping
| ECS Parameter | Kubernetes Parameter |
|--------------|---------------------|
| interval | periodSeconds |
| timeout | timeoutSeconds |
| retries | failureThreshold |
| startPeriod | initialDelaySeconds |

## Test Coverage
Added comprehensive test suites for both converters:
- `service_converter_health_test.go`: Tests ServiceConverter health check conversion
- `task_converter_health_test.go`: Tests TaskConverter health check conversion

All tests cover:
- CMD-SHELL format conversion
- HTTP format conversion with port extraction
- CMD format conversion
- Containers without health checks
- Multiple containers with different health checks
- Default timing parameters

## Example
The `examples/service-with-secrets/` task definition includes a health check that will now be properly converted to Kubernetes probes:
```json
"healthCheck": {
  "command": ["CMD-SHELL", "wget -q -O - http://localhost:8080/health || exit 1"],
  "interval": 30,
  "timeout": 5,
  "retries": 3,
  "startPeriod": 30
}
```

This will be converted to both Liveness and Readiness probes in the resulting Kubernetes Pod/Deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)