### PR TITLE
feat: Remove DevMode flag from entire codebase

### DIFF
--- a/controlplane/cmd/tui-test/mock.go
+++ b/controlplane/cmd/tui-test/mock.go
@@ -55,7 +55,6 @@ func testMockClientBasic() {
 		AdminPort:  8091,
 		LocalStack: true,
 		Traefik:    false,
-		DevMode:    false,
 	})
 	if err != nil {
 		log.Printf("Error creating instance: %v", err)

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -47,7 +47,6 @@ type FeaturesConfig struct {
 	TestMode         bool `yaml:"testMode" mapstructure:"testMode"`
 	ContainerMode    bool `yaml:"containerMode" mapstructure:"containerMode"`
 	AutoRecoverState bool `yaml:"autoRecoverState" mapstructure:"autoRecoverState"`
-	DevMode          bool `yaml:"devMode" mapstructure:"devMode"`
 	IAMIntegration   bool `yaml:"iamIntegration" mapstructure:"iamIntegration"`
 	TUIMock          bool `yaml:"tuiMock" mapstructure:"tuiMock"`
 }
@@ -161,7 +160,6 @@ func bindLegacyEnvVars() {
 	v.BindEnv("kubernetes.keepClustersOnShutdown", "KECS_KEEP_CLUSTERS_ON_SHUTDOWN")
 	v.BindEnv("features.autoRecoverState", "KECS_AUTO_RECOVER_STATE")
 	v.BindEnv("aws.proxyImage", "KECS_AWS_PROXY_IMAGE")
-	v.BindEnv("features.devMode", "KECS_DEV_MODE")
 	v.BindEnv("features.iamIntegration", "KECS_IAM_INTEGRATION")
 	v.BindEnv("localstack.enabled", "KECS_LOCALSTACK_ENABLED")
 	v.BindEnv("localstack.useTraefik", "KECS_LOCALSTACK_USE_TRAEFIK")

--- a/controlplane/internal/controlplane/admin/instance_api.go
+++ b/controlplane/internal/controlplane/admin/instance_api.go
@@ -66,7 +66,6 @@ type Instance struct {
 	AdminPort  int       `json:"adminPort"`
 	LocalStack bool      `json:"localStack"`
 	Traefik    bool      `json:"traefik"`
-	DevMode    bool      `json:"devMode"`
 	CreatedAt  time.Time `json:"createdAt"`
 }
 
@@ -77,7 +76,6 @@ type CreateInstanceRequest struct {
 	AdminPort  int    `json:"adminPort"`
 	LocalStack bool   `json:"localStack"`
 	Traefik    bool   `json:"traefik"`
-	DevMode    bool   `json:"devMode"`
 }
 
 // ErrorResponse represents an API error response
@@ -135,7 +133,6 @@ func (api *InstanceAPI) handleListInstances(w http.ResponseWriter, r *http.Reque
 			AdminPort  int       `yaml:"adminPort"`
 			LocalStack bool      `yaml:"localStack"`
 			Traefik    bool      `yaml:"traefik"`
-			DevMode    bool      `yaml:"devMode"`
 		}
 		if err := yaml.Unmarshal(configData, &config); err != nil {
 			logging.Error("Failed to parse instance config", "instance", entry.Name(), "error", err)
@@ -155,7 +152,6 @@ func (api *InstanceAPI) handleListInstances(w http.ResponseWriter, r *http.Reque
 			AdminPort:  config.AdminPort,
 			LocalStack: config.LocalStack,
 			Traefik:    config.Traefik,
-			DevMode:    config.DevMode,
 			CreatedAt:  config.CreatedAt,
 		})
 	}

--- a/controlplane/internal/controlplane/cmd/list.go
+++ b/controlplane/internal/controlplane/cmd/list.go
@@ -44,16 +44,12 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	// Display instances in a table format
 	fmt.Println("KECS Instances:")
-	fmt.Println("===============================================================================")
-	fmt.Printf("%-20s %-10s %-10s %-10s %-8s %-10s %-8s\n", "NAME", "STATUS", "API PORT", "ADMIN PORT", "DEV MODE", "LOCALSTACK", "TRAEFIK")
-	fmt.Println("-------------------------------------------------------------------------------")
+	fmt.Println("==================================================================")
+	fmt.Printf("%-20s %-10s %-10s %-10s %-10s %-8s\n", "NAME", "STATUS", "API PORT", "ADMIN PORT", "LOCALSTACK", "TRAEFIK")
+	fmt.Println("------------------------------------------------------------------")
 
 	for _, inst := range instances {
 		status := strings.ToLower(inst.Status)
-		devMode := "no"
-		if inst.DevMode {
-			devMode = "yes"
-		}
 		localStack := "no"
 		if inst.LocalStack {
 			localStack = "yes"
@@ -63,17 +59,16 @@ func runList(cmd *cobra.Command, args []string) error {
 			traefik = "yes"
 		}
 
-		fmt.Printf("%-20s %-10s %-10d %-10d %-8s %-10s %-8s\n",
+		fmt.Printf("%-20s %-10s %-10d %-10d %-10s %-8s\n",
 			inst.Name,
 			status,
 			inst.ApiPort,
 			inst.AdminPort,
-			devMode,
 			localStack,
 			traefik,
 		)
 	}
-	fmt.Println("===============================================================================")
+	fmt.Println("==================================================================")
 
 	// Show helpful commands
 	fmt.Println("\nCommands:")

--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -46,7 +46,6 @@ var (
 	startNoLocalStack bool
 	startNoTraefik    bool
 	startTimeout      time.Duration
-	startDevMode      bool
 )
 
 var startCmd = &cobra.Command{
@@ -68,7 +67,6 @@ func init() {
 	startCmd.Flags().BoolVar(&startNoLocalStack, "no-localstack", false, "Disable LocalStack deployment")
 	startCmd.Flags().BoolVar(&startNoTraefik, "no-traefik", false, "Disable Traefik deployment")
 	startCmd.Flags().DurationVar(&startTimeout, "timeout", 10*time.Minute, "Timeout for cluster creation")
-	startCmd.Flags().BoolVar(&startDevMode, "dev", false, "Enable dev mode (deprecated, registry is always enabled)")
 }
 
 func runStart(cmd *cobra.Command, args []string) error {
@@ -107,7 +105,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 		NoTraefik:    startNoTraefik,
 		ApiPort:      startApiPort,
 		AdminPort:    startAdminPort,
-		DevMode:      startDevMode,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), startTimeout)

--- a/controlplane/internal/instance/config.go
+++ b/controlplane/internal/instance/config.go
@@ -37,9 +37,6 @@ type InstanceConfig struct {
 	LocalStack bool `yaml:"localStack"`
 	Traefik    bool `yaml:"traefik"`
 
-	// Development settings
-	DevMode bool `yaml:"devMode"`
-
 	// Data directory
 	DataDir string `yaml:"dataDir"`
 }
@@ -65,7 +62,6 @@ func SaveInstanceConfig(instanceName string, opts StartOptions) error {
 		AdminPort:  opts.AdminPort,
 		LocalStack: !opts.NoLocalStack,
 		Traefik:    !opts.NoTraefik,
-		DevMode:    opts.DevMode,
 		DataDir:    opts.DataDir,
 	}
 

--- a/controlplane/internal/instance/manager.go
+++ b/controlplane/internal/instance/manager.go
@@ -35,7 +35,6 @@ type StartOptions struct {
 	NoTraefik    bool
 	ApiPort      int
 	AdminPort    int
-	DevMode      bool
 }
 
 // CreationStatus represents the status of instance creation
@@ -56,10 +55,10 @@ type Manager struct {
 
 // NewManager creates a new instance manager
 func NewManager() (*Manager, error) {
-	// Default configuration - registry will be enabled per-instance based on DevMode flag
+	// Default configuration - registry is always enabled for all instances
 	k3dConfig := &kecs.ClusterManagerConfig{
 		Provider:       "k3d",
-		EnableRegistry: false, // Will be overridden per-instance based on DevMode
+		EnableRegistry: true,  // Always enabled for local development
 		ContainerMode:  false, // TUI mode is not container mode
 	}
 	k3dManager, err := kecs.NewK3dClusterManager(k3dConfig)
@@ -350,7 +349,6 @@ func (m *Manager) List(ctx context.Context) ([]InstanceInfo, error) {
 			ApiPort:    cfg.APIPort,
 			AdminPort:  cfg.AdminPort,
 			HasData:    hasData,
-			DevMode:    cfg.DevMode,
 			LocalStack: cfg.LocalStack,
 			Traefik:    cfg.Traefik,
 		})
@@ -366,7 +364,6 @@ type InstanceInfo struct {
 	ApiPort    int
 	AdminPort  int
 	HasData    bool
-	DevMode    bool
 	LocalStack bool
 	Traefik    bool
 }
@@ -416,7 +413,6 @@ func (m *Manager) Restart(ctx context.Context, instanceName string) error {
 			AdminPort:  8081,
 			LocalStack: true,
 			Traefik:    false,
-			DevMode:    false,
 		}
 	}
 
@@ -427,7 +423,6 @@ func (m *Manager) Restart(ctx context.Context, instanceName string) error {
 		AdminPort:    savedConfig.AdminPort,
 		NoLocalStack: !savedConfig.LocalStack,
 		NoTraefik:    !savedConfig.Traefik,
-		DevMode:      savedConfig.DevMode,
 	}
 
 	// Use restartInstance to handle the restart

--- a/controlplane/internal/tui/api/k3d_provider.go
+++ b/controlplane/internal/tui/api/k3d_provider.go
@@ -103,7 +103,6 @@ func (p *K3dInstanceProvider) getInstanceInfo(ctx context.Context, name string) 
 		inst.AdminPort = config.AdminPort
 		inst.LocalStack = config.LocalStack
 		inst.Traefik = config.Traefik
-		inst.DevMode = config.DevMode
 		inst.CreatedAt = config.CreatedAt
 	}
 
@@ -188,7 +187,6 @@ func (p *K3dInstanceProvider) CreateInstance(ctx context.Context, opts CreateIns
 		AdminPort:    opts.AdminPort,
 		NoLocalStack: !opts.LocalStack,
 		NoTraefik:    !opts.Traefik,
-		DevMode:      opts.DevMode,
 	}
 
 	// Use the instance manager to start the instance

--- a/controlplane/internal/tui/api/types.go
+++ b/controlplane/internal/tui/api/types.go
@@ -29,7 +29,6 @@ type Instance struct {
 	AdminPort  int       `json:"adminPort"`
 	LocalStack bool      `json:"localStack"`
 	Traefik    bool      `json:"traefik"`
-	DevMode    bool      `json:"devMode"`
 	CreatedAt  time.Time `json:"createdAt"`
 }
 
@@ -40,7 +39,6 @@ type CreateInstanceOptions struct {
 	AdminPort  int    `json:"adminPort"`
 	LocalStack bool   `json:"localStack"`
 	Traefik    bool   `json:"traefik"`
-	DevMode    bool   `json:"devMode"`
 }
 
 // Cluster represents an ECS cluster

--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -1344,7 +1344,6 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 				AdminPort:  formData["adminPort"].(int),
 				LocalStack: formData["localStack"].(bool),
 				Traefik:    formData["traefik"].(bool),
-				DevMode:    formData["devMode"].(bool),
 			}
 
 			// Initialize creation steps
@@ -1382,7 +1381,7 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case " ", "space":
 		// Toggle checkbox or press button
 		switch m.instanceForm.focusedField {
-		case FieldLocalStack, FieldTraefik, FieldDevMode:
+		case FieldLocalStack, FieldTraefik:
 			m.instanceForm.ToggleCheckbox()
 		case FieldSubmit:
 			// Same as enter on submit
@@ -1401,7 +1400,6 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 				AdminPort:  formData["adminPort"].(int),
 				LocalStack: formData["localStack"].(bool),
 				Traefik:    formData["traefik"].(bool),
-				DevMode:    formData["devMode"].(bool),
 			}
 
 			// Initialize creation steps

--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -62,7 +62,6 @@ func (m Model) loadDataFromAPI() tea.Cmd {
 				AdminPort:  inst.AdminPort,
 				LocalStack: inst.LocalStack,
 				Traefik:    inst.Traefik,
-				DevMode:    inst.DevMode,
 				Age:        time.Since(inst.CreatedAt),
 			}
 		}
