### PR TITLE
feat: Remove LocalStack and Traefik options from TUI

### DIFF
--- a/controlplane/cmd/tui-test/mock.go
+++ b/controlplane/cmd/tui-test/mock.go
@@ -54,7 +54,6 @@ func testMockClientBasic() {
 		APIPort:    8090,
 		AdminPort:  8091,
 		LocalStack: true,
-		Traefik:    false,
 	})
 	if err != nil {
 		log.Printf("Error creating instance: %v", err)

--- a/controlplane/internal/controlplane/cmd/list.go
+++ b/controlplane/internal/controlplane/cmd/list.go
@@ -44,9 +44,9 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	// Display instances in a table format
 	fmt.Println("KECS Instances:")
-	fmt.Println("==================================================================")
-	fmt.Printf("%-20s %-10s %-10s %-10s %-10s %-8s\n", "NAME", "STATUS", "API PORT", "ADMIN PORT", "LOCALSTACK", "TRAEFIK")
-	fmt.Println("------------------------------------------------------------------")
+	fmt.Println("=========================================================")
+	fmt.Printf("%-20s %-10s %-10s %-10s %-10s\n", "NAME", "STATUS", "API PORT", "ADMIN PORT", "LOCALSTACK")
+	fmt.Println("---------------------------------------------------------")
 
 	for _, inst := range instances {
 		status := strings.ToLower(inst.Status)
@@ -54,21 +54,16 @@ func runList(cmd *cobra.Command, args []string) error {
 		if inst.LocalStack {
 			localStack = "yes"
 		}
-		traefik := "no"
-		if inst.Traefik {
-			traefik = "yes"
-		}
 
-		fmt.Printf("%-20s %-10s %-10d %-10d %-10s %-8s\n",
+		fmt.Printf("%-20s %-10s %-10d %-10d %-10s\n",
 			inst.Name,
 			status,
 			inst.ApiPort,
 			inst.AdminPort,
 			localStack,
-			traefik,
 		)
 	}
-	fmt.Println("==================================================================")
+	fmt.Println("=========================================================")
 
 	// Show helpful commands
 	fmt.Println("\nCommands:")

--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -44,7 +44,6 @@ var (
 	startAdminPort    int
 	startConfigFile   string
 	startNoLocalStack bool
-	startNoTraefik    bool
 	startTimeout      time.Duration
 )
 
@@ -65,7 +64,6 @@ func init() {
 	startCmd.Flags().IntVar(&startAdminPort, "admin-port", 8081, "Admin API port")
 	startCmd.Flags().StringVar(&startConfigFile, "config", "", "Configuration file path")
 	startCmd.Flags().BoolVar(&startNoLocalStack, "no-localstack", false, "Disable LocalStack deployment")
-	startCmd.Flags().BoolVar(&startNoTraefik, "no-traefik", false, "Disable Traefik deployment")
 	startCmd.Flags().DurationVar(&startTimeout, "timeout", 10*time.Minute, "Timeout for cluster creation")
 }
 
@@ -102,7 +100,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 		DataDir:      startDataDir,
 		ConfigFile:   startConfigFile,
 		NoLocalStack: startNoLocalStack,
-		NoTraefik:    startNoTraefik,
 		ApiPort:      startApiPort,
 		AdminPort:    startAdminPort,
 	}

--- a/controlplane/internal/instance/config.go
+++ b/controlplane/internal/instance/config.go
@@ -35,7 +35,6 @@ type InstanceConfig struct {
 
 	// Feature toggles
 	LocalStack bool `yaml:"localStack"`
-	Traefik    bool `yaml:"traefik"`
 
 	// Data directory
 	DataDir string `yaml:"dataDir"`
@@ -61,7 +60,6 @@ func SaveInstanceConfig(instanceName string, opts StartOptions) error {
 		APIPort:    opts.ApiPort,
 		AdminPort:  opts.AdminPort,
 		LocalStack: !opts.NoLocalStack,
-		Traefik:    !opts.NoTraefik,
 		DataDir:    opts.DataDir,
 	}
 

--- a/controlplane/internal/instance/manager.go
+++ b/controlplane/internal/instance/manager.go
@@ -32,7 +32,6 @@ type StartOptions struct {
 	DataDir      string
 	ConfigFile   string
 	NoLocalStack bool
-	NoTraefik    bool
 	ApiPort      int
 	AdminPort    int
 }
@@ -350,7 +349,6 @@ func (m *Manager) List(ctx context.Context) ([]InstanceInfo, error) {
 			AdminPort:  cfg.AdminPort,
 			HasData:    hasData,
 			LocalStack: cfg.LocalStack,
-			Traefik:    cfg.Traefik,
 		})
 	}
 
@@ -365,7 +363,6 @@ type InstanceInfo struct {
 	AdminPort  int
 	HasData    bool
 	LocalStack bool
-	Traefik    bool
 }
 
 // IsRunning checks if an instance is running
@@ -412,7 +409,6 @@ func (m *Manager) Restart(ctx context.Context, instanceName string) error {
 			APIPort:    4566,
 			AdminPort:  8081,
 			LocalStack: true,
-			Traefik:    false,
 		}
 	}
 
