### PR TITLE
fix: Service Discovery instance registration implementation

### DIFF
--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -18,6 +18,7 @@ import (
 type DefaultECSAPI struct {
 	storage                   storage.Storage
 	clusterManager            kubernetes.ClusterManager
+	serviceManager            *kubernetes.ServiceManager
 	taskManagerInstance       *kubernetes.TaskManager
 	region                    string
 	accountID                 string
@@ -76,6 +77,11 @@ func (api *DefaultECSAPI) SetELBv2Integration(elbv2Integration elbv2.Integration
 // SetServiceDiscoveryManager sets the service discovery manager for the ECS API
 func (api *DefaultECSAPI) SetServiceDiscoveryManager(serviceDiscoveryManager servicediscovery.Manager) {
 	api.serviceDiscoveryManager = serviceDiscoveryManager
+}
+
+// SetServiceManager sets the service manager for the ECS API
+func (api *DefaultECSAPI) SetServiceManager(serviceManager *kubernetes.ServiceManager) {
+	api.serviceManager = serviceManager
 }
 
 // SetLocalStackManager sets the LocalStack manager for the ECS API

--- a/controlplane/internal/converters/service_converter.go
+++ b/controlplane/internal/converters/service_converter.go
@@ -167,6 +167,10 @@ func (c *ServiceConverter) createDeployment(
 	c.addCloudWatchLogsAnnotations(podAnnotations, containerDefs)
 
 	// Add Service Registry annotations to pod template
+	logging.Info("Checking ServiceRegistries for pod template",
+		"serviceName", service.ServiceName,
+		"hasServiceRegistries", service.ServiceRegistries != "",
+		"serviceRegistries", service.ServiceRegistries)
 	if service.ServiceRegistries != "" {
 		podAnnotations["kecs.dev/service-registries"] = service.ServiceRegistries
 		logging.Info("Added Service Registry annotations to pod template",

--- a/controlplane/internal/kubernetes/service_manager.go
+++ b/controlplane/internal/kubernetes/service_manager.go
@@ -26,6 +26,12 @@ type ServiceManager struct {
 	taskManager    *TaskManager
 }
 
+// SetTaskManager sets or updates the task manager
+func (sm *ServiceManager) SetTaskManager(taskManager *TaskManager) {
+	sm.taskManager = taskManager
+	logging.Info("ServiceManager TaskManager updated")
+}
+
 // NewServiceManager creates a new ServiceManager
 func NewServiceManager(storage storage.Storage, clusterManager ClusterManager) *ServiceManager {
 	// Create TaskManager if storage is available


### PR DESCRIPTION
## Summary
This PR fixes and enhances the Service Discovery integration to enable automatic instance registration when tasks become running.

## Issues Fixed
- ServiceRegistries field was not being passed to ServiceConverter (#488 related)
- TaskManager was not initialized with Service Discovery Manager
- Instance registration logic was not being triggered

## Changes Made

### ServiceRegistries Propagation
- Added ServiceRegistries field to temporary storage service object in service_ecs_api.go
- Added debug logging to trace ServiceRegistries propagation in service_converter.go
- Fixed the data flow: ECS Service → ServiceConverter → Pod Template → Pod → Task

### TaskManager Service Discovery Integration  
- Enhanced TaskManager to use both ServiceRegistries and legacy ServiceRegistryMetadata
- Added proper Service Discovery Manager initialization in TaskManager
- Implemented re-initialization of TaskManager with Service Discovery support
- Added ServiceManager as a shared component for better integration

### Instance Registration Improvements
- Enhanced RegisterInstance to handle duplicate registrations gracefully
- Added instance map initialization to prevent nil pointer errors
- Improved error handling and debug logging throughout
- Added support for extracting service ID from registry ARN

### Code Organization
- Added SetTaskManager method to ServiceManager for updates
- Added SetServiceManager method to DefaultECSAPI
- Improved logging for debugging Service Discovery operations

## Testing
- Verified ServiceRegistries now appears in Pod annotations
- Confirmed Service Discovery integration initializes successfully
- Tested service creation with Service Discovery configuration

## Related Issues
- Builds on #491 (Add Route53 integration for ECS Service Discovery)
- Builds on #492 (Add Service Discovery API codegen foundation)
- Builds on #493 (Add Service Discovery API implementation for KECS)

## Test Plan
1. Create KECS instance: `kecs start`
2. Create Service Discovery namespace and service
3. Create ECS service with ServiceRegistries configuration
4. Verify pod annotations include `kecs.dev/service-registries`
5. Verify Service Discovery integration logs show successful initialization

## Notes
- This PR focuses on the instance registration mechanism
- CoreDNS integration and health check updates will be addressed in follow-up PRs
- E2E testing with actual DNS resolution requires additional work

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>