### PR TITLE
feat: Add automatic Service Discovery registration for ECS tasks

### DIFF
--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -121,7 +121,7 @@ func (api *DefaultECSAPI) getClusterManager() kubernetes.ClusterManager {
 // taskManager returns the task manager, creating it if necessary
 func (api *DefaultECSAPI) taskManager() (*kubernetes.TaskManager, error) {
 	if api.taskManagerInstance == nil {
-		tm, err := kubernetes.NewTaskManager(api.storage)
+		tm, err := kubernetes.NewTaskManagerWithServiceDiscovery(api.storage, api.serviceDiscoveryManager)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Implement automatic registration and deregistration of ECS tasks with AWS Cloud Map Service Discovery when ServiceRegistry is configured on ECS services, matching AWS ECS behavior.

## Key Changes

- **TaskManager Enhancement**: Added Service Discovery Manager integration to TaskManager for automatic instance lifecycle management
- **Auto-registration**: Tasks automatically register with Service Discovery when reaching RUNNING state
- **Auto-deregistration**: Tasks automatically deregister when stopping or terminated
- **ListInstances API**: Implemented missing ListInstances API for Service Discovery
- **Metadata Support**: Register task IP addresses and container ports with Service Discovery

## Implementation Details

### Architecture
- Extended `TaskManager` to accept optional Service Discovery Manager
- Used `StartedBy` field (`ecs-svc/<service-name>`) to identify service-owned tasks
- ServiceRegistry metadata stored in service configuration

### Workflow
1. Service created with ServiceRegistry → metadata stored
2. Task starts → reaches RUNNING state → registers IP with Service Discovery
3. Task stops → deregisters from Service Discovery
4. Other services can discover instances via DNS or API

## Testing

Successfully tested with service-to-service communication example:
- ✅ ServiceRegistry configuration on ECS services
- ✅ Automatic task registration on startup
- ✅ ListInstances API returns registered instances
- ✅ DiscoverInstances API works correctly
- ✅ Direct IP communication between services

## AWS ECS Compatibility

This implementation provides AWS ECS-compatible behavior for:
- ServiceRegistry configuration in CreateService/UpdateService
- Automatic instance registration/deregistration
- Service Discovery API operations (ListInstances, DiscoverInstances)
- Container name and port mapping in registry

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>