### PR TITLE
fix: Remove LocalStack host port forwarding to prevent multiple instance conflicts

### DIFF
--- a/controlplane/internal/instance/helpers.go
+++ b/controlplane/internal/instance/helpers.go
@@ -64,11 +64,8 @@ func (m *Manager) createCluster(ctx context.Context, instanceName string, cfg *c
 		int32(opts.AdminPort): adminNodePort, // Map host Admin port to NodePort for Admin API
 	}
 
-	// If LocalStack is enabled, add its port mapping
-	if cfg.LocalStack.Enabled {
-		// LocalStack always uses fixed NodePort 30566
-		portMappings[4566] = 30566
-	}
+	// LocalStack port mapping is no longer needed as it's accessed only internally
+	// This prevents port conflicts when running multiple instances
 
 	// Enable k3d registry
 	m.k3dManager.SetEnableRegistry(true)


### PR DESCRIPTION
## Summary

This PR fixes an issue where creating multiple KECS instances would fail with a port conflict error on port 4566.

## Problem

When trying to create a second KECS instance while another is already running, the creation would fail with:
```
Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint k3d-kecs-brave-lamport-server-0: Bind for 0.0.0.0:4566 failed: port is already allocated
```

## Root Cause

Each k3d cluster was configured to forward host port 4566 to NodePort 30566 for LocalStack access. When multiple instances were created, they would compete for the same host port 4566, causing the conflict.

## Solution  

Removed the unnecessary host port forwarding for LocalStack (4566 -> 30566). LocalStack is only accessed internally within the cluster via NodePort 30566, so exposing it on the host is not required and only causes conflicts.

## Changes
- Removed LocalStack port mapping from k3d cluster creation in `internal/instance/helpers.go`
- LocalStack remains accessible within the cluster on NodePort 30566
- Host ports are now only mapped for ECS API and Admin API (which use dynamic port allocation)

## Testing
- ✅ Unit tests pass
- ✅ Can now create multiple KECS instances without port conflicts
- ✅ LocalStack functionality remains intact for internal cluster access

Fixes #553