### PR TITLE
feat: Add TaskSet Kubernetes integration and EXTERNAL deployment controller support

### DIFF
--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -20,6 +20,7 @@ type DefaultECSAPI struct {
 	clusterManager            kubernetes.ClusterManager
 	serviceManager            *kubernetes.ServiceManager
 	taskManagerInstance       *kubernetes.TaskManager
+	taskSetManager            *kubernetes.TaskSetManager
 	region                    string
 	accountID                 string
 	iamIntegration            iam.Integration
@@ -82,6 +83,11 @@ func (api *DefaultECSAPI) SetServiceDiscoveryManager(serviceDiscoveryManager ser
 // SetServiceManager sets the service manager for the ECS API
 func (api *DefaultECSAPI) SetServiceManager(serviceManager *kubernetes.ServiceManager) {
 	api.serviceManager = serviceManager
+}
+
+// SetTaskSetManager sets the TaskSet manager for the ECS API
+func (api *DefaultECSAPI) SetTaskSetManager(taskSetManager *kubernetes.TaskSetManager) {
+	api.taskSetManager = taskSetManager
 }
 
 // SetLocalStackManager sets the LocalStack manager for the ECS API

--- a/controlplane/internal/controlplane/api/task_set_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/task_set_ecs_api_test.go
@@ -155,10 +155,8 @@ var _ = Describe("TaskSetEcsApi", func() {
 			Expect(*resp.TaskSet.Status).To(Equal("DRAINING"))
 			Expect(*resp.TaskSet.Id).To(Equal(taskSetID))
 
-			// Verify status was updated to DRAINING
-			taskSet, err := mockTaskSetStore.Get(ctx, serviceARN, taskSetID)
-			Expect(err).To(BeNil())
-			Expect(taskSet.Status).To(Equal("DRAINING"))
+			// Note: TaskSet is deleted from storage after setting status to DRAINING
+			// so we cannot verify it exists in storage anymore
 		})
 
 		It("should return error when service or taskSet is missing", func() {
@@ -307,8 +305,17 @@ var _ = Describe("TaskSetEcsApi", func() {
 				},
 			}
 
+			// Mock service exists
+			err := mockServiceStore.Create(ctx, &storage.Service{
+				ARN:          serviceARN,
+				ServiceName:  serviceName,
+				ClusterARN:   clusterARN,
+				DesiredCount: 10,
+			})
+			Expect(err).To(BeNil())
+
 			// Mock task set exists
-			err := mockTaskSetStore.Create(ctx, &storage.TaskSet{
+			err = mockTaskSetStore.Create(ctx, &storage.TaskSet{
 				ID:                   taskSetID,
 				ARN:                  fmt.Sprintf("arn:aws:ecs:%s:%s:task-set/%s/%s/%s", region, accountID, clusterName, serviceName, taskSetID),
 				ServiceARN:           serviceARN,

--- a/controlplane/internal/converters/taskset_converter.go
+++ b/controlplane/internal/converters/taskset_converter.go
@@ -1,0 +1,315 @@
+package converters
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+// TaskSetConverter converts TaskSet to Kubernetes resources
+type TaskSetConverter struct {
+	taskConverter *TaskConverter
+}
+
+// NewTaskSetConverter creates a new TaskSet converter
+func NewTaskSetConverter(taskConverter *TaskConverter) *TaskSetConverter {
+	return &TaskSetConverter{
+		taskConverter: taskConverter,
+	}
+}
+
+// ConvertTaskSetToDeployment converts a TaskSet to a Kubernetes Deployment
+func (c *TaskSetConverter) ConvertTaskSetToDeployment(
+	taskSet *storage.TaskSet,
+	service *storage.Service,
+	taskDef *storage.TaskDefinition,
+	clusterName string,
+) (*appsv1.Deployment, error) {
+	// Parse network configuration
+	var networkConfig *generated.NetworkConfiguration
+	if taskSet.NetworkConfiguration != "" {
+		if err := json.Unmarshal([]byte(taskSet.NetworkConfiguration), &networkConfig); err != nil {
+			return nil, fmt.Errorf("failed to parse network configuration: %w", err)
+		}
+	}
+
+	// Create RunTask request JSON for converter
+	runTaskReq := map[string]interface{}{
+		"taskDefinition": taskSet.TaskDefinition,
+		"cluster":        clusterName,
+		"launchType":     taskSet.LaunchType,
+	}
+
+	if networkConfig != nil {
+		runTaskReq["networkConfiguration"] = networkConfig
+	}
+
+	if taskSet.PlatformVersion != "" {
+		runTaskReq["platformVersion"] = taskSet.PlatformVersion
+	}
+
+	runTaskJSON, err := json.Marshal(runTaskReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal run task request: %w", err)
+	}
+
+	// Get cluster object
+	clusterObj := &storage.Cluster{
+		Name:      clusterName,
+		Region:    taskSet.Region,
+		AccountID: taskSet.AccountID,
+	}
+
+	// Generate task ID for the deployment
+	taskID := fmt.Sprintf("taskset-%s-%s", service.ServiceName, taskSet.ID)
+
+	// Convert task to pod using existing converter
+	pod, err := c.taskConverter.ConvertTaskToPod(taskDef, runTaskJSON, clusterObj, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert task to pod: %w", err)
+	}
+
+	// Create deployment from pod template
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.GetDeploymentName(service.ServiceName, taskSet.ID),
+			Namespace: pod.Namespace,
+			Labels: map[string]string{
+				"kecs.io/cluster":             clusterName,
+				"kecs.io/service":             service.ServiceName,
+				"kecs.io/taskset":             taskSet.ID,
+				"kecs.io/taskset-external-id": taskSet.ExternalID,
+				"kecs.io/role":                "taskset",
+				"kecs.io/managed":             "true",
+			},
+			Annotations: map[string]string{
+				"kecs.io/taskset-arn":      taskSet.ARN,
+				"kecs.io/service-arn":      taskSet.ServiceARN,
+				"kecs.io/task-definition":  taskSet.TaskDefinition,
+				"kecs.io/launch-type":      taskSet.LaunchType,
+				"kecs.io/platform-version": taskSet.PlatformVersion,
+				"kecs.io/stability-status": taskSet.StabilityStatus,
+				"kecs.io/status":           taskSet.Status,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: c.GetReplicas(taskSet, service),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kecs.io/taskset": taskSet.ID,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"kecs.io/cluster":             clusterName,
+						"kecs.io/service":             service.ServiceName,
+						"kecs.io/taskset":             taskSet.ID,
+						"kecs.io/taskset-external-id": taskSet.ExternalID,
+						"kecs.io/role":                "taskset-pod",
+					},
+					Annotations: pod.Annotations,
+				},
+				Spec: pod.Spec,
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: intOrStringPtr("25%"),
+					MaxSurge:       intOrStringPtr("25%"),
+				},
+			},
+			ProgressDeadlineSeconds: int32Ptr(600), // 10 minutes
+		},
+	}
+
+	// Add load balancer labels if configured
+	if taskSet.LoadBalancers != "" {
+		deployment.Spec.Template.Labels["kecs.io/load-balancer-enabled"] = "true"
+	}
+
+	// Add service registry labels if configured
+	if taskSet.ServiceRegistries != "" {
+		deployment.Spec.Template.Labels["kecs.io/service-discovery-enabled"] = "true"
+	}
+
+	return deployment, nil
+}
+
+// ConvertTaskSetToService creates a Kubernetes Service for the TaskSet if needed
+func (c *TaskSetConverter) ConvertTaskSetToService(
+	taskSet *storage.TaskSet,
+	service *storage.Service,
+	taskDef *storage.TaskDefinition,
+	clusterName string,
+	isPrimary bool,
+) (*corev1.Service, error) {
+	// Parse container definitions from task definition
+	var containerDefinitions []generated.ContainerDefinition
+	if err := json.Unmarshal([]byte(taskDef.ContainerDefinitions), &containerDefinitions); err != nil {
+		return nil, fmt.Errorf("failed to parse container definitions: %w", err)
+	}
+
+	// Find port mappings
+	var ports []corev1.ServicePort
+	for _, container := range containerDefinitions {
+		if container.PortMappings != nil {
+			for _, pm := range container.PortMappings {
+				protocol := "tcp"
+				if pm.Protocol != nil {
+					protocol = strings.ToLower(string(*pm.Protocol))
+				}
+				containerPort := int32(80) // default
+				if pm.ContainerPort != nil {
+					containerPort = *pm.ContainerPort
+				}
+				port := corev1.ServicePort{
+					Name:     fmt.Sprintf("%s-%d", protocol, containerPort),
+					Port:     containerPort,
+					Protocol: corev1.ProtocolTCP,
+				}
+				if strings.ToUpper(protocol) == "UDP" {
+					port.Protocol = corev1.ProtocolUDP
+				}
+				ports = append(ports, port)
+			}
+		}
+	}
+
+	// If no ports, don't create a service
+	if len(ports) == 0 {
+		return nil, nil
+	}
+
+	// Create service
+	k8sService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.GetServiceName(service.ServiceName, taskSet.ID),
+			Namespace: c.GetNamespace(clusterName, taskSet.Region),
+			Labels: map[string]string{
+				"kecs.io/cluster":             clusterName,
+				"kecs.io/service":             service.ServiceName,
+				"kecs.io/taskset":             taskSet.ID,
+				"kecs.io/taskset-external-id": taskSet.ExternalID,
+				"kecs.io/role":                "taskset-service",
+				"kecs.io/managed":             "true",
+			},
+			Annotations: map[string]string{
+				"kecs.io/taskset-arn":     taskSet.ARN,
+				"kecs.io/service-arn":     taskSet.ServiceARN,
+				"kecs.io/taskset-primary": fmt.Sprintf("%t", isPrimary),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"kecs.io/taskset": taskSet.ID,
+			},
+			Ports: ports,
+			Type:  corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	// If this is the primary TaskSet, also update the main service selector
+	if isPrimary {
+		k8sService.Labels["kecs.io/primary"] = "true"
+	}
+
+	return k8sService, nil
+}
+
+// GetReplicas calculates the desired replica count for the TaskSet
+func (c *TaskSetConverter) GetReplicas(taskSet *storage.TaskSet, service *storage.Service) *int32 {
+	// Parse scale configuration
+	if taskSet.Scale != "" {
+		var scale generated.Scale
+		if err := json.Unmarshal([]byte(taskSet.Scale), &scale); err == nil {
+			if scale.Value != nil && scale.Unit != nil {
+				switch *scale.Unit {
+				case generated.ScaleUnit("PERCENT"):
+					// Calculate based on percentage of service desired count
+					replicas := int32(float64(service.DesiredCount) * (*scale.Value / 100.0))
+					return &replicas
+				case generated.ScaleUnit("COUNT"):
+					// Use absolute count
+					replicas := int32(*scale.Value)
+					return &replicas
+				}
+			}
+		}
+	}
+
+	// Default to computed desired count if available
+	if taskSet.ComputedDesiredCount > 0 {
+		replicas := int32(taskSet.ComputedDesiredCount)
+		return &replicas
+	}
+
+	// Fall back to 0 replicas
+	replicas := int32(0)
+	return &replicas
+}
+
+// GetDeploymentName generates the deployment name for a TaskSet
+func (c *TaskSetConverter) GetDeploymentName(serviceName, taskSetID string) string {
+	// Ensure the name is valid for Kubernetes
+	name := fmt.Sprintf("%s-%s", serviceName, taskSetID)
+	// Replace underscores with hyphens
+	name = strings.ReplaceAll(name, "_", "-")
+	// Convert to lowercase
+	name = strings.ToLower(name)
+	// Truncate if too long (max 63 characters)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	// Remove trailing hyphens
+	name = strings.TrimSuffix(name, "-")
+	return name
+}
+
+// GetServiceName generates the service name for a TaskSet
+func (c *TaskSetConverter) GetServiceName(serviceName, taskSetID string) string {
+	return c.GetDeploymentName(serviceName, taskSetID) + "-svc"
+}
+
+// GetNamespace returns the namespace for the given cluster and region
+func (c *TaskSetConverter) GetNamespace(clusterName, region string) string {
+	// Use the same namespace pattern as tasks
+	return fmt.Sprintf("%s-%s", clusterName, region)
+}
+
+// UpdateDeploymentScale updates the replica count of a deployment
+func (c *TaskSetConverter) UpdateDeploymentScale(deployment *appsv1.Deployment, taskSet *storage.TaskSet, service *storage.Service) {
+	deployment.Spec.Replicas = c.GetReplicas(taskSet, service)
+}
+
+// GetTaskSetStatusFromDeployment extracts TaskSet status from deployment
+func (c *TaskSetConverter) GetTaskSetStatusFromDeployment(deployment *appsv1.Deployment) (runningCount, pendingCount int64) {
+	if deployment.Status.ReadyReplicas > 0 {
+		runningCount = int64(deployment.Status.ReadyReplicas)
+	}
+
+	if deployment.Status.Replicas > deployment.Status.ReadyReplicas {
+		pendingCount = int64(deployment.Status.Replicas - deployment.Status.ReadyReplicas)
+	}
+
+	return runningCount, pendingCount
+}
+
+// Helper functions
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+func intOrStringPtr(s string) *intstr.IntOrString {
+	val := intstr.FromString(s)
+	return &val
+}
+

--- a/controlplane/internal/converters/taskset_converter_test.go
+++ b/controlplane/internal/converters/taskset_converter_test.go
@@ -1,0 +1,226 @@
+package converters_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
+	"github.com/nandemo-ya/kecs/controlplane/internal/converters"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+var _ = Describe("TaskSetConverter", func() {
+	var (
+		converter *converters.TaskSetConverter
+		taskSet   *storage.TaskSet
+		service   *storage.Service
+		taskDef   *storage.TaskDefinition
+	)
+
+	BeforeEach(func() {
+		taskConverter := converters.NewTaskConverter("us-east-1", "000000000000")
+		converter = converters.NewTaskSetConverter(taskConverter)
+
+		// Create test TaskSet
+		taskSet = &storage.TaskSet{
+			ID:                   "ts-12345678",
+			ARN:                  "arn:aws:ecs:us-east-1:000000000000:task-set/default/test-service/ts-12345678",
+			ServiceARN:           "arn:aws:ecs:us-east-1:000000000000:service/default/test-service",
+			ClusterARN:           "arn:aws:ecs:us-east-1:000000000000:cluster/default",
+			ExternalID:           "blue-deployment",
+			TaskDefinition:       "webapp:1",
+			LaunchType:           "FARGATE",
+			Status:               "ACTIVE",
+			StabilityStatus:      "STEADY_STATE",
+			ComputedDesiredCount: 2,
+			Region:               "us-east-1",
+			AccountID:            "000000000000",
+		}
+
+		// Create test Service
+		service = &storage.Service{
+			ServiceName:  "test-service",
+			DesiredCount: 2,
+		}
+
+		// Create test TaskDefinition
+		containerDefs := []generated.ContainerDefinition{
+			{
+				Name:  taskSetStrPtr("webapp"),
+				Image: taskSetStrPtr("nginx:latest"),
+				PortMappings: []generated.PortMapping{
+					{
+						ContainerPort: taskSetInt32Ptr(80),
+						Protocol:      (*generated.TransportProtocol)(taskSetStrPtr("tcp")),
+					},
+				},
+			},
+		}
+		containerDefsJSON, _ := json.Marshal(containerDefs)
+
+		taskDef = &storage.TaskDefinition{
+			ARN:                  "arn:aws:ecs:us-east-1:000000000000:task-definition/webapp:1",
+			Family:               "webapp",
+			Revision:             1,
+			ContainerDefinitions: string(containerDefsJSON),
+			NetworkMode:          "awsvpc",
+			TaskRoleARN:          "arn:aws:iam::000000000000:role/ecsTaskRole",
+			ExecutionRoleARN:     "arn:aws:iam::000000000000:role/ecsTaskExecutionRole",
+		}
+	})
+
+	Describe("ConvertTaskSetToDeployment", func() {
+		It("should convert TaskSet to Deployment", func() {
+			deployment, err := converter.ConvertTaskSetToDeployment(taskSet, service, taskDef, "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment).NotTo(BeNil())
+
+			// Check deployment metadata
+			Expect(deployment.Name).To(Equal("test-service-ts-12345678"))
+			Expect(deployment.Namespace).To(Equal("default-us-east-1"))
+			Expect(deployment.Labels["kecs.io/taskset"]).To(Equal("ts-12345678"))
+			Expect(deployment.Labels["kecs.io/service"]).To(Equal("test-service"))
+			Expect(deployment.Labels["kecs.io/taskset-external-id"]).To(Equal("blue-deployment"))
+
+			// Check replicas
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
+
+			// Check selector
+			Expect(deployment.Spec.Selector.MatchLabels["kecs.io/taskset"]).To(Equal("ts-12345678"))
+		})
+
+		It("should handle TaskSet with scale configuration", func() {
+			scale := generated.Scale{
+				Value: taskSetFloat64Ptr(50.0),
+				Unit:  (*generated.ScaleUnit)(taskSetStrPtr("PERCENT")),
+			}
+			scaleJSON, _ := json.Marshal(scale)
+			taskSet.Scale = string(scaleJSON)
+
+			deployment, err := converter.ConvertTaskSetToDeployment(taskSet, service, taskDef, "default")
+			Expect(err).NotTo(HaveOccurred())
+
+			// 50% of 2 desired count = 1 replica
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+		})
+	})
+
+	Describe("ConvertTaskSetToService", func() {
+		It("should create Service for TaskSet with port mappings", func() {
+			k8sService, err := converter.ConvertTaskSetToService(taskSet, service, taskDef, "default", false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sService).NotTo(BeNil())
+
+			// Check service metadata
+			Expect(k8sService.Name).To(Equal("test-service-ts-12345678-svc"))
+			Expect(k8sService.Namespace).To(Equal("default-us-east-1"))
+			Expect(k8sService.Labels["kecs.io/taskset"]).To(Equal("ts-12345678"))
+
+			// Check ports
+			Expect(k8sService.Spec.Ports).To(HaveLen(1))
+			Expect(k8sService.Spec.Ports[0].Port).To(Equal(int32(80)))
+			Expect(k8sService.Spec.Ports[0].Name).To(Equal("tcp-80"))
+
+			// Check selector
+			Expect(k8sService.Spec.Selector["kecs.io/taskset"]).To(Equal("ts-12345678"))
+		})
+
+		It("should return nil for TaskSet without port mappings", func() {
+			// TaskDefinition without port mappings
+			containerDefs := []generated.ContainerDefinition{
+				{
+					Name:  taskSetStrPtr("worker"),
+					Image: taskSetStrPtr("busybox:latest"),
+				},
+			}
+			containerDefsJSON, _ := json.Marshal(containerDefs)
+			taskDef.ContainerDefinitions = string(containerDefsJSON)
+
+			k8sService, err := converter.ConvertTaskSetToService(taskSet, service, taskDef, "default", false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sService).To(BeNil())
+		})
+	})
+
+	Describe("GetReplicas", func() {
+		It("should calculate replicas from percentage scale", func() {
+			scale := generated.Scale{
+				Value: taskSetFloat64Ptr(75.0),
+				Unit:  (*generated.ScaleUnit)(taskSetStrPtr("PERCENT")),
+			}
+			scaleJSON, _ := json.Marshal(scale)
+			taskSet.Scale = string(scaleJSON)
+			service.DesiredCount = 4
+
+			replicas := converter.GetReplicas(taskSet, service)
+			Expect(*replicas).To(Equal(int32(3))) // 75% of 4 = 3
+		})
+
+		It("should use absolute count scale", func() {
+			scale := generated.Scale{
+				Value: taskSetFloat64Ptr(5.0),
+				Unit:  (*generated.ScaleUnit)(taskSetStrPtr("COUNT")),
+			}
+			scaleJSON, _ := json.Marshal(scale)
+			taskSet.Scale = string(scaleJSON)
+
+			replicas := converter.GetReplicas(taskSet, service)
+			Expect(*replicas).To(Equal(int32(5)))
+		})
+
+		It("should use computed desired count when no scale", func() {
+			taskSet.ComputedDesiredCount = 3
+			replicas := converter.GetReplicas(taskSet, service)
+			Expect(*replicas).To(Equal(int32(3)))
+		})
+	})
+
+	Describe("GetTaskSetStatusFromDeployment", func() {
+		It("should extract status from deployment", func() {
+			deployment := &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Replicas:      5,
+					ReadyReplicas: 3,
+				},
+			}
+
+			runningCount, pendingCount := converter.GetTaskSetStatusFromDeployment(deployment)
+			Expect(runningCount).To(Equal(int64(3)))
+			Expect(pendingCount).To(Equal(int64(2)))
+		})
+	})
+
+	Describe("Helper Methods", func() {
+		It("should generate valid deployment name", func() {
+			name := converter.GetDeploymentName("my_service-name", "ts-abc123")
+			Expect(name).To(Equal("my-service-name-ts-abc123"))
+		})
+
+		It("should generate valid service name", func() {
+			name := converter.GetServiceName("my-service", "ts-abc123")
+			Expect(name).To(Equal("my-service-ts-abc123-svc"))
+		})
+
+		It("should return correct namespace", func() {
+			namespace := converter.GetNamespace("test-cluster", "us-west-2")
+			Expect(namespace).To(Equal("test-cluster-us-west-2"))
+		})
+	})
+})
+
+// Helper functions
+func taskSetStrPtr(s string) *string {
+	return &s
+}
+
+func taskSetInt32Ptr(i int32) *int32 {
+	return &i
+}
+
+func taskSetFloat64Ptr(f float64) *float64 {
+	return &f
+}
+

--- a/controlplane/internal/kubernetes/taskset_manager.go
+++ b/controlplane/internal/kubernetes/taskset_manager.go
@@ -1,0 +1,407 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/converters"
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+// TaskSetManager manages TaskSet resources in Kubernetes
+type TaskSetManager struct {
+	kubeClient       kubernetes.Interface
+	taskSetConverter *converters.TaskSetConverter
+	taskManager      *TaskManager
+}
+
+// NewTaskSetManager creates a new TaskSet manager
+func NewTaskSetManager(kubeClient kubernetes.Interface, taskManager *TaskManager) *TaskSetManager {
+	// Use default region and account ID for converter
+	// These will be overridden by actual values in the TaskSet/Service objects
+	taskConverter := converters.NewTaskConverter("us-east-1", "000000000000")
+	taskSetConverter := converters.NewTaskSetConverter(taskConverter)
+
+	return &TaskSetManager{
+		kubeClient:       kubeClient,
+		taskSetConverter: taskSetConverter,
+		taskManager:      taskManager,
+	}
+}
+
+// CreateTaskSet creates a new TaskSet in Kubernetes
+func (m *TaskSetManager) CreateTaskSet(
+	ctx context.Context,
+	taskSet *storage.TaskSet,
+	service *storage.Service,
+	taskDef *storage.TaskDefinition,
+	clusterName string,
+) error {
+	logging.Info("Creating TaskSet in Kubernetes",
+		"taskSetId", taskSet.ID,
+		"service", service.ServiceName,
+		"cluster", clusterName)
+
+	// Convert TaskSet to Deployment
+	deployment, err := m.taskSetConverter.ConvertTaskSetToDeployment(taskSet, service, taskDef, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to convert TaskSet to deployment: %w", err)
+	}
+
+	// Create namespace if it doesn't exist
+	namespace := m.taskSetConverter.GetNamespace(clusterName, taskSet.Region)
+	if err := m.ensureNamespace(ctx, namespace); err != nil {
+		return fmt.Errorf("failed to ensure namespace: %w", err)
+	}
+
+	// Create the deployment
+	createdDeployment, err := m.kubeClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			logging.Warn("Deployment already exists, updating instead",
+				"deployment", deployment.Name,
+				"namespace", namespace)
+			// Update the existing deployment
+			createdDeployment, err = m.kubeClient.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to update existing deployment: %w", err)
+			}
+		} else {
+			return fmt.Errorf("failed to create deployment: %w", err)
+		}
+	}
+
+	logging.Info("Created deployment for TaskSet",
+		"deployment", createdDeployment.Name,
+		"namespace", namespace,
+		"replicas", *createdDeployment.Spec.Replicas)
+
+	// Create service if needed
+	k8sService, err := m.taskSetConverter.ConvertTaskSetToService(taskSet, service, taskDef, clusterName, false)
+	if err != nil {
+		logging.Warn("Failed to convert TaskSet to service",
+			"error", err)
+	} else if k8sService != nil {
+		_, err = m.kubeClient.CoreV1().Services(namespace).Create(ctx, k8sService, metav1.CreateOptions{})
+		if err != nil && !errors.IsAlreadyExists(err) {
+			logging.Warn("Failed to create service for TaskSet",
+				"service", k8sService.Name,
+				"error", err)
+		}
+	}
+
+	return nil
+}
+
+// UpdateTaskSet updates an existing TaskSet in Kubernetes
+func (m *TaskSetManager) UpdateTaskSet(
+	ctx context.Context,
+	taskSet *storage.TaskSet,
+	service *storage.Service,
+	clusterName string,
+) error {
+	logging.Info("Updating TaskSet in Kubernetes",
+		"taskSetId", taskSet.ID,
+		"service", service.ServiceName,
+		"cluster", clusterName)
+
+	namespace := m.taskSetConverter.GetNamespace(clusterName, taskSet.Region)
+	deploymentName := m.taskSetConverter.GetDeploymentName(service.ServiceName, taskSet.ID)
+
+	// Get existing deployment
+	deployment, err := m.kubeClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logging.Warn("Deployment not found for TaskSet update",
+				"deployment", deploymentName,
+				"namespace", namespace)
+			// TaskSet doesn't exist in Kubernetes, we might need to create it
+			// This can happen if the TaskSet was created before Kubernetes integration
+			return nil
+		}
+		return fmt.Errorf("failed to get deployment: %w", err)
+	}
+
+	// Update deployment scale
+	m.taskSetConverter.UpdateDeploymentScale(deployment, taskSet, service)
+
+	// Update deployment
+	updatedDeployment, err := m.kubeClient.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update deployment: %w", err)
+	}
+
+	logging.Info("Updated deployment for TaskSet",
+		"deployment", updatedDeployment.Name,
+		"namespace", namespace,
+		"replicas", *updatedDeployment.Spec.Replicas)
+
+	return nil
+}
+
+// DeleteTaskSet deletes a TaskSet from Kubernetes
+func (m *TaskSetManager) DeleteTaskSet(
+	ctx context.Context,
+	taskSet *storage.TaskSet,
+	service *storage.Service,
+	clusterName string,
+	force bool,
+) error {
+	logging.Info("Deleting TaskSet from Kubernetes",
+		"taskSetId", taskSet.ID,
+		"service", service.ServiceName,
+		"cluster", clusterName,
+		"force", force)
+
+	namespace := m.taskSetConverter.GetNamespace(clusterName, taskSet.Region)
+	deploymentName := m.taskSetConverter.GetDeploymentName(service.ServiceName, taskSet.ID)
+
+	// Delete deployment
+	deletePolicy := metav1.DeletePropagationForeground
+	deleteOptions := metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}
+
+	if force {
+		// Use background deletion for force delete
+		deletePolicy = metav1.DeletePropagationBackground
+		deleteOptions.PropagationPolicy = &deletePolicy
+		gracePeriod := int64(0)
+		deleteOptions.GracePeriodSeconds = &gracePeriod
+	}
+
+	err := m.kubeClient.AppsV1().Deployments(namespace).Delete(ctx, deploymentName, deleteOptions)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete deployment: %w", err)
+	}
+
+	// Delete service if exists
+	serviceName := m.taskSetConverter.GetServiceName(service.ServiceName, taskSet.ID)
+	err = m.kubeClient.CoreV1().Services(namespace).Delete(ctx, serviceName, deleteOptions)
+	if err != nil && !errors.IsNotFound(err) {
+		logging.Warn("Failed to delete service for TaskSet",
+			"service", serviceName,
+			"error", err)
+	}
+
+	logging.Info("Deleted TaskSet resources from Kubernetes",
+		"deployment", deploymentName,
+		"namespace", namespace)
+
+	return nil
+}
+
+// GetTaskSetStatus gets the current status of a TaskSet from Kubernetes
+func (m *TaskSetManager) GetTaskSetStatus(
+	ctx context.Context,
+	taskSet *storage.TaskSet,
+	service *storage.Service,
+	clusterName string,
+) (runningCount, pendingCount int64, stabilityStatus string, err error) {
+	namespace := m.taskSetConverter.GetNamespace(clusterName, taskSet.Region)
+	deploymentName := m.taskSetConverter.GetDeploymentName(service.ServiceName, taskSet.ID)
+
+	// Get deployment
+	deployment, err := m.kubeClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// TaskSet doesn't exist in Kubernetes
+			return 0, 0, "STEADY_STATE", nil
+		}
+		return 0, 0, "", fmt.Errorf("failed to get deployment: %w", err)
+	}
+
+	// Get counts from deployment status
+	runningCount, pendingCount = m.taskSetConverter.GetTaskSetStatusFromDeployment(deployment)
+
+	// Determine stability status
+	stabilityStatus = m.getStabilityStatus(deployment)
+
+	return runningCount, pendingCount, stabilityStatus, nil
+}
+
+// SetPrimaryTaskSet updates services to route traffic to the primary TaskSet
+func (m *TaskSetManager) SetPrimaryTaskSet(
+	ctx context.Context,
+	primaryTaskSet *storage.TaskSet,
+	service *storage.Service,
+	clusterName string,
+) error {
+	logging.Info("Setting primary TaskSet",
+		"taskSetId", primaryTaskSet.ID,
+		"service", service.ServiceName,
+		"cluster", clusterName)
+
+	namespace := m.taskSetConverter.GetNamespace(clusterName, primaryTaskSet.Region)
+
+	// Update the main service selector to point to the primary TaskSet
+	mainServiceName := strings.ToLower(service.ServiceName)
+	mainService, err := m.kubeClient.CoreV1().Services(namespace).Get(ctx, mainServiceName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create the main service
+			mainService = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mainServiceName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"kecs.io/cluster": clusterName,
+						"kecs.io/service": service.ServiceName,
+						"kecs.io/role":    "main-service",
+						"kecs.io/managed": "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"kecs.io/taskset": primaryTaskSet.ID,
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			}
+
+			// Get ports from TaskSet service
+			taskSetServiceName := m.taskSetConverter.GetServiceName(service.ServiceName, primaryTaskSet.ID)
+			taskSetService, err := m.kubeClient.CoreV1().Services(namespace).Get(ctx, taskSetServiceName, metav1.GetOptions{})
+			if err == nil && taskSetService != nil {
+				mainService.Spec.Ports = taskSetService.Spec.Ports
+			}
+
+			_, err = m.kubeClient.CoreV1().Services(namespace).Create(ctx, mainService, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create main service: %w", err)
+			}
+		} else {
+			return fmt.Errorf("failed to get main service: %w", err)
+		}
+	} else {
+		// Update existing service selector
+		mainService.Spec.Selector = map[string]string{
+			"kecs.io/taskset": primaryTaskSet.ID,
+		}
+		mainService.Labels["kecs.io/primary-taskset"] = primaryTaskSet.ID
+
+		_, err = m.kubeClient.CoreV1().Services(namespace).Update(ctx, mainService, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update main service: %w", err)
+		}
+	}
+
+	logging.Info("Updated main service to route to primary TaskSet",
+		"service", mainServiceName,
+		"taskSet", primaryTaskSet.ID)
+
+	return nil
+}
+
+// Helper functions
+
+func (m *TaskSetManager) ensureNamespace(ctx context.Context, namespace string) error {
+	_, err := m.kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create namespace
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"kecs.io/managed": "true",
+					},
+				},
+			}
+			_, err = m.kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			if err != nil && !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create namespace: %w", err)
+			}
+		} else {
+			return fmt.Errorf("failed to get namespace: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *TaskSetManager) getStabilityStatus(deployment *appsv1.Deployment) string {
+	// Check deployment conditions
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing {
+			if condition.Status == corev1.ConditionTrue &&
+				condition.Reason == "NewReplicaSetAvailable" {
+				return "STEADY_STATE"
+			}
+			if condition.Status == corev1.ConditionTrue {
+				return "STABILIZING"
+			}
+		}
+		if condition.Type == appsv1.DeploymentReplicaFailure {
+			if condition.Status == corev1.ConditionTrue {
+				return "UNSTABLE"
+			}
+		}
+	}
+
+	// Check replica status
+	if deployment.Status.ReadyReplicas == *deployment.Spec.Replicas {
+		return "STEADY_STATE"
+	}
+
+	if deployment.Status.ReadyReplicas < *deployment.Spec.Replicas {
+		return "STABILIZING"
+	}
+
+	return "STEADY_STATE"
+}
+
+// ListTaskSetsForService lists all TaskSets for a service
+func (m *TaskSetManager) ListTaskSetsForService(
+	ctx context.Context,
+	service *storage.Service,
+	clusterName string,
+	region string,
+) ([]*TaskSetInfo, error) {
+	namespace := m.taskSetConverter.GetNamespace(clusterName, region)
+
+	// List deployments with service label
+	labelSelector := fmt.Sprintf("kecs.io/service=%s,kecs.io/role=taskset", service.ServiceName)
+	deployments, err := m.kubeClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list deployments: %w", err)
+	}
+
+	var taskSets []*TaskSetInfo
+	for _, deployment := range deployments.Items {
+		taskSetID := deployment.Labels["kecs.io/taskset"]
+		externalID := deployment.Labels["kecs.io/taskset-external-id"]
+
+		runningCount, pendingCount := m.taskSetConverter.GetTaskSetStatusFromDeployment(&deployment)
+		stabilityStatus := m.getStabilityStatus(&deployment)
+
+		taskSets = append(taskSets, &TaskSetInfo{
+			TaskSetID:       taskSetID,
+			ExternalID:      externalID,
+			RunningCount:    runningCount,
+			PendingCount:    pendingCount,
+			StabilityStatus: stabilityStatus,
+		})
+	}
+
+	return taskSets, nil
+}
+
+// TaskSetInfo contains information about a TaskSet in Kubernetes
+type TaskSetInfo struct {
+	TaskSetID       string
+	ExternalID      string
+	RunningCount    int64
+	PendingCount    int64
+	StabilityStatus string
+}
+

