### PR TITLE
fix: Fix Service Discovery registration and prevent CoreDNS duplicate configs

### DIFF
--- a/controlplane/internal/servicediscovery/manager.go
+++ b/controlplane/internal/servicediscovery/manager.go
@@ -100,7 +100,17 @@ func (m *manager) CreateNamespace(ctx context.Context, namespace *Namespace) err
 	// Check if namespace already exists
 	for _, ns := range m.namespaces {
 		if ns.Name == namespace.Name {
-			return fmt.Errorf("namespace with name %s already exists", namespace.Name)
+			logging.Info("Namespace already exists, updating existing namespace",
+				"name", namespace.Name,
+				"existingID", ns.ID,
+				"newID", namespace.ID)
+			// Update the existing namespace's ID in our records if needed
+			// This handles the case where controlplane restarts and tries to recreate
+			namespace.ID = ns.ID
+			namespace.ARN = ns.ARN
+			namespace.CreatedAt = ns.CreatedAt
+			m.namespaces[ns.ID] = namespace
+			return nil
 		}
 	}
 
@@ -157,7 +167,10 @@ func (m *manager) CreatePrivateDnsNamespace(ctx context.Context, name, vpc strin
 	// Check if namespace already exists
 	for _, ns := range m.namespaces {
 		if ns.Name == name {
-			return nil, fmt.Errorf("namespace with name %s already exists", name)
+			logging.Info("Namespace already exists, returning existing namespace",
+				"name", name,
+				"id", ns.ID)
+			return ns, nil
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Introduced TaskUpdater interface to resolve circular dependency between sync and kubernetes packages
- Fixed BatchUpdater to trigger Service Discovery registration when tasks become RUNNING
- Prevented duplicate CoreDNS domain configurations to fix crashes
- Made namespace creation idempotent to handle controlplane restarts gracefully

## Changes

### 1. Circular Dependency Resolution
- Created `TaskUpdater` interface to decouple package dependencies
- SyncController now uses interface instead of direct TaskManager reference

### 2. Service Discovery Registration Fix
- BatchUpdater now calls UpdateTaskStatus when updating task status to RUNNING
- This properly triggers Service Discovery registration for running tasks

### 3. CoreDNS Duplicate Configuration Prevention
- Check and remove existing duplicate entries before adding new domain configuration
- Prevents CoreDNS crashes due to duplicate domain definitions

### 4. Idempotent Namespace Creation
- Return existing namespace instead of error when namespace already exists
- Improves stability during controlplane restarts

## Test plan
- [x] Controlplane builds successfully
- [x] Service Discovery instance registration works
- [x] CoreDNS doesn't crash with duplicate configurations
- [x] Service-to-service DNS resolution functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)