@@ -271,7 +270,6 @@ func (m Model) createInstanceCmd(opts api.CreateInstanceOptions) tea.Cmd {
 				AdminPort:  instance.AdminPort,
 				LocalStack: instance.LocalStack,
 				Traefik:    instance.Traefik,
-				DevMode:    instance.DevMode,
 				Age:        time.Since(instance.CreatedAt),
 			},
 		}
@@ -487,7 +485,6 @@ func (m Model) updateInstanceStatusCmd() tea.Cmd {
 				AdminPort:  inst.AdminPort,
 				LocalStack: inst.LocalStack,
 				Traefik:    inst.Traefik,
-				DevMode:    inst.DevMode,
 				Age:        time.Since(inst.CreatedAt),
 			}
 		}

--- a/controlplane/internal/tui/instance_form.go
+++ b/controlplane/internal/tui/instance_form.go
@@ -19,7 +19,6 @@ const (
 	FieldAdminPort
 	FieldLocalStack
 	FieldTraefik
-	FieldDevMode
 	FieldSubmit
 	FieldCancel
 )
@@ -38,7 +37,6 @@ type InstanceForm struct {
 	adminPort    string
 	localStack   bool
 	traefik      bool
-	devMode      bool
 
 	// UI state
 	focusedField FormField
@@ -70,7 +68,6 @@ func NewInstanceForm() *InstanceForm {
 		adminPort:    "8081",
 		localStack:   true,
 		traefik:      true,
-		devMode:      false,
 		focusedField: FieldInstanceName, // Start with instance name field, not close button
 	}
 }