--- a/controlplane/internal/storage/duckdb/duckdb.go
+++ b/controlplane/internal/storage/duckdb/duckdb.go
@@ -272,6 +272,7 @@ func (s *DuckDBStorage) createServicesTable(ctx context.Context) error {
 		service_registries VARCHAR,
 		network_configuration VARCHAR,
 		deployment_configuration VARCHAR,
+		deployment_controller VARCHAR,
 		placement_constraints VARCHAR,
 		placement_strategy VARCHAR,
 		capacity_provider_strategy VARCHAR,

--- a/controlplane/internal/storage/interfaces.go
+++ b/controlplane/internal/storage/interfaces.go
@@ -307,6 +307,9 @@ type Service struct {
 	// Deployment configuration as JSON
 	DeploymentConfiguration string `json:"deploymentConfiguration,omitempty"`
 
+	// Deployment controller as JSON (type: ECS|CODE_DEPLOY|EXTERNAL)
+	DeploymentController string `json:"deploymentController,omitempty"`
+
 	// Placement constraints as JSON
 	PlacementConstraints string `json:"placementConstraints,omitempty"`
 

--- a/docs/adr/records/0022-task-set-kubernetes-integration.md
+++ b/docs/adr/records/0022-task-set-kubernetes-integration.md
@@ -1,0 +1,167 @@
+# ADR-0022: TaskSet and Kubernetes Integration
+
+## Status
+Proposed
+
+## Context
+Amazon ECS TaskSets are a crucial component for advanced deployment strategies, particularly Blue/Green deployments and canary releases. A TaskSet represents a group of tasks running the same task definition version within a service. This allows multiple versions of an application to run simultaneously with controlled traffic distribution.
+
+In KECS, we need to map this ECS concept to Kubernetes resources while maintaining API compatibility and providing similar functionality.
+
+### ECS TaskSet Concepts
+- **TaskSet**: A collection of tasks (containers) running the same task definition
+- **Scale**: Percentage or count of desired tasks relative to service's desired count
+- **Primary TaskSet**: The TaskSet receiving production traffic
+- **Active TaskSet**: A TaskSet that is running and can receive traffic
+- **Service Registry**: Integration with service discovery for traffic routing
+
+### Use Cases
+1. **Blue/Green Deployment**: Running two TaskSets simultaneously and switching traffic
+2. **Canary Deployment**: Gradually shifting traffic from one TaskSet to another
+3. **A/B Testing**: Running multiple versions with specific traffic distribution
+4. **Rollback**: Quick reversion to previous TaskSet without redeployment
+
+## Decision
+
+### Kubernetes Resource Mapping
+
+We will map ECS TaskSets to Kubernetes resources as follows:
+
+#### 1. TaskSet → Deployment + Service
+Each TaskSet will be represented by:
+- **Kubernetes Deployment**: Manages the pods (tasks) for this TaskSet
+- **Kubernetes Service** (optional): For TaskSet-specific service discovery
+- **Labels**: Used to identify and group resources belonging to a TaskSet
+
+```yaml
+# Deployment for TaskSet
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {service-name}-{taskset-id}
+  namespace: {cluster-name}-{region}
+  labels:
+    kecs.io/cluster: {cluster-name}
+    kecs.io/service: {service-name}
+    kecs.io/taskset: {taskset-id}
+    kecs.io/taskset-external-id: {external-id}
+    kecs.io/role: taskset
+spec:
+  replicas: {computed-desired-count}
+  selector:
+    matchLabels:
+      kecs.io/taskset: {taskset-id}
+  template:
+    metadata:
+      labels:
+        kecs.io/cluster: {cluster-name}
+        kecs.io/service: {service-name}
+        kecs.io/taskset: {taskset-id}
+    spec:
+      containers: [...]
+```
+
+#### 2. Traffic Management
+
+For traffic distribution between TaskSets, we'll use:
+
+**Option A: Service with Endpoints Management** (Initial Implementation)
+- Main service points to all pods across TaskSets
+- Use label selectors to control which TaskSets receive traffic
+- Simple but limited traffic distribution control
+
+**Option B: Ingress/Gateway Based** (Future Enhancement)
+- Use Ingress controllers or Service Mesh for advanced traffic management
+- Supports percentage-based traffic splitting
+- Better for production Blue/Green deployments
+
+#### 3. Scale Management
+
+TaskSet scale will be calculated as:
+```
+taskset.computedDesiredCount = service.desiredCount * (taskset.scale.value / 100)
+```
+
+For example:
+- Service desired count: 10
+- Blue TaskSet scale: 100% → 10 replicas
+- Green TaskSet scale: 0% → 0 replicas (standby)
+
+### State Management
+
+#### TaskSet Lifecycle States
+1. **PROVISIONING**: Creating Kubernetes resources
+2. **ACTIVE**: Deployment is ready and pods are running
+3. **PRIMARY**: This TaskSet is receiving production traffic
+4. **DRAINING**: Removing from service discovery, terminating tasks
+
+#### Stability Status
+- **STABILIZING**: Deployment is rolling out
+- **STEADY_STATE**: All replicas are ready
+- **UNSTABLE**: Deployment has issues
+
+### Service Discovery Integration
+
+TaskSets will integrate with service discovery through:
+1. **Service selectors**: Updated to include/exclude TaskSet labels
+2. **DNS records**: TaskSet-specific DNS entries for testing
+3. **Health checks**: Readiness probes ensure only healthy pods receive traffic
+
+### API Implementation
+
+The existing TaskSet API handlers will be enhanced to:
+
+1. **CreateTaskSet**:
+   - Create Kubernetes Deployment
+   - Configure service discovery
+   - Set initial scale
+
+2. **UpdateTaskSet**:
+   - Update Deployment replicas for scale changes
+   - Modify service selectors for traffic shifts
+
+3. **DeleteTaskSet**:
+   - Gracefully drain traffic
+   - Delete Deployment and associated resources
+
+4. **DescribeTaskSets**:
+   - Aggregate status from Kubernetes resources
+   - Calculate running/pending/desired counts
+
+## Consequences
+
+### Positive
+- Enables Blue/Green deployments in KECS
+- Maintains ECS API compatibility
+- Leverages native Kubernetes capabilities
+- Supports gradual rollouts and quick rollbacks
+
+### Negative
+- Complex state synchronization between ECS model and Kubernetes
+- Initial implementation limited to basic traffic distribution
+- Requires careful coordination of multiple Kubernetes resources
+
+### Neutral
+- Additional Kubernetes resources per TaskSet increase cluster overhead
+- Need to implement cleanup for orphaned TaskSets
+
+## Implementation Plan
+
+### Phase 1: Basic TaskSet Support
+- Create/Delete TaskSet with Deployment creation
+- Scale management
+- Status reporting
+
+### Phase 2: Traffic Management
+- Service selector updates for PRIMARY TaskSet
+- Basic Blue/Green switching
+
+### Phase 3: Advanced Features
+- Percentage-based traffic splitting
+- Canary deployment support
+- Integration with Ingress/Service Mesh
+
+## References
+- [AWS ECS TaskSets Documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-external.html)
+- [Kubernetes Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/)

--- a/examples/task-set-blue-green/README.md
+++ b/examples/task-set-blue-green/README.md
@@ -1,0 +1,208 @@
+# TaskSet Blue/Green Deployment Example
+
+This example demonstrates how to perform Blue/Green deployments using Amazon ECS TaskSets with KECS.
+
+## Overview
+
+TaskSets enable advanced deployment strategies by allowing multiple versions of an application to run simultaneously within a single ECS service. This example shows:
+
+- Running two TaskSets (Blue and Green) within one service
+- Switching traffic between TaskSets
+- Rolling back to the previous version
+- Managing TaskSet lifecycle
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│           ECS Service                   │
+│  (EXTERNAL Deployment Controller)       │
+├─────────────────┬───────────────────────┤
+│   Blue TaskSet  │   Green TaskSet       │
+│   (PRIMARY)     │   (Standby)           │
+│   Scale: 100%   │   Scale: 0%           │
+│   Version: 1.0  │   Version: 2.0        │
+│   3 Tasks       │   0 Tasks             │
+└─────────────────┴───────────────────────┘
+```
+
+## Files
+
+- `task_def_blue.json` - Task definition for Blue version (v1.0.0)
+- `task_def_green.json` - Task definition for Green version (v2.0.0)
+- `service_def.json` - Service definition with EXTERNAL deployment controller
+- `deploy.sh` - Deployment script for Blue/Green operations
+
+## Prerequisites
+
+1. KECS running locally:
+```bash
+kecs start
+```
+
+2. AWS CLI configured to use KECS:
+```bash
+export AWS_ENDPOINT_URL=http://localhost:8080
+export AWS_REGION=us-east-1
+```
+
+## Usage
+
+### 1. Initial Setup
+
+Create the cluster, service, and both TaskSets:
+
+```bash
+./deploy.sh setup
+```
+
+This will:
+- Create an ECS cluster
+- Register both Blue and Green task definitions
+- Create a service with EXTERNAL deployment controller
+- Create Blue TaskSet as PRIMARY (100% scale)
+- Create Green TaskSet in standby (0% scale)
+
+### 2. Check Status
+
+View the current TaskSet configuration:
+
+```bash
+./deploy.sh status
+```
+
+Output shows:
+- External ID (blue-deployment/green-deployment)
+- Status (ACTIVE/PRIMARY/DRAINING)
+- Scale percentage
+- Desired/Running/Pending task counts
+
+### 3. Deploy Green Version
+
+Switch from Blue to Green:
+
+```bash
+./deploy.sh deploy
+```
+
+This performs:
+1. Scale Green TaskSet to 100%
+2. Wait for Green tasks to stabilize
+3. Set Green TaskSet as PRIMARY
+4. Scale Blue TaskSet to 0%
+
+### 4. Rollback to Blue
+
+If issues occur, rollback to Blue:
+
+```bash
+./deploy.sh rollback
+```
+
+This reverses the deployment:
+1. Scale Blue TaskSet to 100%
+2. Wait for Blue tasks to stabilize
+3. Set Blue TaskSet as PRIMARY
+4. Scale Green TaskSet to 0%
+
+### 5. Cleanup
+
+Remove all resources:
+
+```bash
+./deploy.sh cleanup
+```
+
+## Key Concepts
+
+### TaskSet States
+
+- **PROVISIONING**: TaskSet is being created
+- **ACTIVE**: TaskSet is running and can serve traffic
+- **PRIMARY**: TaskSet is the primary traffic target
+- **DRAINING**: TaskSet is being removed from service
+
+### Scale Management
+
+TaskSet scale is expressed as a percentage of the service's desired count:
+- `100%` - Full capacity (all traffic)
+- `50%` - Half capacity (canary deployment)
+- `0%` - Standby (no traffic)
+
+### Traffic Switching
+
+The PRIMARY TaskSet receives production traffic. Only one TaskSet can be PRIMARY at a time.
+
+## Advanced Scenarios
+
+### Canary Deployment
+
+For gradual rollout, scale both TaskSets partially:
+
+```bash
+# 90% Blue, 10% Green (Canary)
+aws ecs update-task-set --cluster default --service webapp-service \
+    --task-set $BLUE_TASKSET --scale "value=90,unit=PERCENT"
+
+aws ecs update-task-set --cluster default --service webapp-service \
+    --task-set $GREEN_TASKSET --scale "value=10,unit=PERCENT"
+```
+
+### A/B Testing
+
+Run both versions at 50% for A/B testing:
+
+```bash
+# 50% Blue, 50% Green
+aws ecs update-task-set --cluster default --service webapp-service \
+    --task-set $BLUE_TASKSET --scale "value=50,unit=PERCENT"
+
+aws ecs update-task-set --cluster default --service webapp-service \
+    --task-set $GREEN_TASKSET --scale "value=50,unit=PERCENT"
+```
+
+## Monitoring
+
+Monitor TaskSet deployment:
+
+```bash
+# Watch TaskSet status
+watch -n 2 "./deploy.sh status"
+
+# Check running pods (if using KECS)
+kubectl get pods -n default-us-east-1 -l kecs.io/service=webapp-service
+
+# View logs
+aws logs tail /kecs/webapp --follow
+```
+
+## Troubleshooting
+
+### TaskSet Not Scaling
+
+If tasks don't start:
+1. Check task definition is valid
+2. Verify network configuration
+3. Review task logs for errors
+
+### Service Not Found
+
+Ensure service was created with EXTERNAL deployment controller:
+```bash
+aws ecs describe-services --cluster default --services webapp-service \
+    --query 'services[0].deploymentController'
+```
+
+### Tasks Failing Health Checks
+
+Review health check configuration in task definition:
+- Increase `startPeriod` for slow-starting applications
+- Adjust `interval` and `timeout` values
+- Check application logs for startup errors
+
+## Notes
+
+- This example uses FARGATE launch type
+- Network configuration uses dummy subnet/security group IDs
+- In production, use proper VPC configuration
+- Task definitions use different nginx versions to simulate version changes

--- a/examples/task-set-blue-green/create_service.json
+++ b/examples/task-set-blue-green/create_service.json
@@ -1,0 +1,29 @@
+{
+  "serviceName": "webapp-service",
+  "cluster": "default",
+  "desiredCount": 2,
+  "deploymentController": {
+    "type": "EXTERNAL"
+  },
+  "schedulingStrategy": "REPLICA",
+  "launchType": "FARGATE",
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-12345"],
+      "securityGroups": ["sg-12345"],
+      "assignPublicIp": "ENABLED"
+    }
+  },
+  "healthCheckGracePeriodSeconds": 60,
+  "enableECSManagedTags": true,
+  "tags": [
+    {
+      "key": "Environment",
+      "value": "test"
+    },
+    {
+      "key": "Application",
+      "value": "webapp"
+    }
+  ]
+}

--- a/examples/task-set-blue-green/deploy.sh
+++ b/examples/task-set-blue-green/deploy.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+set -e
+
+# Blue/Green Deployment Script for KECS TaskSet
+# This script demonstrates how to perform a Blue/Green deployment using ECS TaskSets
+
+# Configuration
+CLUSTER_NAME="${CLUSTER_NAME:-default}"
+SERVICE_NAME="webapp-service"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localhost:8080}"
+
+# Colors for output
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Helper functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_blue() {
+    echo -e "${BLUE}[BLUE]${NC} $1"
+}
+
+log_green() {
+    echo -e "${GREEN}[GREEN]${NC} $1"
+}
+
+# AWS CLI wrapper
+aws_ecs() {
+    aws ecs "$@" --region "$AWS_REGION" --endpoint-url "$AWS_ENDPOINT" --no-cli-pager
+}
+
+# Step 1: Create ECS Cluster
+create_cluster() {
+    log_info "Creating ECS cluster: $CLUSTER_NAME"
+    aws_ecs create-cluster --cluster-name "$CLUSTER_NAME" || true
+    log_info "Cluster created/exists: $CLUSTER_NAME"
+}
+
+# Step 2: Register Task Definitions
+register_task_definitions() {
+    log_info "Registering Blue task definition..."
+    BLUE_TASK_DEF=$(aws_ecs register-task-definition \
+        --cli-input-json file://task_def_blue.json \
+        --query 'taskDefinition.taskDefinitionArn' \
+        --output text)
+    log_blue "Blue task definition: $BLUE_TASK_DEF"
+    
+    log_info "Registering Green task definition..."
+    GREEN_TASK_DEF=$(aws_ecs register-task-definition \
+        --cli-input-json file://task_def_green.json \
+        --query 'taskDefinition.taskDefinitionArn' \
+        --output text)
+    log_green "Green task definition: $GREEN_TASK_DEF"
+}
+
+# Step 3: Create Service with EXTERNAL deployment controller
+create_service() {
+    log_info "Creating service with EXTERNAL deployment controller..."
+    aws_ecs create-service \
+        --cli-input-json file://service_def.json \
+        --query 'service.serviceArn' \
+        --output text || {
+        log_warn "Service might already exist, continuing..."
+    }
+}
+
+# Step 4: Create Blue TaskSet (Primary)
+create_blue_taskset() {
+    log_blue "Creating Blue TaskSet as PRIMARY..."
+    
+    BLUE_TASKSET=$(aws_ecs create-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-definition webapp:1 \
+        --external-id "blue-deployment" \
+        --network-configuration "awsvpcConfiguration={subnets=[subnet-12345,subnet-67890],securityGroups=[sg-webapp],assignPublicIp=ENABLED}" \
+        --launch-type FARGATE \
+        --scale "value=100,unit=PERCENT" \
+        --query 'taskSet.taskSetArn' \
+        --output text 2>/dev/null) || {
+        log_warn "Blue TaskSet might already exist"
+        BLUE_TASKSET=$(aws_ecs describe-task-sets \
+            --cluster "$CLUSTER_NAME" \
+            --service "$SERVICE_NAME" \
+            --query "taskSets[?externalId=='blue-deployment'].taskSetArn | [0]" \
+            --output text)
+    }
+    
+    log_blue "Blue TaskSet ARN: $BLUE_TASKSET"
+    
+    # Update service to set Blue as PRIMARY
+    log_info "Setting Blue TaskSet as PRIMARY..."
+    aws_ecs update-service-primary-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --primary-task-set "$BLUE_TASKSET" || true
+}
+
+# Step 5: Create Green TaskSet (Standby)
+create_green_taskset() {
+    log_green "Creating Green TaskSet in standby (0% scale)..."
+    
+    GREEN_TASKSET=$(aws_ecs create-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-definition webapp:2 \
+        --external-id "green-deployment" \
+        --network-configuration "awsvpcConfiguration={subnets=[subnet-12345,subnet-67890],securityGroups=[sg-webapp],assignPublicIp=ENABLED}" \
+        --launch-type FARGATE \
+        --scale "value=0,unit=PERCENT" \
+        --query 'taskSet.taskSetArn' \
+        --output text 2>/dev/null) || {
+        log_warn "Green TaskSet might already exist"
+        GREEN_TASKSET=$(aws_ecs describe-task-sets \
+            --cluster "$CLUSTER_NAME" \
+            --service "$SERVICE_NAME" \
+            --query "taskSets[?externalId=='green-deployment'].taskSetArn | [0]" \
+            --output text)
+    }
+    
+    log_green "Green TaskSet ARN: $GREEN_TASKSET"
+}
+
+# Step 6: Show TaskSet Status
+show_status() {
+    log_info "Current TaskSet status:"
+    aws_ecs describe-task-sets \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --query 'taskSets[*].[externalId,status,scale.value,scale.unit,computedDesiredCount,runningCount,pendingCount]' \
+        --output table
+}
+
+# Step 7: Perform Blue to Green Switch
+switch_to_green() {
+    log_info "Starting Blue to Green deployment..."
+    
+    # Scale up Green TaskSet
+    log_green "Scaling up Green TaskSet to 100%..."
+    aws_ecs update-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-set "$GREEN_TASKSET" \
+        --scale "value=100,unit=PERCENT"
+    
+    log_info "Waiting for Green TaskSet to stabilize (30 seconds)..."
+    sleep 30
+    
+    # Make Green PRIMARY
+    log_green "Setting Green TaskSet as PRIMARY..."
+    aws_ecs update-service-primary-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --primary-task-set "$GREEN_TASKSET"
+    
+    log_info "Waiting for traffic shift (10 seconds)..."
+    sleep 10
+    
+    # Scale down Blue TaskSet
+    log_blue "Scaling down Blue TaskSet to 0%..."
+    aws_ecs update-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-set "$BLUE_TASKSET" \
+        --scale "value=0,unit=PERCENT"
+    
+    log_green "Blue to Green deployment completed!"
+}
+
+# Step 8: Rollback to Blue
+rollback_to_blue() {
+    log_warn "Rolling back to Blue deployment..."
+    
+    # Scale up Blue TaskSet
+    log_blue "Scaling up Blue TaskSet to 100%..."
+    aws_ecs update-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-set "$BLUE_TASKSET" \
+        --scale "value=100,unit=PERCENT"
+    
+    log_info "Waiting for Blue TaskSet to stabilize (30 seconds)..."
+    sleep 30
+    
+    # Make Blue PRIMARY
+    log_blue "Setting Blue TaskSet as PRIMARY..."
+    aws_ecs update-service-primary-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --primary-task-set "$BLUE_TASKSET"
+    
+    log_info "Waiting for traffic shift (10 seconds)..."
+    sleep 10
+    
+    # Scale down Green TaskSet
+    log_green "Scaling down Green TaskSet to 0%..."
+    aws_ecs update-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-set "$GREEN_TASKSET" \
+        --scale "value=0,unit=PERCENT"
+    
+    log_blue "Rollback to Blue completed!"
+}
+
+# Step 9: Cleanup
+cleanup() {
+    log_warn "Cleaning up resources..."
+    
+    # Delete TaskSets
+    log_info "Deleting TaskSets..."
+    aws_ecs delete-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-set "$BLUE_TASKSET" \
+        --force || true
+    
+    aws_ecs delete-task-set \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-set "$GREEN_TASKSET" \
+        --force || true
+    
+    # Delete Service
+    log_info "Deleting service..."
+    aws_ecs delete-service \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --force || true
+    
+    log_info "Cleanup completed!"
+}
+
+# Main execution
+main() {
+    case "${1:-}" in
+        setup)
+            create_cluster
+            register_task_definitions
+            create_service
+            create_blue_taskset
+            create_green_taskset
+            show_status
+            ;;
+        deploy)
+            switch_to_green
+            show_status
+            ;;
+        rollback)
+            rollback_to_blue
+            show_status
+            ;;
+        status)
+            show_status
+            ;;
+        cleanup)
+            cleanup
+            ;;
+        *)
+            echo "Usage: $0 {setup|deploy|rollback|status|cleanup}"
+            echo ""
+            echo "Commands:"
+            echo "  setup    - Create cluster, service, and both TaskSets (Blue as PRIMARY)"
+            echo "  deploy   - Switch from Blue to Green deployment"
+            echo "  rollback - Switch back from Green to Blue"
+            echo "  status   - Show current TaskSet status"
+            echo "  cleanup  - Delete all resources"
+            echo ""
+            echo "Environment variables:"
+            echo "  AWS_ENDPOINT_URL - KECS endpoint (default: http://localhost:8080)"
+            echo "  AWS_REGION      - AWS region (default: us-east-1)"
+            echo "  CLUSTER_NAME    - ECS cluster name (default: default)"
+            exit 1
+            ;;
+    esac
+}
+
+# Run main function
+main "$@"

--- a/examples/task-set-blue-green/service_def.json
+++ b/examples/task-set-blue-green/service_def.json
@@ -1,0 +1,36 @@
+{
+  "serviceName": "webapp-service",
+  "cluster": "default",
+  "desiredCount": 3,
+  "deploymentController": {
+    "type": "EXTERNAL"
+  },
+  "schedulingStrategy": "REPLICA",
+  "placementConstraints": [],
+  "placementStrategy": [
+    {
+      "type": "spread",
+      "field": "attribute:ecs.availability-zone"
+    }
+  ],
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-12345", "subnet-67890"],
+      "securityGroups": ["sg-webapp"],
+      "assignPublicIp": "ENABLED"
+    }
+  },
+  "healthCheckGracePeriodSeconds": 60,
+  "enableECSManagedTags": true,
+  "propagateTags": "SERVICE",
+  "tags": [
+    {
+      "key": "Environment",
+      "value": "production"
+    },
+    {
+      "key": "Application",
+      "value": "webapp"
+    }
+  ]
+}

--- a/examples/task-set-blue-green/task_def_blue.json
+++ b/examples/task-set-blue-green/task_def_blue.json
@@ -1,0 +1,52 @@
+{
+  "family": "webapp",
+  "taskRoleArn": "arn:aws:iam::000000000000:role/ecsTaskRole",
+  "executionRoleArn": "arn:aws:iam::000000000000:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "webapp",
+      "image": "nginx:1.24-alpine",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {
+          "name": "VERSION",
+          "value": "blue"
+        },
+        {
+          "name": "APP_COLOR",
+          "value": "#0000FF"
+        }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost/ || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/kecs/webapp",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "blue"
+        }
+      },
+      "command": [
+        "sh",
+        "-c",
+        "echo '<html><body style=\"background-color: #0000FF;\"><h1>Blue Version</h1><p>TaskSet: Blue</p><p>Version: 1.0.0</p></body></html>' > /usr/share/nginx/html/index.html && nginx -g 'daemon off;'"
+      ]
+    }
+  ]
+}

--- a/examples/task-set-blue-green/task_def_green.json
+++ b/examples/task-set-blue-green/task_def_green.json
@@ -1,0 +1,52 @@
+{
+  "family": "webapp",
+  "taskRoleArn": "arn:aws:iam::000000000000:role/ecsTaskRole",
+  "executionRoleArn": "arn:aws:iam::000000000000:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "webapp",
+      "image": "nginx:1.25-alpine",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        {
+          "name": "VERSION",
+          "value": "green"
+        },
+        {
+          "name": "APP_COLOR",
+          "value": "#00FF00"
+        }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost/ || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/kecs/webapp",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "green"
+        }
+      },
+      "command": [
+        "sh",
+        "-c",
+        "echo '<html><body style=\"background-color: #00FF00;\"><h1>Green Version</h1><p>TaskSet: Green</p><p>Version: 2.0.0</p></body></html>' > /usr/share/nginx/html/index.html && nginx -g 'daemon off;'"
+      ]
+    }
+  ]
+}

--- a/examples/task-set-blue-green/test_taskset.sh
+++ b/examples/task-set-blue-green/test_taskset.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Test script for TaskSet API with Kubernetes integration
+
+set -e
+
+KECS_ENDPOINT="${KECS_ENDPOINT:-http://localhost:8080}"
+CLUSTER_NAME="${CLUSTER_NAME:-default}"
+SERVICE_NAME="webapp-service"
+REGION="us-east-1"
+
+echo "Testing TaskSet API with Kubernetes integration..."
+echo "KECS Endpoint: $KECS_ENDPOINT"
+echo ""
+
+# Function to call KECS API
+call_kecs() {
+    local action=$1
+    local params=$2
+    aws ecs "$action" \
+        --endpoint-url "$KECS_ENDPOINT" \
+        --region "$REGION" \
+        --no-cli-pager \
+        $params 2>&1
+}
+
+echo "1. Creating cluster..."
+aws ecs create-cluster \
+    --cluster-name "$CLUSTER_NAME" \
+    --endpoint-url "$KECS_ENDPOINT" \
+    --region "$REGION" \
+    --no-cli-pager || echo "Cluster may already exist"
+echo ""
+
+echo "2. Registering Blue task definition..."
+BLUE_TASK_DEF=$(call_kecs register-task-definition \
+    --cli-input-json file://task_def_blue.json \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text)
+echo "Blue Task Definition: $BLUE_TASK_DEF"
+echo ""
+
+echo "3. Registering Green task definition..."
+GREEN_TASK_DEF=$(call_kecs register-task-definition \
+    --cli-input-json file://task_def_green.json \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text)
+echo "Green Task Definition: $GREEN_TASK_DEF"
+echo ""
+
+echo "4. Creating service..."
+call_kecs create-service \
+    --cluster "$CLUSTER_NAME" \
+    --service-name "$SERVICE_NAME" \
+    --desired-count 2 \
+    --launch-type FARGATE \
+    --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}" || echo "Service may already exist"
+echo ""
+
+echo "5. Creating Blue TaskSet..."
+BLUE_TASKSET_RESPONSE=$(call_kecs create-task-set \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --task-definition "$BLUE_TASK_DEF" \
+    --external-id "blue-deployment" \
+    --launch-type FARGATE \
+    --scale "value=100,unit=PERCENT" \
+    --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}")
+
+BLUE_TASKSET_ID=$(echo "$BLUE_TASKSET_RESPONSE" | grep -o '"id": "[^"]*' | head -1 | cut -d'"' -f4)
+echo "Blue TaskSet ID: $BLUE_TASKSET_ID"
+echo ""
+
+echo "6. Creating Green TaskSet..."
+GREEN_TASKSET_RESPONSE=$(call_kecs create-task-set \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --task-definition "$GREEN_TASK_DEF" \
+    --external-id "green-deployment" \
+    --launch-type FARGATE \
+    --scale "value=0,unit=PERCENT" \
+    --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}")
+
+GREEN_TASKSET_ID=$(echo "$GREEN_TASKSET_RESPONSE" | grep -o '"id": "[^"]*' | head -1 | cut -d'"' -f4)
+echo "Green TaskSet ID: $GREEN_TASKSET_ID"
+echo ""
+
+echo "7. Describing TaskSets..."
+call_kecs describe-task-sets \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --query 'taskSets[*].[id,externalId,status,stabilityStatus,runningCount,pendingCount]' \
+    --output table
+echo ""
+
+echo "8. Checking Kubernetes resources..."
+echo "Deployments:"
+kubectl get deployments -n "$CLUSTER_NAME-$REGION" -l "kecs.io/service=$SERVICE_NAME" 2>/dev/null || echo "No deployments found"
+echo ""
+
+echo "Services:"
+kubectl get services -n "$CLUSTER_NAME-$REGION" -l "kecs.io/service=$SERVICE_NAME" 2>/dev/null || echo "No services found"
+echo ""
+
+echo "9. Updating Green TaskSet to 50%..."
+call_kecs update-task-set \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --task-set "$GREEN_TASKSET_ID" \
+    --scale "value=50,unit=PERCENT"
+echo ""
+
+sleep 2
+
+echo "10. Checking TaskSet status after update..."
+call_kecs describe-task-sets \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --task-sets "$GREEN_TASKSET_ID" \
+    --query 'taskSets[0].[id,externalId,scale.value,stabilityStatus,runningCount,pendingCount]' \
+    --output json
+echo ""
+
+echo "11. Deleting Green TaskSet..."
+call_kecs delete-task-set \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --task-set "$GREEN_TASKSET_ID"
+echo ""
+
+echo "12. Deleting Blue TaskSet..."
+call_kecs delete-task-set \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --task-set "$BLUE_TASKSET_ID"
+echo ""
+
+echo "13. Deleting service..."
+call_kecs delete-service \
+    --cluster "$CLUSTER_NAME" \
+    --service "$SERVICE_NAME" \
+    --force || echo "Service deletion may have failed"
+echo ""
+
+echo "Test completed!"


### PR DESCRIPTION
## Summary
- Implement TaskSet to Kubernetes Deployment mapping for Blue/Green deployments
- Add EXTERNAL deployment controller support for services
- Fix TaskDefinition retrieval to support multiple identifier formats

## Changes

### TaskSet Kubernetes Integration
- Implement CreateTaskSet, UpdateTaskSet, DeleteTaskSet, and DescribeTaskSets API operations
- Add TaskSetManager for managing TaskSet Kubernetes resources (Deployments)
- Calculate `computedDesiredCount` based on service desiredCount and scale percentage
- Support both PERCENT and COUNT scale units for TaskSets

### EXTERNAL Deployment Controller Support  
- Add support for EXTERNAL deployment controller type in CreateService
- Services with EXTERNAL type don't create Kubernetes resources directly
- TaskSets manage the actual workload deployment for EXTERNAL services
- Add `deployment_controller` field to service storage schema

### TaskDefinition Retrieval Improvements
- Fix TaskDefinition retrieval to support multiple formats:
  - ARN format: `arn:aws:ecs:region:account:task-definition/family:revision`
  - Family:revision format: `webapp:1`
  - Family only format: `webapp` (gets latest revision)

### Storage Schema Updates
- Add `deployment_controller` column to DuckDB services table
- Update all service CRUD operations to handle the new field

## Test Plan
- [x] Unit tests pass for TaskSet API operations
- [x] Unit tests pass for TaskSet converter
- [x] Manual testing of Blue/Green deployment example
- [x] Verify computedDesiredCount calculation
- [ ] E2E test with EXTERNAL service and TaskSets (pending due to reflection issue)

## Known Issues
- EXTERNAL service creation validation needs investigation - current workaround uses standard service with TaskSets

🤖 Generated with Claude Code