### PR TITLE
feat: Replace FluentBit with Vector for CloudWatch Logs integration

### DIFF
--- a/examples/single-task-nginx/service_def_with_logs.json
+++ b/examples/single-task-nginx/service_def_with_logs.json
@@ -1,0 +1,35 @@
+{
+  "serviceName": "nginx-with-logs-service",
+  "cluster": "default",
+  "taskDefinition": "nginx-with-logs:1",
+  "desiredCount": 1,
+  "launchType": "FARGATE",
+  "platformVersion": "LATEST",
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-12345678", "subnet-87654321"],
+      "securityGroups": ["sg-nginx-web"],
+      "assignPublicIp": "ENABLED"
+    }
+  },
+  "deploymentConfiguration": {
+    "maximumPercent": 200,
+    "minimumHealthyPercent": 100,
+    "deploymentCircuitBreaker": {
+      "enable": true,
+      "rollback": true
+    }
+  },
+  "enableECSManagedTags": true,
+  "propagateTags": "SERVICE",
+  "tags": [
+    {
+      "key": "Environment",
+      "value": "development"
+    },
+    {
+      "key": "Application",
+      "value": "nginx-with-logs"
+    }
+  ]
+}

--- a/examples/vector-cloudwatch/vector-config.yaml
+++ b/examples/vector-cloudwatch/vector-config.yaml
@@ -1,0 +1,98 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config
+  namespace: kecs-system
+data:
+  vector.toml: |
+    # Vector configuration for CloudWatch Logs integration
+    
+    # Input: Collect logs from Kubernetes containers
+    [sources.kubernetes_logs]
+    type = "kubernetes_logs"
+    auto_partial_merge = true
+    exclude_paths = [
+      "/var/log/containers/*_kecs-system_*.log",
+      "/var/log/containers/*_kube-system_*.log"
+    ]
+    
+    # Transform: Parse container logs and extract metadata
+    [transforms.parse_logs]
+    type = "remap"
+    inputs = ["kubernetes_logs"]
+    source = '''
+    # Parse JSON logs if present
+    if is_string(.message) && starts_with(.message, "{") {
+      parsed = parse_json!(.message)
+      . = merge(., parsed)
+    }
+    
+    # Extract ECS metadata from pod annotations
+    .ecs_cluster = .kubernetes.pod_annotations."kecs.dev/cluster" ?? "default"
+    .ecs_service = .kubernetes.pod_annotations."kecs.dev/service" ?? "unknown"
+    .ecs_task_family = .kubernetes.pod_annotations."kecs.dev/task-family" ?? "unknown"
+    
+    # Extract CloudWatch Logs configuration from annotations
+    .container_name = .kubernetes.container_name
+    prefix = "kecs.dev/container-" + .container_name + "-logs"
+    
+    .log_driver = .kubernetes.pod_annotations.(prefix + "-driver") ?? "none"
+    .log_group = .kubernetes.pod_annotations.(prefix + "-group") ?? "/ecs/default-logs"
+    .log_stream_prefix = .kubernetes.pod_annotations.(prefix + "-stream-prefix") ?? .container_name
+    .log_region = .kubernetes.pod_annotations.(prefix + "-region") ?? "us-east-1"
+    
+    # Create log stream name
+    .log_stream = .log_stream_prefix + "/" + .kubernetes.pod_name
+    '''
+    
+    # Filter: Only send logs configured for CloudWatch
+    [transforms.filter_cloudwatch]
+    type = "filter"
+    inputs = ["parse_logs"]
+    condition = '''
+    .log_driver == "awslogs"
+    '''
+    
+    # Transform: Format for CloudWatch
+    [transforms.format_cloudwatch]
+    type = "remap"
+    inputs = ["filter_cloudwatch"]
+    source = '''
+    # Keep only necessary fields
+    .timestamp = .timestamp
+    .message = .message
+    .log_group = .log_group
+    .log_stream = .log_stream
+    
+    # Add ECS metadata to the message
+    .message = "[" + .ecs_cluster + "/" + .ecs_service + "] " + .message
+    '''
+    
+    # Output: Send to CloudWatch Logs (via LocalStack)
+    [sinks.cloudwatch_logs]
+    type = "aws_cloudwatch_logs"
+    inputs = ["format_cloudwatch"]
+    endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
+    region = "us-east-1"
+    group_name = "{{ log_group }}"
+    stream_name = "{{ log_stream }}"
+    create_missing_group = true
+    create_missing_stream = true
+    encoding.codec = "text"
+    
+    # Retry configuration
+    request.retry_attempts = 3
+    request.retry_initial_backoff_secs = 1
+    
+    # Batch configuration for performance
+    batch.max_bytes = 1048576  # 1MB
+    batch.max_events = 10000
+    batch.timeout_secs = 1
+    
+    # For debugging: Also output to console
+    [sinks.console_debug]
+    type = "console"
+    inputs = ["parse_logs"]
+    encoding.codec = "json"
+    # Only enable for debugging
+    # target = "stdout"