@@ -89,7 +86,6 @@ func NewInstanceFormWithSuggestions(instances []Instance) *InstanceForm {
 		adminPort:    fmt.Sprintf("%d", adminPort),
 		localStack:   true,
 		traefik:      true,
-		devMode:      false,
 		focusedField: FieldInstanceName, // Start with instance name field, not close button
 	}
 }
@@ -102,7 +98,6 @@ func (f *InstanceForm) Reset() {
 	f.adminPort = "8081"
 	f.localStack = true
 	f.traefik = true
-	f.devMode = false
 	f.focusedField = FieldInstanceName
 	f.errorMsg = ""
 	f.successMsg = ""
@@ -141,8 +136,6 @@ func (f *InstanceForm) ToggleCheckbox() {
 		f.localStack = !f.localStack
 	case FieldTraefik:
 		f.traefik = !f.traefik
-	case FieldDevMode:
-		f.devMode = !f.devMode
 	}
 }
 
@@ -224,7 +217,6 @@ func (f *InstanceForm) GetFormData() map[string]interface{} {
 		"adminPort":    adminPort,
 		"localStack":   f.localStack,
 		"traefik":      f.traefik,
-		"devMode":      f.devMode,
 	}
 }
 

--- a/controlplane/internal/tui/instance_form_render.go
+++ b/controlplane/internal/tui/instance_form_render.go
@@ -134,7 +134,6 @@ func (m Model) renderInstanceForm() string {
 	// Checkboxes
 	content = append(content, m.renderCheckbox("Enable LocalStack", f.localStack, f.focusedField == FieldLocalStack))
 	content = append(content, m.renderCheckbox("Enable Traefik Gateway", f.traefik, f.focusedField == FieldTraefik))
-	content = append(content, m.renderCheckbox("Developer Mode", f.devMode, f.focusedField == FieldDevMode))
 	content = append(content, "")
 
 	// Buttons (centered)

--- a/controlplane/internal/tui/instance_form_test.go
+++ b/controlplane/internal/tui/instance_form_test.go
@@ -24,7 +24,6 @@ var _ = Describe("InstanceForm", func() {
 			Expect(data["adminPort"]).To(Equal(8081))
 			Expect(data["localStack"]).To(BeTrue())
 			Expect(data["traefik"]).To(BeTrue())
-			Expect(data["devMode"]).To(BeFalse())
 		})
 	})
 