@@ -422,7 +418,6 @@ func (m *Manager) Restart(ctx context.Context, instanceName string) error {
 		ApiPort:      savedConfig.APIPort,
 		AdminPort:    savedConfig.AdminPort,
 		NoLocalStack: !savedConfig.LocalStack,
-		NoTraefik:    !savedConfig.Traefik,
 	}
 
 	// Use restartInstance to handle the restart

--- a/controlplane/internal/tui/api/k3d_provider.go
+++ b/controlplane/internal/tui/api/k3d_provider.go
@@ -102,7 +102,7 @@ func (p *K3dInstanceProvider) getInstanceInfo(ctx context.Context, name string) 
 		inst.APIPort = config.APIPort
 		inst.AdminPort = config.AdminPort
 		inst.LocalStack = config.LocalStack
-		inst.Traefik = config.Traefik
+		inst.Traefik = false // Always false, Traefik is deprecated
 		inst.CreatedAt = config.CreatedAt
 	}
 
@@ -186,7 +186,6 @@ func (p *K3dInstanceProvider) CreateInstance(ctx context.Context, opts CreateIns
 		ApiPort:      opts.APIPort,
 		AdminPort:    opts.AdminPort,
 		NoLocalStack: !opts.LocalStack,
-		NoTraefik:    !opts.Traefik,
 	}
 
 	// Use the instance manager to start the instance

--- a/controlplane/internal/tui/api/types.go
+++ b/controlplane/internal/tui/api/types.go
@@ -38,7 +38,6 @@ type CreateInstanceOptions struct {
 	APIPort    int    `json:"apiPort"`
 	AdminPort  int    `json:"adminPort"`
 	LocalStack bool   `json:"localStack"`
-	Traefik    bool   `json:"traefik"`
 }
 
 // Cluster represents an ECS cluster

--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -1343,7 +1343,6 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 				APIPort:    formData["apiPort"].(int),
 				AdminPort:  formData["adminPort"].(int),
 				LocalStack: formData["localStack"].(bool),
-				Traefik:    formData["traefik"].(bool),
 			}
 
 			// Initialize creation steps
@@ -1353,9 +1352,6 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 			}
 			if opts.LocalStack {
 				steps = append(steps, CreationStep{Name: "Starting LocalStack", Status: "pending"})
-			}
-			if opts.Traefik {
-				steps = append(steps, CreationStep{Name: "Configuring Traefik", Status: "pending"})
 			}
 			steps = append(steps, CreationStep{Name: "Finalizing", Status: "pending"})
 
