### PR TITLE
fix: Service Discovery registration for existing pods and klog replacement

### DIFF
--- a/controlplane/internal/controllers/sync/mappers/task_mapper.go
+++ b/controlplane/internal/controllers/sync/mappers/task_mapper.go
@@ -177,6 +177,11 @@ func (m *TaskStateMapper) MapPodToTask(pod *corev1.Pod) *storage.Task {
 	// Extract CPU and memory from pod spec
 	task.CPU, task.Memory = m.extractResourceLimits(pod)
 
+	// Extract Service Registries from pod annotations
+	if serviceRegistries, exists := pod.Annotations["kecs.dev/service-registries"]; exists {
+		task.ServiceRegistries = serviceRegistries
+	}
+
 	return task
 }
 

--- a/controlplane/internal/controllers/sync/task_sync.go
+++ b/controlplane/internal/controllers/sync/task_sync.go
@@ -8,27 +8,27 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 
 	"github.com/nandemo-ya/kecs/controlplane/internal/controllers/sync/mappers"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
 )
 
 // syncTask syncs a pod to ECS task state
 func (c *SyncController) syncTask(ctx context.Context, key string) error {
-	klog.Infof("syncTask called with key: %s", key)
+	logging.Debug("syncTask called", "key", key)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return fmt.Errorf("invalid resource key: %s", key)
 	}
 
 	// Get the pod
-	klog.Infof("Getting pod %s/%s", namespace, name)
+	logging.Debug("Getting pod", "namespace", namespace, "name", name)
 	pod, err := c.podLister.Pods(namespace).Get(name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Pod was deleted, update task to STOPPED
-			klog.Infof("Pod %s/%s not found, handling deletion", namespace, name)
+			logging.Debug("Pod not found, handling deletion", "namespace", namespace, "name", name)
 			return c.handleDeletedPod(ctx, namespace, name)
 		}
 		return fmt.Errorf("error fetching pod: %v", err)
@@ -36,7 +36,7 @@ func (c *SyncController) syncTask(ctx context.Context, key string) error {
 
 	// Check if this is an ECS-managed pod
 	if !isECSManagedPod(pod) {
-		klog.Infof("Ignoring non-ECS pod: %s", name)
+		logging.Debug("Ignoring non-ECS pod", "name", name)
 		return nil
 	}
 
@@ -47,15 +47,15 @@ func (c *SyncController) syncTask(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to map pod to task")
 	}
 
-	klog.Infof("Mapped pod to task - taskArn: %s, status: %s", task.ARN, task.LastStatus)
+	logging.Debug("Mapped pod to task", "taskArn", task.ARN, "status", task.LastStatus)
 
 	// Add to batch updater for efficient storage update
 	c.batchUpdater.AddTaskUpdate(task)
-	klog.Infof("Queued task update for pod %s/%s", namespace, name)
+	logging.Debug("Queued task update", "namespace", namespace, "name", name)
 
 	// Log the sync result
-	klog.V(2).Infof("Successfully synced task %s: status=%s, health=%s",
-		task.ARN, task.LastStatus, task.HealthStatus)
+	logging.Debug("Successfully synced task",
+		"taskArn", task.ARN, "status", task.LastStatus, "health", task.HealthStatus)
 
 	return nil
 }
@@ -79,10 +79,16 @@ func (c *SyncController) handleDeletedPod(ctx context.Context, namespace, podNam
 	if err != nil {
 		if isNotFound(err) {
 			// Task doesn't exist, nothing to do
-			klog.V(4).Infof("Task not found for deleted pod %s/%s", namespace, podName)
+			logging.Debug("Task not found for deleted pod", "namespace", namespace, "pod", podName)
 			return nil
 		}
 		return fmt.Errorf("error getting task: %v", err)
+	}
+
+	// Check if task is nil
+	if task == nil {
+		logging.Debug("Task is nil for deleted pod", "namespace", namespace, "pod", podName)
+		return nil
 	}
 
 	// Update task to STOPPED
@@ -109,13 +115,13 @@ func (c *SyncController) handleDeletedPod(ctx context.Context, namespace, podNam
 	// Add to batch updater
 	c.batchUpdater.AddTaskUpdate(task)
 
-	klog.V(2).Infof("Marked task %s as STOPPED due to pod deletion", taskARN)
+	logging.Debug("Marked task as STOPPED due to pod deletion", "taskArn", taskARN)
 	return nil
 }
 
 // syncPod is the main entry point for pod synchronization
 func (c *SyncController) syncPod(ctx context.Context, key string) error {
-	klog.V(4).Infof("Syncing pod: %s", key)
+	logging.Debug("Syncing pod", "key", key)
 	return c.syncTask(ctx, key)
 }
 


### PR DESCRIPTION
## Summary
- Replace klog with logging package throughout sync controller to follow project conventions
- Add support for processing existing pods when controller starts up
- Fix Service Discovery registration to work correctly after controlplane restarts

## Changes
- Replace klog with logging package in sync controller and task_sync
- Add `processExistingPods` method to handle existing pods on controller startup
- Fix nil pointer dereference in task_sync.go
- Add ServiceRegistries field mapping in TaskStateMapper
- Handle duplicate task creation gracefully in ServiceManager
- Update task status immediately for existing pods in watchPodStatus

## Test Plan
- [x] Unit tests pass
- [x] Pre-commit hooks pass
- [x] Deployed and tested Service Discovery registration
- [x] Verified pods are properly tracked after controlplane restart
- [x] Confirmed ServiceRegistries metadata propagates to pod annotations

## Related Issues
- Fixes Service Discovery registration not working after controlplane restarts
- Addresses klog usage violating project conventions
- Resolves nil pointer dereference crashes in task sync

🤖 Generated with [Claude Code](https://claude.ai/code)