--- a/controlplane/internal/tui/mock/data.go
+++ b/controlplane/internal/tui/mock/data.go
@@ -17,7 +17,6 @@ type InstanceData struct {
 	AdminPort  int
 	LocalStack bool
 	Traefik    bool
-	DevMode    bool
 	Age        time.Duration
 }
 
@@ -71,11 +70,11 @@ type LogData struct {
 // Predefined mock data
 var (
 	mockInstances = []InstanceData{
-		{Name: "development", Status: "ACTIVE", Clusters: 3, Services: 12, Tasks: 28, APIPort: 8080, AdminPort: 8081, LocalStack: true, Traefik: true, DevMode: true, Age: 5 * 24 * time.Hour},
-		{Name: "staging", Status: "ACTIVE", Clusters: 2, Services: 8, Tasks: 18, APIPort: 8090, AdminPort: 8091, LocalStack: true, Traefik: true, DevMode: false, Age: 3 * 24 * time.Hour},
-		{Name: "testing", Status: "STOPPED", Clusters: 1, Services: 0, Tasks: 0, APIPort: 8100, AdminPort: 8101, LocalStack: false, Traefik: false, DevMode: false, Age: 7 * 24 * time.Hour},
-		{Name: "production", Status: "ACTIVE", Clusters: 5, Services: 25, Tasks: 62, APIPort: 8110, AdminPort: 8111, LocalStack: false, Traefik: true, DevMode: false, Age: 24 * time.Hour},
-		{Name: "local", Status: "ACTIVE", Clusters: 1, Services: 3, Tasks: 5, APIPort: 8120, AdminPort: 8121, LocalStack: true, Traefik: false, DevMode: true, Age: 2 * time.Hour},
+		{Name: "development", Status: "ACTIVE", Clusters: 3, Services: 12, Tasks: 28, APIPort: 8080, AdminPort: 8081, LocalStack: true, Traefik: true, Age: 5 * 24 * time.Hour},
+		{Name: "staging", Status: "ACTIVE", Clusters: 2, Services: 8, Tasks: 18, APIPort: 8090, AdminPort: 8091, LocalStack: true, Traefik: true, Age: 3 * 24 * time.Hour},
+		{Name: "testing", Status: "STOPPED", Clusters: 1, Services: 0, Tasks: 0, APIPort: 8100, AdminPort: 8101, LocalStack: false, Traefik: false, Age: 7 * 24 * time.Hour},
+		{Name: "production", Status: "ACTIVE", Clusters: 5, Services: 25, Tasks: 62, APIPort: 8110, AdminPort: 8111, LocalStack: false, Traefik: true, Age: 24 * time.Hour},
+		{Name: "local", Status: "ACTIVE", Clusters: 1, Services: 3, Tasks: 5, APIPort: 8120, AdminPort: 8121, LocalStack: true, Traefik: false, Age: 2 * time.Hour},
 	}
 
 	mockClusters = map[string][]ClusterData{

--- a/controlplane/internal/tui/mock/generator.go
+++ b/controlplane/internal/tui/mock/generator.go
@@ -26,7 +26,6 @@ type InstanceMsg struct {
 	AdminPort  int
 	LocalStack bool
 	Traefik    bool
-	DevMode    bool
 	Age        time.Duration
 }
 
@@ -94,7 +93,6 @@ func LoadAllData(selectedInstance, selectedCluster, selectedService, selectedTas
 				AdminPort:  data.AdminPort,
 				LocalStack: data.LocalStack,
 				Traefik:    data.Traefik,
-				DevMode:    data.DevMode,
 				Age:        data.Age,
 			}
 		}

--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -44,7 +44,6 @@ type Instance struct {
 	AdminPort  int
 	LocalStack bool
 	Traefik    bool
-	DevMode    bool
 	Age        time.Duration
 	Selected   bool
 }

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -500,9 +500,6 @@ func (m Model) renderSummary() string {
 					if inst.Traefik {
 						features = append(features, "Traefik")
 					}
-					if inst.DevMode {
-						features = append(features, "DevMode")
-					}
 					break
 				}
 			}
@@ -543,9 +540,6 @@ func (m Model) renderSummary() string {
 						}
 						if inst.Traefik {
 							features = append(features, "Traefik")
-						}
-						if inst.DevMode {
-							features = append(features, "DevMode")
 						}
 						break
 					}

