### PR TITLE
feat: Add centralized version management with build-time injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,20 @@ GOIMPORTS=goimports
 GOLANGCI_LINT=golangci-lint
 DOCKER=docker
 DOCKER_IMAGE=ghcr.io/nandemo-ya/kecs
-VERSION=$(shell git describe --tags --always --dirty)
-LDFLAGS=-ldflags "-X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version=$(VERSION)"
+
+# Version information
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+GO_VERSION := $(shell go version | cut -d' ' -f3)
+
+# Build flags
+LDFLAGS := -ldflags "\
+  -X github.com/nandemo-ya/kecs/controlplane/internal/version.Version=$(VERSION) \
+  -X github.com/nandemo-ya/kecs/controlplane/internal/version.GitCommit=$(GIT_COMMIT) \
+  -X github.com/nandemo-ya/kecs/controlplane/internal/version.BuildDate=$(BUILD_DATE) \
+  -X github.com/nandemo-ya/kecs/controlplane/internal/version.GoVersion=$(GO_VERSION)"
+
 GOTEST=$(GO) test
 GOVET=$(GO) vet
 PLATFORMS=linux/amd64 linux/arm64

--- a/controlplane/internal/controlplane/cmd/version.go
+++ b/controlplane/internal/controlplane/cmd/version.go
@@ -1,16 +1,16 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/version"
 )
 
-// Version information
 var (
-	Version   = "0.1.0"
-	GitCommit = "unknown"
-	BuildDate = "unknown"
+	jsonOutput bool
 
 	// versionCmd represents the version command
 	versionCmd = &cobra.Command{
@@ -18,10 +18,22 @@ var (
 		Short: "Print the version information",
 		Long:  `Print the version, git commit, and build date of the KECS Control Plane.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("KECS Control Plane\n")
-			fmt.Printf("Version:    %s\n", Version)
-			fmt.Printf("Git commit: %s\n", GitCommit)
-			fmt.Printf("Built:      %s\n", BuildDate)
+			info := version.GetInfo()
+
+			if jsonOutput {
+				output, _ := json.MarshalIndent(info, "", "  ")
+				fmt.Println(string(output))
+			} else {
+				fmt.Printf("KECS Control Plane\n")
+				fmt.Printf("Version:    %s\n", info.Version)
+				fmt.Printf("Git commit: %s\n", info.GitCommit)
+				fmt.Printf("Built:      %s\n", info.BuildDate)
+				fmt.Printf("Go version: %s\n", info.GoVersion)
+			}
 		},
 	}
 )
+
+func init() {
+	versionCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output version information in JSON format")
+}

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/version"
 )
 
 var (
@@ -169,9 +171,9 @@ func (m Model) renderHeader() string {
 	maxContentWidth := leftColumnWidth - 2 // Account for header padding
 
 	// Build the header content
-	headerText := "KECS v0.0.1-alpha"
+	headerText := fmt.Sprintf("KECS %s", version.GetVersion())
 	if m.selectedInstance != "" {
-		headerText = fmt.Sprintf("KECS v0.0.1-alpha | Instance: %s", m.selectedInstance)
+		headerText = fmt.Sprintf("KECS %s | Instance: %s", version.GetVersion(), m.selectedInstance)
 	}
 
 	// Check if we need to truncate
@@ -179,7 +181,7 @@ func (m Model) renderHeader() string {
 		if m.selectedInstance != "" {
 			// Shorten instance name
 			instanceName := m.selectedInstance
-			prefix := "KECS v0.0.1-alpha | "
+			prefix := fmt.Sprintf("KECS %s | ", version.GetVersion())
 			maxInstanceWidth := maxContentWidth - len(prefix) - 3 // -3 for "..."
 			if maxInstanceWidth > 0 && len(instanceName) > maxInstanceWidth {
 				instanceName = instanceName[:maxInstanceWidth] + "..."

--- a/controlplane/internal/version/version.go
+++ b/controlplane/internal/version/version.go
@@ -1,0 +1,52 @@
+// Package version provides version information for KECS
+package version
+
+// These variables are set via ldflags during build time
+var (
+	// Version is the semantic version of KECS
+	Version = "dev"
+
+	// GitCommit is the git commit SHA
+	GitCommit = "unknown"
+
+	// BuildDate is the date when the binary was built
+	BuildDate = "unknown"
+
+	// GoVersion is the Go version used to build
+	GoVersion = "unknown"
+)
+
+// GetVersion returns the version string
+func GetVersion() string {
+	if Version == "" {
+		return "dev"
+	}
+	return Version
+}
+
+// GetFullVersion returns the full version information
+func GetFullVersion() string {
+	v := GetVersion()
+	if GitCommit != "unknown" && GitCommit != "" {
+		v += "-" + GitCommit
+	}
+	return v
+}
+
+// Info contains all version information
+type Info struct {
+	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
+// GetInfo returns all version information
+func GetInfo() Info {
+	return Info{
+		Version:   Version,
+		GitCommit: GitCommit,
+		BuildDate: BuildDate,
+		GoVersion: GoVersion,
+	}
+}


### PR DESCRIPTION
## Summary
- Implement centralized version management system with build-time variable injection
- Create version package to provide consistent version information across the application
- Enable dynamic version display based on git tags and build metadata

## Changes
### Version Package
- Created `internal/version/version.go` with version variables and helper functions
- Variables injected at build time: Version, GitCommit, BuildDate, GoVersion
- Added `GetVersion()`, `GetFullVersion()`, and `GetInfo()` helper functions

### Build System
- Updated Makefile to inject version information via ldflags
- Version automatically derived from git tags using `git describe --tags`
- Captures git commit SHA, build date, and Go version
- All build targets now include version injection

### Version Display Updates
- TUI header now displays actual version from version package
- Version command enhanced with structured output and JSON format option
- Removed hardcoded version strings throughout the codebase

## Testing
- Built binary with `make build`
- Verified version injection: `./bin/kecs version` shows proper version info
- Tested JSON output: `./bin/kecs version --json`
- Confirmed TUI displays correct version in header

## Benefits
- Single source of truth for version information
- Automatic version detection from git tags
- Build metadata included for debugging
- Consistent version display across all components

🤖 Generated with [Claude Code](https://claude.ai/code)