### PR TITLE
fix: Fix Service Discovery registration and prevent CoreDNS duplicate configs

### DIFF
--- a/controlplane/internal/servicediscovery/manager.go
+++ b/controlplane/internal/servicediscovery/manager.go
@@ -100,7 +100,17 @@ func (m *manager) CreateNamespace(ctx context.Context, namespace *Namespace) err
 	// Check if namespace already exists
 	for _, ns := range m.namespaces {
 		if ns.Name == namespace.Name {
-			return fmt.Errorf("namespace with name %s already exists", namespace.Name)
+			logging.Info("Namespace already exists, updating existing namespace",
+				"name", namespace.Name,
+				"existingID", ns.ID,
+				"newID", namespace.ID)
+			// Update the existing namespace's ID in our records if needed
+			// This handles the case where controlplane restarts and tries to recreate
+			namespace.ID = ns.ID
+			namespace.ARN = ns.ARN
+			namespace.CreatedAt = ns.CreatedAt
+			m.namespaces[ns.ID] = namespace
+			return nil
 		}
 	}
 
@@ -157,7 +167,10 @@ func (m *manager) CreatePrivateDnsNamespace(ctx context.Context, name, vpc strin
 	// Check if namespace already exists
 	for _, ns := range m.namespaces {
 		if ns.Name == name {
-			return nil, fmt.Errorf("namespace with name %s already exists", name)
+			logging.Info("Namespace already exists, returning existing namespace",
+				"name", name,
+				"id", ns.ID)
+			return ns, nil
 		}
 	}
 


### PR DESCRIPTION
## Summary
- TaskUpdater interfaceを導入してsyncとkubernetesパッケージ間の循環依存を解消
- BatchUpdaterがタスクがRUNNINGになった際にService Discovery登録をトリガーするよう修正
- CoreDNSの重複ドメイン設定を防止してクラッシュを修正
- namespace作成を冪等にしてcontrolplane再起動時の重複エラーを防止

## 修正内容

### 1. 循環依存の解消
- `TaskUpdater` interfaceを作成してパッケージ間の依存関係を整理
- SyncControllerがTaskManagerを直接参照せずinterfaceを使用

### 2. Service Discovery登録の修正
- BatchUpdaterがタスクステータスをRUNNINGに更新する際にUpdateTaskStatusを呼び出し
- これによりService Discovery登録が適切にトリガーされる

### 3. CoreDNS重複設定の防止
- 新しいドメイン設定を追加する前に既存の重複エントリをチェック・削除
- CoreDNSのクラッシュを防止

### 4. Namespace作成の冪等性
- 既存のnamespaceがある場合はエラーを返さずに既存のものを返す
- controlplane再起動時の安定性向上

## Test plan
- [x] controlplaneのビルドが成功
- [x] Service Discoveryのinstance登録が動作
- [x] CoreDNSが重複設定でクラッシュしない
- [x] サービス間のDNS解決が機能

🤖 Generated with [Claude Code](https://claude.ai/code)