--- a/examples/vector-cloudwatch/vector-daemonset.yaml
+++ b/examples/vector-cloudwatch/vector-daemonset.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector
+  namespace: kecs-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - nodes
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vector
+subjects:
+- kind: ServiceAccount
+  name: vector
+  namespace: kecs-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector
+  namespace: kecs-system
+  labels:
+    app: vector
+spec:
+  selector:
+    matchLabels:
+      app: vector
+  template:
+    metadata:
+      labels:
+        app: vector
+    spec:
+      serviceAccountName: vector
+      containers:
+      - name: vector
+        image: timberio/vector:0.34.0-alpine
+        env:
+        - name: VECTOR_CONFIG_DIR
+          value: /etc/vector
+        - name: VECTOR_LOG
+          value: info
+        - name: VECTOR_SELF_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: AWS_ACCESS_KEY_ID
+          value: "test"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "test"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/vector
+          readOnly: true
+        - name: var-log
+          mountPath: /var/log
+          readOnly: true
+        - name: var-lib-docker-containers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        resources:
+          limits:
+            memory: 512Mi
+            cpu: 500m
+          requests:
+            memory: 256Mi
+            cpu: 200m
+      volumes:
+      - name: config
+        configMap:
+          name: vector-config
+      - name: var-log
+        hostPath:
+          path: /var/log
+      - name: var-lib-docker-containers
+        hostPath:
+          path: /var/lib/docker/containers
+      hostNetwork: false
+      dnsPolicy: ClusterFirst

--- a/examples/vector-cloudwatch/vector-simple-config.yaml
+++ b/examples/vector-cloudwatch/vector-simple-config.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config
+  namespace: kecs-system
+data:
+  vector.toml: |
+    # Simple Vector configuration for CloudWatch Logs
+    
+    # Input: Collect all container logs
+    [sources.kubernetes_logs]
+    type = "kubernetes_logs"
+    
+    # Transform: Add namespace filter
+    [transforms.filter_namespace]
+    type = "filter"
+    inputs = ["kubernetes_logs"]
+    condition = '''
+    !includes(["kecs-system", "kube-system"], .kubernetes.pod_namespace)
+    '''
+    
+    # Transform: Format log message
+    [transforms.format_logs]
+    type = "remap"
+    inputs = ["filter_namespace"]
+    source = '''
+    # Extract basic metadata
+    .namespace = string!(.kubernetes.pod_namespace)
+    .pod_name = string!(.kubernetes.pod_name)
+    .container_name = string!(.kubernetes.container_name)
+    
+    # Build log stream name
+    .log_stream = .namespace + "/" + .pod_name + "/" + .container_name
+    
+    # Check for ECS annotations (safely)
+    if exists(.kubernetes.pod_annotations."kecs.dev/cluster") {
+      .ecs_cluster = string!(.kubernetes.pod_annotations."kecs.dev/cluster")
+    } else {
+      .ecs_cluster = "default"
+    }
+    
+    if exists(.kubernetes.pod_annotations."kecs.dev/service") {
+      .ecs_service = string!(.kubernetes.pod_annotations."kecs.dev/service")
+    } else {
+      .ecs_service = "none"
+    }
+    
+    # Default log group based on namespace
+    if starts_with(.namespace, "default-") {
+      .log_group = "/ecs/default-logs"
+    } else {
+      .log_group = "/kecs/" + .namespace
+    }
+    '''
+    
+    # Output: Send to CloudWatch Logs via LocalStack
+    [sinks.cloudwatch]
+    type = "aws_cloudwatch_logs"
+    inputs = ["format_logs"]
+    endpoint = "http://localstack.kecs-system.svc.cluster.local:4566"
+    region = "us-east-1"
+    group_name = "{{ log_group }}"
+    stream_name = "{{ log_stream }}"
+    create_missing_group = true
+    create_missing_stream = true
+    encoding.codec = "text"
+    
+    # Output: Console for debugging
+    [sinks.console]
+    type = "console"
+    inputs = ["format_logs"]
+    encoding.codec = "json"
+    target = "stdout"


### PR DESCRIPTION
## Summary
- Replace FluentBit with Vector as the log shipping solution for CloudWatch Logs
- Vector provides simpler configuration and more powerful log transformation capabilities
- Successfully tested end-to-end log delivery to LocalStack CloudWatch Logs

## Changes
- Add Vector DaemonSet configuration with proper RBAC settings
- Add Vector ConfigMap with CloudWatch Logs sink configuration  
- Add sample service definition with CloudWatch Logs settings
- Support dynamic log group/stream creation based on namespace
- Integrate with LocalStack for AWS service emulation

## Benefits
- **Simpler configuration**: Vector uses TOML/VRL syntax which is more intuitive than FluentBit's Lua scripting
- **Better debugging**: Clear console output shows exactly what's being processed
- **Flexible routing**: Powerful VRL (Vector Remap Language) for log transformation
- **AWS compatibility**: Better CloudWatch Logs API integration

## Test Results
Confirmed that nginx container logs are successfully delivered to CloudWatch Logs in LocalStack:
- Log group: `/ecs/default-logs`
- Log stream: `default-us-east-1/ecs-service-nginx-with-logs-service-*/nginx`
- Both startup logs and access logs are captured

## Next Steps
- [ ] Implement task definition logConfiguration to pod annotations conversion
- [ ] Add support for per-service log configuration
- [ ] Performance tuning and batch optimization

🤖 Generated with [Claude Code](https://claude.ai/code)