### PR TITLE
feat: Implement Resource Cleanup Worker for automatic stale resource removal (#489)

### DIFF
--- a/controlplane/internal/controllers/sync/mappers/task_mapper.go
+++ b/controlplane/internal/controllers/sync/mappers/task_mapper.go
@@ -31,6 +31,9 @@ func NewTaskStateMapper(accountID, region string) *TaskStateMapper {
 func (m *TaskStateMapper) MapPodPhaseToTaskStatus(pod *corev1.Pod) (desiredStatus, lastStatus string) {
 	// Check if pod is being deleted
 	if pod.DeletionTimestamp != nil {
+		// When pod is being terminated, lastStatus should be DEPROVISIONING
+		// and desiredStatus should be STOPPED
+		// Note: The actual transition to STOPPED happens when the pod is fully deleted
 		return "STOPPED", "DEPROVISIONING"
 	}
 

--- a/controlplane/internal/controlplane/api/resource_cleanup_worker.go
+++ b/controlplane/internal/controlplane/api/resource_cleanup_worker.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+// ResourceCleanupWorker manages cleanup of stale resources
+type ResourceCleanupWorker struct {
+	storage storage.Storage
+	ticker  *time.Ticker
+	done    chan struct{}
+
+	// Configuration
+	enabled           bool
+	interval          time.Duration
+	taskRetention     time.Duration
+	serviceRetention  time.Duration
+	instanceRetention time.Duration
+	taskSetRetention  time.Duration
+	logRetention      time.Duration
+}
+
+// NewResourceCleanupWorker creates a new resource cleanup worker
+func NewResourceCleanupWorker(storage storage.Storage) *ResourceCleanupWorker {
+	return &ResourceCleanupWorker{
+		storage:           storage,
+		done:              make(chan struct{}),
+		enabled:           config.GetBool("cleanup.enabled"),
+		interval:          config.GetDuration("cleanup.interval", 5*time.Minute),
+		taskRetention:     config.GetDuration("cleanup.task.retention", 1*time.Hour),
+		serviceRetention:  config.GetDuration("cleanup.service.retention", 24*time.Hour),
+		instanceRetention: config.GetDuration("cleanup.containerInstance.retention", 1*time.Hour),
+		taskSetRetention:  config.GetDuration("cleanup.taskSet.retention", 24*time.Hour),
+		logRetention:      config.GetDuration("cleanup.log.retention", 7*24*time.Hour),
+	}
+}
+
+// Start begins the background resource cleanup
+func (w *ResourceCleanupWorker) Start(ctx context.Context) {
+	if !w.enabled {
+		logging.Info("Resource cleanup worker: Disabled by configuration")
+		return
+	}
+
+	w.ticker = time.NewTicker(w.interval)
+
+	go func() {
+		logging.Info("Resource cleanup worker: Started successfully",
+			"interval", w.interval,
+			"taskRetention", w.taskRetention,
+			"serviceRetention", w.serviceRetention,
+			"instanceRetention", w.instanceRetention,
+			"taskSetRetention", w.taskSetRetention,
+			"logRetention", w.logRetention,
+		)
+
+		// Run initial cleanup
+		w.cleanupResources(ctx)
+
+		for {
+			select {
+			case <-ctx.Done():
+				logging.Info("Resource cleanup worker: Stopping due to context cancellation")
+				return
+			case <-w.done:
+				logging.Info("Resource cleanup worker: Stopping")
+				return
+			case <-w.ticker.C:
+				w.cleanupResources(ctx)
+			}
+		}
+	}()
+}
+
+// Stop halts the background resource cleanup
+func (w *ResourceCleanupWorker) Stop() {
+	if w.ticker != nil {
+		w.ticker.Stop()
+	}
+	close(w.done)
+}
+
+// cleanupResources orchestrates cleanup of all resource types
+func (w *ResourceCleanupWorker) cleanupResources(ctx context.Context) {
+	logging.Debug("Resource cleanup worker: Starting cleanup cycle")
+
+	totalDeleted := 0
+
+	// Cleanup stopped tasks
+	if count := w.cleanupStoppedTasks(ctx); count > 0 {
+		totalDeleted += count
+		logging.Info("Resource cleanup worker: Deleted stopped tasks", "count", count)
+	}
+
+	// Cleanup deleted services
+	if count := w.cleanupDeletedServices(ctx); count > 0 {
+		totalDeleted += count
+		logging.Info("Resource cleanup worker: Deleted services", "count", count)
+	}
+
+	// Cleanup stale container instances
+	if count := w.cleanupStaleContainerInstances(ctx); count > 0 {
+		totalDeleted += count
+		logging.Info("Resource cleanup worker: Deleted container instances", "count", count)
+	}
+
+	// Cleanup orphaned task sets
+	if count := w.cleanupOrphanedTaskSets(ctx); count > 0 {
+		totalDeleted += count
+		logging.Info("Resource cleanup worker: Deleted task sets", "count", count)
+	}
+
+	// Cleanup old task logs
+	if count := w.cleanupOldTaskLogs(ctx); count > 0 {
+		totalDeleted += count
+		logging.Info("Resource cleanup worker: Deleted old logs", "count", count)
+	}
+
+	if totalDeleted > 0 {
+		logging.Info("Resource cleanup worker: Cleanup cycle completed", "totalDeleted", totalDeleted)
+	} else {
+		logging.Debug("Resource cleanup worker: Cleanup cycle completed, nothing to clean")
+	}
+}
+
+// cleanupStoppedTasks removes tasks that have been stopped for longer than retention period
+func (w *ResourceCleanupWorker) cleanupStoppedTasks(ctx context.Context) int {
+	cutoff := time.Now().Add(-w.taskRetention)
+
+	// Get all clusters
+	clusters, err := w.storage.ClusterStore().List(ctx)
+	if err != nil {
+		logging.Error("Resource cleanup worker: Failed to list clusters", "error", err)
+		return 0
+	}
+
+	totalDeleted := 0
+	for _, cluster := range clusters {
+		// Clean up STOPPED tasks
+		count, err := w.storage.TaskStore().DeleteOlderThan(ctx, cluster.ARN, cutoff, "STOPPED")
+		if err != nil {
+			logging.Error("Resource cleanup worker: Failed to delete stopped tasks",
+				"cluster", cluster.Name, "error", err)
+			continue
+		}
+		totalDeleted += count
+
+		// Also clean up DEPROVISIONING tasks that are stuck
+		// This handles cases where pod deletion events were not properly processed
+		count, err = w.storage.TaskStore().DeleteOlderThan(ctx, cluster.ARN, cutoff, "DEPROVISIONING")
+		if err != nil {
+			logging.Error("Resource cleanup worker: Failed to delete deprovisioning tasks",
+				"cluster", cluster.Name, "error", err)
+			continue
+		}
+		totalDeleted += count
+	}
+
+	return totalDeleted
+}
+
+// cleanupDeletedServices removes services marked for deletion
+func (w *ResourceCleanupWorker) cleanupDeletedServices(ctx context.Context) int {
+	cutoff := time.Now().Add(-w.serviceRetention)
+
+	// Get all clusters
+	clusters, err := w.storage.ClusterStore().List(ctx)
+	if err != nil {
+		logging.Error("Resource cleanup worker: Failed to list clusters", "error", err)
+		return 0
+	}
+
+	totalDeleted := 0
+	for _, cluster := range clusters {
+		count, err := w.storage.ServiceStore().DeleteMarkedForDeletion(ctx, cluster.ARN, cutoff)
+		if err != nil {
+			logging.Error("Resource cleanup worker: Failed to delete services",
+				"cluster", cluster.Name, "error", err)
+			continue
+		}
+		totalDeleted += count
+	}
+
+	return totalDeleted
+}
+
+// cleanupStaleContainerInstances removes container instances that are no longer active
+func (w *ResourceCleanupWorker) cleanupStaleContainerInstances(ctx context.Context) int {
+	cutoff := time.Now().Add(-w.instanceRetention)
+
+	// Get all clusters
+	clusters, err := w.storage.ClusterStore().List(ctx)
+	if err != nil {
+		logging.Error("Resource cleanup worker: Failed to list clusters", "error", err)
+		return 0
+	}
+
+	totalDeleted := 0
+	for _, cluster := range clusters {
+		count, err := w.storage.ContainerInstanceStore().DeleteStale(ctx, cluster.ARN, cutoff)
+		if err != nil {
+			logging.Error("Resource cleanup worker: Failed to delete container instances",
+				"cluster", cluster.Name, "error", err)
+			continue
+		}
+		totalDeleted += count
+	}
+
+	return totalDeleted
+}
+
+// cleanupOrphanedTaskSets removes task sets without associated services
+func (w *ResourceCleanupWorker) cleanupOrphanedTaskSets(ctx context.Context) int {
+	// Get all clusters
+	clusters, err := w.storage.ClusterStore().List(ctx)
+	if err != nil {
+		logging.Error("Resource cleanup worker: Failed to list clusters", "error", err)
+		return 0
+	}
+
+	totalDeleted := 0
+	for _, cluster := range clusters {
+		count, err := w.storage.TaskSetStore().DeleteOrphaned(ctx, cluster.ARN)
+		if err != nil {
+			logging.Error("Resource cleanup worker: Failed to delete orphaned task sets",
+				"cluster", cluster.Name, "error", err)
+			continue
+		}
+		totalDeleted += count
+	}
+
+	return totalDeleted
+}
+
+// cleanupOldTaskLogs removes log entries older than retention period
+func (w *ResourceCleanupWorker) cleanupOldTaskLogs(ctx context.Context) int {
+	// TODO: Implement when TaskLogStore is available
+	// For now, return 0 as this store doesn't exist yet
+	return 0
+}

--- a/controlplane/internal/storage/cache/cached_storage.go
+++ b/controlplane/internal/storage/cache/cached_storage.go
@@ -535,3 +535,19 @@ type paginatedClustersResult struct {
 	Clusters  []*storage.Cluster
 	NextToken string
 }
+
+// DeleteOlderThan deletes tasks older than the specified time with the given status
+func (s *cachedTaskStore) DeleteOlderThan(ctx context.Context, clusterARN string, before time.Time, status string) (int, error) {
+	// Clear cache for the cluster
+	s.cache.Delete(ctx, clusterARN)
+	// Pass through to underlying store
+	return s.backend.DeleteOlderThan(ctx, clusterARN, before, status)
+}
+
+// DeleteMarkedForDeletion deletes services marked for deletion before the specified time
+func (s *cachedServiceStore) DeleteMarkedForDeletion(ctx context.Context, clusterARN string, before time.Time) (int, error) {
+	// Clear cache for the cluster
+	s.cache.Delete(ctx, clusterARN)
+	// Pass through to underlying store
+	return s.backend.DeleteMarkedForDeletion(ctx, clusterARN, before)
+}

--- a/controlplane/internal/storage/interfaces.go
+++ b/controlplane/internal/storage/interfaces.go
@@ -258,6 +258,9 @@ type ServiceStore interface {
 
 	// Get service by ARN
 	GetByARN(ctx context.Context, arn string) (*Service, error)
+
+	// DeleteMarkedForDeletion deletes services marked for deletion before the specified time
+	DeleteMarkedForDeletion(ctx context.Context, clusterARN string, before time.Time) (int, error)
 }
 
 // Service represents an ECS service in storage
@@ -383,6 +386,9 @@ type TaskStore interface {
 
 	// CreateOrUpdate creates a new task or updates if it already exists
 	CreateOrUpdate(ctx context.Context, task *Task) error
+
+	// DeleteOlderThan deletes tasks older than the specified time with the given status
+	DeleteOlderThan(ctx context.Context, clusterARN string, before time.Time, status string) (int, error)
 }
 
 // TaskFilters defines filters for listing tasks
@@ -627,6 +633,9 @@ type TaskSetStore interface {
 
 	// Update primary task set
 	UpdatePrimary(ctx context.Context, serviceARN, taskSetID string) error
+
+	// DeleteOrphaned deletes task sets that no longer have an associated service
+	DeleteOrphaned(ctx context.Context, clusterARN string) (int, error)
 }
 
 // TaskSet represents an ECS task set in storage
@@ -730,6 +739,9 @@ type ContainerInstanceStore interface {
 
 	// Get container instances by ARNs
 	GetByARNs(ctx context.Context, arns []string) ([]*ContainerInstance, error)
+
+	// DeleteStale deletes container instances that have been inactive before the specified time
+	DeleteStale(ctx context.Context, clusterARN string, before time.Time) (int, error)
 }
 
 // ContainerInstance represents an ECS container instance in storage

--- a/docs/adr/records/0024-resource-cleanup-worker.md
+++ b/docs/adr/records/0024-resource-cleanup-worker.md
@@ -1,0 +1,116 @@
+# ADR-0024: Resource Cleanup Worker
+
+Date: 2025-08-23
+
+## Status
+
+Proposed
+
+## Context
+
+KECS creates various ECS resources during normal operation, but some resources are not automatically cleaned up when they are no longer needed. This leads to accumulation of stale resources over time, particularly:
+
+1. **Stopped Tasks**: Tasks that have been stopped but remain in the database indefinitely
+2. **Deleted Services**: Service records that persist after the service has been deleted
+3. **Stale Container Instances**: Container instances from nodes that no longer exist
+4. **Orphaned TaskSets**: TaskSets without associated services
+5. **Task Logs**: Log entries that grow unbounded over time
+
+This issue was reported in #489, where old tasks were found to remain in the system indefinitely. A systematic approach to resource cleanup is needed to maintain system health and prevent unbounded resource growth.
+
+## Decision
+
+We will implement a Resource Cleanup Worker that periodically scans and removes stale resources based on configurable retention policies. The worker will:
+
+1. **Run periodically** (default: every 5 minutes) in a background goroutine
+2. **Handle multiple resource types** with type-specific cleanup logic
+3. **Use configurable retention periods** for each resource type
+4. **Provide safe cleanup** that respects resource dependencies
+5. **Log cleanup operations** for observability
+
+### Architecture
+
+```
+ResourceCleanupWorker
+├── Start(ctx) - Starts the background worker
+├── Stop() - Stops the worker gracefully
+├── cleanupResources() - Main cleanup orchestrator
+│   ├── cleanupStoppedTasks()
+│   ├── cleanupDeletedServices()
+│   ├── cleanupStaleContainerInstances()
+│   ├── cleanupOrphanedTaskSets()
+│   └── cleanupOldTaskLogs()
+└── Configuration
+    ├── Enabled (bool)
+    ├── Interval (duration)
+    └── RetentionPeriods (map[ResourceType]duration)
+```
+
+### Default Retention Periods
+
+- **Stopped Tasks**: 1 hour (configurable via `KECS_CLEANUP_TASK_RETENTION`)
+- **Deleted Services**: 24 hours (configurable via `KECS_CLEANUP_SERVICE_RETENTION`)
+- **Stale Container Instances**: 1 hour (configurable via `KECS_CLEANUP_CONTAINER_INSTANCE_RETENTION`)
+- **Orphaned TaskSets**: 24 hours (configurable via `KECS_CLEANUP_TASKSET_RETENTION`)
+- **Task Logs**: 7 days (configurable via `KECS_CLEANUP_LOG_RETENTION`)
+
+### Storage Interface Extensions
+
+New methods will be added to the storage interfaces:
+
+```go
+// TaskStore interface
+DeleteOlderThan(ctx context.Context, before time.Time, status string) (int, error)
+
+// ServiceStore interface
+DeleteMarkedForDeletion(ctx context.Context, before time.Time) (int, error)
+
+// ContainerInstanceStore interface
+DeleteStale(ctx context.Context, before time.Time) (int, error)
+
+// TaskSetStore interface
+DeleteOrphaned(ctx context.Context) (int, error)
+
+// TaskLogStore interface (new)
+DeleteOlderThan(ctx context.Context, before time.Time) (int, error)
+```
+
+## Consequences
+
+### Positive
+
+1. **Automatic cleanup** prevents unbounded resource growth
+2. **Configurable retention** allows different policies for different environments
+3. **Improved performance** by reducing database size
+4. **Better observability** through cleanup logging
+5. **Extensible design** allows adding new resource types easily
+
+### Negative
+
+1. **Additional background processing** adds some CPU/memory overhead
+2. **Risk of premature deletion** if retention periods are too short
+3. **Complexity** in handling resource dependencies correctly
+4. **Testing complexity** for time-based cleanup logic
+
+### Mitigation Strategies
+
+1. **Conservative defaults**: Use longer retention periods by default
+2. **Dry-run mode**: Add option to log what would be deleted without actually deleting
+3. **Metrics**: Export cleanup metrics for monitoring
+4. **Feature flag**: Allow disabling cleanup worker entirely if needed
+
+## Implementation Plan
+
+1. Create `resource_cleanup_worker.go` with worker structure
+2. Add cleanup methods to storage interfaces
+3. Implement DuckDB store methods for each cleanup operation
+4. Add configuration loading from environment variables
+5. Integrate worker into control plane startup
+6. Add tests for cleanup logic
+7. Document configuration options
+
+## References
+
+- Issue #489: Old tasks remain in the system
+- Similar pattern: `test_mode_task_worker.go` for worker implementation reference
+- AWS ECS cleanup behavior documentation


### PR DESCRIPTION
## Summary
- Implements a Resource Cleanup Worker that periodically removes stale resources from the system
- Addresses issue #489 where old tasks remain in the system indefinitely
- Adds configurable retention periods for different resource types

## Implementation Details

### Resource Cleanup Worker
- Runs periodically (default: every 5 minutes) in a background goroutine
- Cleans up multiple resource types: Tasks, Services, Container Instances, TaskSets
- Uses configurable retention periods via environment variables
- Integrates with control plane lifecycle (startup/shutdown)

### Default Retention Periods
- **Stopped Tasks**: 1 hour (`KECS_CLEANUP_TASK_RETENTION`)
- **Deleted Services**: 24 hours (`KECS_CLEANUP_SERVICE_RETENTION`)  
- **Stale Container Instances**: 1 hour (`KECS_CLEANUP_CONTAINER_INSTANCE_RETENTION`)
- **Orphaned TaskSets**: 24 hours (`KECS_CLEANUP_TASKSET_RETENTION`)

### Storage Layer Changes
Added cleanup methods to storage interfaces:
- `TaskStore.DeleteOlderThan()` - Removes stopped tasks older than specified time
- `ServiceStore.DeleteMarkedForDeletion()` - Removes services marked for deletion
- `ContainerInstanceStore.DeleteStale()` - Removes inactive container instances
- `TaskSetStore.DeleteOrphaned()` - Removes task sets without associated services

### Configuration
All settings configurable via environment variables:
- `KECS_CLEANUP_ENABLED` - Enable/disable cleanup worker (default: true)
- `KECS_CLEANUP_INTERVAL` - Cleanup interval (default: 5m)
- Individual retention periods for each resource type

## Test Plan
- [x] Unit tests pass for all storage implementations
- [x] Mock implementations updated with cleanup methods
- [x] Pre-commit hooks pass (formatting, linting, tests)
- [ ] Manual testing with running KECS instance
- [ ] Verify cleanup actually removes stale resources
- [ ] Confirm retention periods work as expected

## Related
- Fixes #489
- ADR-0024 documents this design decision

🤖 Generated with [Claude Code](https://claude.ai/code)