@@ -1369,7 +1365,7 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 			// Start creation and monitoring
 			return m, tea.Batch(
 				m.createInstanceCmd(opts),
-				m.monitorInstanceCreation(opts.Name, opts.LocalStack, opts.Traefik),
+				m.monitorInstanceCreation(opts.Name, opts.LocalStack),
 			)
 		case FieldCancel:
 			// Cancel and close
@@ -1381,8 +1377,7 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case " ", "space":
 		// Toggle checkbox or press button
 		switch m.instanceForm.focusedField {
-		case FieldLocalStack, FieldTraefik:
-			m.instanceForm.ToggleCheckbox()
+		// No checkboxes anymore, LocalStack is always enabled
 		case FieldSubmit:
 			// Same as enter on submit
 			if !m.instanceForm.Validate() {
@@ -1399,7 +1394,6 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 				APIPort:    formData["apiPort"].(int),
 				AdminPort:  formData["adminPort"].(int),
 				LocalStack: formData["localStack"].(bool),
-				Traefik:    formData["traefik"].(bool),
 			}
 
 			// Initialize creation steps
@@ -1409,9 +1403,6 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 			}
 			if opts.LocalStack {
 				steps = append(steps, CreationStep{Name: "Starting LocalStack", Status: "pending"})
-			}
-			if opts.Traefik {
-				steps = append(steps, CreationStep{Name: "Configuring Traefik", Status: "pending"})
 			}
 			steps = append(steps, CreationStep{Name: "Finalizing", Status: "pending"})
 
@@ -1425,7 +1416,7 @@ func (m Model) handleInstanceCreateInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 			// Start creation and monitoring
 			return m, tea.Batch(
 				m.createInstanceCmd(opts),
-				m.monitorInstanceCreation(opts.Name, opts.LocalStack, opts.Traefik),
+				m.monitorInstanceCreation(opts.Name, opts.LocalStack),
 			)
 		case FieldCancel:
 			m.currentView = m.previousView

--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -277,7 +277,7 @@ func (m Model) createInstanceCmd(opts api.CreateInstanceOptions) tea.Cmd {
 }
 
 // monitorInstanceCreation monitors the creation progress and sends status updates
