### PR TITLE
fix: Add ESC key support in TUI Task Definition views

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -86,6 +86,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.commandPalette.Reset()
 			} else if m.currentView == ViewTaskDescribe {
 				m.currentView = m.previousView
+			} else if m.currentView == ViewTaskDefinitionRevisions && m.showTaskDefJSON {
+				// Special case: just hide JSON view without navigating
+				m.showTaskDefJSON = false
 			} else if m.currentView != ViewInstances {
 				// Go back to previous view if not at root
 				m.goBack()
@@ -1553,11 +1556,6 @@ func (m Model) handleTaskDefinitionFamiliesKeys(msg tea.KeyMsg) (Model, tea.Cmd)
 			m.previousView = m.currentView
 			m.currentView = ViewInstanceSwitcher
 		}
-	case "esc":
-		// Go back to clusters view
-		m.currentView = ViewClusters
-		m.selectedFamily = ""
-		return m, m.loadDataFromAPI()
 	}
 	return m, nil
 }
@@ -1675,17 +1673,6 @@ func (m Model) handleTaskDefinitionRevisionsKeys(msg tea.KeyMsg) (Model, tea.Cmd
 			m.instanceSwitcher = NewInstanceSwitcher(m.instances)
 			m.previousView = m.currentView
 			m.currentView = ViewInstanceSwitcher
-		}
-	case "esc":
-		// Go back to task definition families view
-		if m.showTaskDefJSON {
-			// If JSON is shown, just hide it
-			m.showTaskDefJSON = false
-		} else {
-			// Otherwise go back to families view
-			m.currentView = ViewTaskDefinitionFamilies
-			m.selectedFamily = ""
-			m.taskDefRevisionCursor = 0
 		}
 	}
 	return m, nil

--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -328,6 +328,20 @@ func (m *Model) goBack() {
 		m.selectedService = ""
 	case ViewLogs:
 		m.currentView = m.previousView
+	case ViewTaskDefinitionFamilies:
+		m.currentView = ViewClusters
+		m.selectedFamily = ""
+	case ViewTaskDefinitionRevisions:
+		// Special handling for JSON view
+		if m.showTaskDefJSON {
+			// Just hide the JSON view
+			m.showTaskDefJSON = false
+		} else {
+			// Go back to families view
+			m.currentView = ViewTaskDefinitionFamilies
+			m.selectedFamily = ""
+			m.taskDefRevisionCursor = 0
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR adds ESC key support to the Task Definition views in the TUI, allowing users to navigate back to previous views.

## Changes

- Added ESC key handler in Task Definition Families view to return to Clusters view
- Added ESC key handler in Task Definition Revisions view to return to Families view
- When JSON view is displayed, ESC key hides the JSON instead of navigating back

## Testing

- ✅ All tests pass
- ✅ Built successfully
- ✅ ESC key navigation tested in TUI

## User Experience

Previously, users had to use the 'q' key to quit or use specific navigation keys. Now they can intuitively use the ESC key to go back, which is a common pattern in terminal applications.

🤖 Generated with [Claude Code](https://claude.ai/code)