--- a/docs/tui-backend-api.md
+++ b/docs/tui-backend-api.md
@@ -79,8 +79,7 @@ Creates a new KECS instance (currently returns 501 Not Implemented).
   "apiPort": 8090,
   "adminPort": 8091,
   "localStack": true,
-  "traefik": true,
-  "devMode": false
+  "traefik": true
 }
 ```
 


### PR DESCRIPTION
## Summary
- Removed all DevMode-related code and comments from the KECS codebase
- Local registry is now always enabled for all instances  
- Simplified configuration and user experience

## Background
DevMode was originally intended to control local registry enablement for KECS development. However, the local registry is essential for all users to use locally built Docker images. This change simplifies the codebase by removing the unnecessary configuration option.

## Changes
- Remove DevMode field from all structs (StartOptions, InstanceConfig, InstanceInfo, etc.)
- Remove DevMode from TUI forms and display logic
- Remove --dev flag from CLI commands  
- Update k3d configuration to always enable registry
- Remove DevMode from config files and environment variables
- Update tests and documentation

## Test Plan
- [x] Build succeeds (`make build`)
- [x] All tests pass (`make test`)
- [x] TUI starts without DevMode field
- [x] Instance creation works without DevMode option
- [x] CLI list command displays correctly without DevMode column

🤖 Generated with [Claude Code](https://claude.ai/code)