### PR TITLE
fix: Improve cluster creation stability by making namespace creation synchronous

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_ecs_api.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api.go
@@ -688,23 +688,6 @@ func (api *DefaultECSAPI) PutClusterCapacityProviders(ctx context.Context, req *
 	}, nil
 }
 
-// createK8sClusterAndNamespace creates a namespace for the ECS cluster in the existing KECS instance
-func (api *DefaultECSAPI) createK8sClusterAndNamespace(cluster *storage.Cluster) {
-	// In the new design, we use the existing KECS instance's k3d cluster
-	// ECS clusters are represented as Kubernetes namespaces
-	logging.Info("Creating namespace for ECS cluster", "cluster", cluster.Name, "k8sCluster", cluster.K8sClusterName)
-
-	// In the new architecture, the KECS instance (k3d cluster) should already exist
-	// We only need to create namespaces for ECS clusters
-	// The k3d cluster name in storage is just for reference to the KECS instance
-
-	// Create namespace
-	api.createNamespaceForCluster(cluster)
-
-	// Deploy LocalStack if enabled
-	api.deployLocalStackIfEnabled(cluster)
-}
-
 // createNamespaceForCluster creates a namespace in the k3d cluster
 func (api *DefaultECSAPI) createNamespaceForCluster(cluster *storage.Cluster) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Fixed issue where namespace creation was being skipped in CI/test environments
- Made namespace creation synchronous to ensure it exists before CreateCluster returns
- Removed CI environment check that was preventing namespace creation
- LocalStack deployment remains asynchronous as it's not critical for cluster creation

## Problem
In CI/CD environments like GitHub Actions, the namespace creation was being skipped entirely due to a check for `GITHUB_ACTIONS` or `CI` environment variables. This could cause subsequent operations to fail because they expected the namespace to exist.

## Solution
1. **Synchronous namespace creation**: Changed `CreateCluster` to call `createNamespaceForCluster` synchronously instead of in a goroutine
2. **Removed CI skip logic**: Eliminated the environment variable check that was preventing namespace creation in CI
3. **Async LocalStack only**: Only LocalStack deployment remains asynchronous since it's not critical for cluster functionality

## Test plan
- [ ] Verify cluster creation works in local development
- [ ] Confirm namespace is created before CreateCluster returns
- [ ] Test in CI environment (GitHub Actions) to ensure namespace exists for subsequent operations
- [ ] Validate that LocalStack deployment still works asynchronously when enabled

🤖 Generated with [Claude Code](https://claude.ai/code)