-func (m Model) monitorInstanceCreation(instanceName string, hasLocalStack, hasTraefik bool) tea.Cmd {
+func (m Model) monitorInstanceCreation(instanceName string, hasLocalStack bool) tea.Cmd {
 	return func() tea.Msg {
 		// Start a background monitoring goroutine
 		startTime := time.Now()
@@ -290,9 +290,6 @@ func (m Model) monitorInstanceCreation(instanceName string, hasLocalStack, hasTr
 
 		if hasLocalStack {
 			steps = append(steps, CreationStep{Name: "Starting LocalStack", Status: "pending"})
-		}
-		if hasTraefik {
-			steps = append(steps, CreationStep{Name: "Configuring Traefik", Status: "pending"})
 		}
 		steps = append(steps, CreationStep{Name: "Finalizing", Status: "pending"})
 

--- a/controlplane/internal/tui/instance_form.go
+++ b/controlplane/internal/tui/instance_form.go
@@ -17,8 +17,6 @@ const (
 	FieldInstanceName
 	FieldAPIPort
 	FieldAdminPort
-	FieldLocalStack
-	FieldTraefik
 	FieldSubmit
 	FieldCancel
 )
@@ -35,8 +33,6 @@ type InstanceForm struct {
 	instanceName string
 	apiPort      string
 	adminPort    string
-	localStack   bool
-	traefik      bool
 
 	// UI state
 	focusedField FormField
@@ -66,8 +62,6 @@ func NewInstanceForm() *InstanceForm {
 		instanceName: defaultName,
 		apiPort:      "8080",
 		adminPort:    "8081",
-		localStack:   true,
-		traefik:      true,
 		focusedField: FieldInstanceName, // Start with instance name field, not close button
 	}
 }
@@ -84,8 +78,6 @@ func NewInstanceFormWithSuggestions(instances []Instance) *InstanceForm {
 		instanceName: defaultName,
 		apiPort:      fmt.Sprintf("%d", apiPort),
 		adminPort:    fmt.Sprintf("%d", adminPort),
-		localStack:   true,
-		traefik:      true,
 		focusedField: FieldInstanceName, // Start with instance name field, not close button
 	}
 }
@@ -96,8 +88,6 @@ func (f *InstanceForm) Reset() {
 	f.instanceName = defaultName
 	f.apiPort = "8080"
 	f.adminPort = "8081"
-	f.localStack = true
-	f.traefik = true
 	f.focusedField = FieldInstanceName
 	f.errorMsg = ""
 	f.successMsg = ""
@@ -131,12 +121,7 @@ func (f *InstanceForm) MoveFocusDown() {
 
 // ToggleCheckbox toggles the checkbox at the current focus
 func (f *InstanceForm) ToggleCheckbox() {
-	switch f.focusedField {
-	case FieldLocalStack:
-		f.localStack = !f.localStack
-	case FieldTraefik:
-		f.traefik = !f.traefik
-	}
+	// No checkboxes anymore
 }
 
 // UpdateField updates the text field at the current focus
@@ -215,8 +200,7 @@ func (f *InstanceForm) GetFormData() map[string]interface{} {
 		"instanceName": f.instanceName,
 		"apiPort":      apiPort,
 		"adminPort":    adminPort,
-		"localStack":   f.localStack,
-		"traefik":      f.traefik,
+		"localStack":   true, // Always enabled
 	}
 }
 

--- a/controlplane/internal/tui/instance_form_render.go
+++ b/controlplane/internal/tui/instance_form_render.go
@@ -131,11 +131,6 @@ func (m Model) renderInstanceForm() string {
 	}
 	content = append(content, "")
 
-	// Checkboxes
-	content = append(content, m.renderCheckbox("Enable LocalStack", f.localStack, f.focusedField == FieldLocalStack))
-	content = append(content, m.renderCheckbox("Enable Traefik Gateway", f.traefik, f.focusedField == FieldTraefik))
-	content = append(content, "")
-
 	// Buttons (centered)
 	createBtnLabel := "Create"
 	if f.isCreating {

--- a/controlplane/internal/tui/instance_form_test.go
+++ b/controlplane/internal/tui/instance_form_test.go
@@ -22,8 +22,7 @@ var _ = Describe("InstanceForm", func() {
 			Expect(data["instanceName"]).NotTo(BeEmpty())
 			Expect(data["apiPort"]).To(Equal(8080))
 			Expect(data["adminPort"]).To(Equal(8081))
-			Expect(data["localStack"]).To(BeTrue())
-			Expect(data["traefik"]).To(BeTrue())
+			Expect(data["localStack"]).To(BeTrue()) // Always true
 		})
 	})
 
@@ -32,9 +31,6 @@ var _ = Describe("InstanceForm", func() {
 			// Start at instance name
 			form.MoveFocusDown() // API port
 			form.MoveFocusDown() // Admin port
-			form.MoveFocusDown() // LocalStack
-			form.MoveFocusDown() // Traefik
-			form.MoveFocusDown() // Dev mode
 			form.MoveFocusDown() // Submit
 			form.MoveFocusDown() // Cancel
 			form.MoveFocusDown() // Back to close button
@@ -46,7 +42,7 @@ var _ = Describe("InstanceForm", func() {
 		It("should move focus up through fields", func() {
 			form.MoveFocusUp() // From instance name to cancel
 			form.MoveFocusUp() // Submit
-			form.MoveFocusUp() // Dev mode
+			form.MoveFocusUp() // Admin port
 			// Continue cycling
 		})
 	})
@@ -66,24 +62,7 @@ var _ = Describe("InstanceForm", func() {
 		})
 	})
 
-	Describe("Checkbox Toggle", func() {
-		It("should toggle LocalStack checkbox", func() {
-			// Move to LocalStack field
-			form.MoveFocusDown() // API port
-			form.MoveFocusDown() // Admin port
-			form.MoveFocusDown() // LocalStack
-
-			// Toggle
-			form.ToggleCheckbox()
-			data := form.GetFormData()
-			Expect(data["localStack"]).To(BeFalse())
-
-			// Toggle back
-			form.ToggleCheckbox()
-			data = form.GetFormData()
-			Expect(data["localStack"]).To(BeTrue())
-		})
-	})
+	// Checkbox tests removed - LocalStack is always enabled, no checkboxes in form
 
 	Describe("Validation", func() {
 		It("should validate empty instance name", func() {

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -488,18 +488,11 @@ func (m Model) renderSummary() string {
 			}
 
 			// Find instance configuration
-			var features []string
 			var apiPort, adminPort int
 			for _, inst := range m.instances {
 				if inst.Name == m.selectedInstance {
 					apiPort = inst.APIPort
 					adminPort = inst.AdminPort
-					if inst.LocalStack {
-						features = append(features, "LocalStack")
-					}
-					if inst.Traefik {
-						features = append(features, "Traefik")
-					}
 					break
 				}
 			}
@@ -508,11 +501,6 @@ func (m Model) renderSummary() string {
 			line1 := fmt.Sprintf("Clusters: %-4d  API:   %d", len(m.clusters), apiPort)
 			line2 := fmt.Sprintf("Services: %-4d  Admin: %d", totalServices, adminPort)
 			line3 := fmt.Sprintf("Tasks:    %-4d", totalTasks)
-
-			// Add features on the same line if they exist
-			if len(features) > 0 {
-				line3 += "  " + strings.Join(features, ", ")
-			}
 
 			// Create multi-line summary with consistent styling
 			summary = summaryStyle.Render(line1) + "\n" +
@@ -529,28 +517,8 @@ func (m Model) renderSummary() string {
 				totalRunning += svc.Running
 			}
 
-			// Add instance configuration info
-			var instanceInfo string
-			if m.selectedInstance != "" {
-				var features []string
-				for _, inst := range m.instances {
-					if inst.Name == m.selectedInstance {
-						if inst.LocalStack {
-							features = append(features, "LocalStack")
-						}
-						if inst.Traefik {
-							features = append(features, "Traefik")
-						}
-						break
-					}
-				}
-				if len(features) > 0 {
-					instanceInfo = " | " + strings.Join(features, ", ")
-				}
-			}
-
-			summary = fmt.Sprintf("Cluster: %s | Services: %d | Desired Tasks: %d | Running Tasks: %d%s",
-				m.selectedCluster, len(m.services), totalDesired, totalRunning, instanceInfo)
+			summary = fmt.Sprintf("Cluster: %s | Services: %d | Desired Tasks: %d | Running Tasks: %d",
+				m.selectedCluster, len(m.services), totalDesired, totalRunning)
 		}
 
 	case ViewTasks:


### PR DESCRIPTION
## Summary
- Remove LocalStack and Traefik checkboxes from TUI instance creation form
- Simplify user experience by removing unnecessary configuration options
- Keep internal flags for testing purposes

## Changes
- **Traefik option completely removed** - Already deprecated and unused (deployTraefik function returns nil)
- **LocalStack checkbox removed from TUI** - Now always enabled for users as it's essential for AWS API emulation
- **Internal NoLocalStack flag retained** - For unit testing purposes only
- **Updated tests** - Removed checkbox-related test cases

## Why these changes?
Both LocalStack and Traefik are essential components that shouldn't be user-configurable:
- **LocalStack**: Required for AWS service emulation in local environment
- **Traefik**: Already deprecated and non-functional in the codebase

This change streamlines the instance creation process and prevents potential configuration errors.

## Test plan
- [x] All TUI tests pass
- [x] Build succeeds (`make build`)
- [x] Control plane tests pass
- [ ] Manual testing of instance creation via TUI
- [ ] Verify LocalStack is always deployed with new instances

🤖 Generated with [Claude Code](https://claude.ai/code)