### PR TITLE
feat: Update health command to support multiple instances

### DIFF
--- a/controlplane/internal/controlplane/cmd/health.go
+++ b/controlplane/internal/controlplane/cmd/health.go
@@ -1,72 +1,147 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/instance"
 )
 
 var (
-	healthURL      string
+	healthInstance string
 	healthTimeout  time.Duration
 	healthDetailed bool
 )
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
-	Short: "Check the health of KECS control plane",
-	Long:  `Check the health status of the KECS control plane by querying the admin health endpoint.`,
+	Short: "Check the health of KECS instances",
+	Long:  `Check the health status of all KECS instances or a specific instance.`,
 	RunE:  runHealth,
 }
 
 func init() {
 	RootCmd.AddCommand(healthCmd)
 
-	healthCmd.Flags().StringVar(&healthURL, "url", "http://localhost:8081", "Admin server URL")
+	healthCmd.Flags().StringVar(&healthInstance, "instance", "", "Check health of specific instance (default: all instances)")
 	healthCmd.Flags().DurationVar(&healthTimeout, "timeout", 5*time.Second, "Request timeout")
 	healthCmd.Flags().BoolVar(&healthDetailed, "detailed", false, "Show detailed health information")
 }
 
 func runHealth(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	// Create instance manager
+	manager, err := instance.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to create instance manager: %w", err)
+	}
+
+	// Get list of instances
+	instances, err := manager.List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list instances: %w", err)
+	}
+
+	// Filter by instance name if specified
+	if healthInstance != "" {
+		var filtered []instance.InstanceInfo
+		for _, inst := range instances {
+			if inst.Name == healthInstance {
+				filtered = append(filtered, inst)
+				break
+			}
+		}
+		if len(filtered) == 0 {
+			return fmt.Errorf("instance %q not found", healthInstance)
+		}
+		instances = filtered
+	}
+
+	if len(instances) == 0 {
+		fmt.Println("No KECS instances found")
+		return nil
+	}
+
+	// Check health of each instance
+	type instanceHealth struct {
+		Name      string                 `json:"name"`
+		Status    string                 `json:"status"`
+		ApiPort   int                    `json:"api_port"`
+		AdminPort int                    `json:"admin_port"`
+		Health    map[string]interface{} `json:"health,omitempty"`
+		Error     string                 `json:"error,omitempty"`
+	}
+
+	var results []instanceHealth
+
 	client := &http.Client{
 		Timeout: healthTimeout,
 	}
 
-	// Choose endpoint based on detailed flag
-	endpoint := "/health"
-	if healthDetailed {
-		endpoint = "/health/detailed"
+	for _, inst := range instances {
+		result := instanceHealth{
+			Name:      inst.Name,
+			Status:    strings.ToLower(inst.Status),
+			ApiPort:   inst.ApiPort,
+			AdminPort: inst.AdminPort,
+		}
+
+		// Only check health for running instances
+		if strings.ToLower(inst.Status) == "running" {
+			// Choose endpoint based on detailed flag
+			endpoint := "/health"
+			if healthDetailed {
+				endpoint = "/health/detailed"
+			}
+
+			// Build health check URL for this instance
+			instanceURL := fmt.Sprintf("http://localhost:%d%s", inst.AdminPort, endpoint)
+
+			resp, err := client.Get(instanceURL)
+			if err != nil {
+				result.Error = fmt.Sprintf("Failed to connect: %v", err)
+			} else {
+				defer resp.Body.Close()
+
+				// Parse response
+				var healthData map[string]interface{}
+				if err := json.NewDecoder(resp.Body).Decode(&healthData); err != nil {
+					result.Error = fmt.Sprintf("Failed to parse response: %v", err)
+				} else {
+					result.Health = healthData
+				}
+			}
+		}
+
+		results = append(results, result)
 	}
 
-	resp, err := client.Get(healthURL + endpoint)
+	// Pretty print the results
+	output, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to connect to admin server: %v\n", err)
-		os.Exit(1)
-	}
-	defer resp.Body.Close()
-
-	// Parse response
-	var result map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse response: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Pretty print the result
-	output, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to format response: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to format response: %w", err)
 	}
 
 	fmt.Println(string(output))
 
-	// Exit with appropriate code
-	if resp.StatusCode != http.StatusOK {
+	// Check if any instance is unhealthy
+	hasUnhealthy := false
+	for _, result := range results {
+		if result.Error != "" || (result.Health != nil && result.Health["status"] != "ok") {
+			hasUnhealthy = true
+			break
+		}
+	}
+
+	if hasUnhealthy {
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
Updated the `kecs health` command to support multiple KECS instances, aligning it with the multi-instance architecture.

## Changes
- **Multi-instance support**: Health command now checks all running KECS instances by default
- **Instance filtering**: Added `--instance` flag to check a specific instance
- **Enhanced response format**: Shows instance details including name, status, API/Admin ports
- **Smart health checking**: Only queries health endpoint for running instances

## Benefits
- Better visibility into the health of all KECS deployments
- Consistent with other multi-instance commands (`kecs list`, `kecs stop`, etc.)
- More informative output with instance metadata

## Usage Examples
```bash
# Check health of all instances
kecs health

# Check health of specific instance
kecs health --instance my-instance

# Show detailed health information
kecs health --detailed
```

## Response Format
```json
[
  {
    "name": "instance-name",
    "status": "running",
    "api_port": 8080,
    "admin_port": 8081,
    "health": {
      "status": "ok"
    }
  },
  {
    "name": "stopped-instance",
    "status": "stopped",
    "api_port": 8090,
    "admin_port": 8091
  }
]
```

## Test plan
- [x] Build and run the command
- [x] Test with running instance - health check works
- [x] Test with stopped instance - shows status without health check
- [x] Test with specific instance flag - filters correctly
- [x] Test with non-existent instance - shows error
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)