### PR TITLE
feat: Add nginx-with-log-generator example for testing log functionality

### DIFF
--- a/examples/nginx-with-log-generator/README.md
+++ b/examples/nginx-with-log-generator/README.md
@@ -1,0 +1,61 @@
+# Nginx with Log Generator Example
+
+This example demonstrates log generation and viewing in KECS using a multi-container task definition with:
+- An nginx web server container
+- A sidecar container that continuously sends HTTP requests to nginx every 5 seconds
+
+This setup ensures continuous log generation without needing port forwarding or external access.
+
+## Prerequisites
+- KECS instance running
+- Default cluster created
+
+## Deployment
+
+1. Register the task definition:
+```bash
+export AWS_ENDPOINT_URL=http://localhost:5373
+aws ecs register-task-definition --cli-input-json file://task_def.json
+```
+
+2. Create the service:
+```bash
+aws ecs create-service --cli-input-json file://service_def.json
+```
+
+## Viewing Logs
+
+### Using KECS TUI
+```bash
+kecs tui --instance <instance-name>
+```
+Navigate to the task and press 'l' to view logs.
+
+### Using kubectl
+```bash
+# Get the pod name
+kubectl get pods -n default-us-east-1
+
+# View nginx logs
+kubectl logs -n default-us-east-1 <pod-name> nginx
+
+# View log-generator logs
+kubectl logs -n default-us-east-1 <pod-name> log-generator
+```
+
+## Expected Behavior
+
+The log-generator container will:
+1. Send an HTTP request to the nginx container every 5 seconds
+2. Log "Sending request to nginx..." before each request
+3. Log "Request successful" after a successful request
+
+The nginx container will log access logs for each request:
+- Standard nginx access logs showing the internal requests from the log-generator
+
+## Cleanup
+
+Delete the service:
+```bash
+aws ecs delete-service --cluster default --service nginx-with-log-generator --force
+```

--- a/examples/nginx-with-log-generator/deploy.sh
+++ b/examples/nginx-with-log-generator/deploy.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Set AWS endpoint to KECS
+export AWS_ENDPOINT_URL=http://localhost:5373
+export AWS_REGION=us-east-1
+
+echo "Deploying nginx-with-log-generator example..."
+echo "========================================="
+
+# Check if default cluster exists
+echo "1. Checking for default cluster..."
+if ! aws ecs describe-clusters --clusters default 2>/dev/null | grep -q "ACTIVE"; then
+    echo "   Creating default cluster..."
+    aws ecs create-cluster --cluster-name default
+else
+    echo "   Default cluster already exists"
+fi
+
+# Register task definition
+echo ""
+echo "2. Registering task definition..."
+aws ecs register-task-definition --cli-input-json file://task_def.json > /dev/null
+if [ $? -eq 0 ]; then
+    echo "   Task definition registered successfully"
+else
+    echo "   Failed to register task definition"
+    exit 1
+fi
+
+# Create or update service
+echo ""
+echo "3. Creating service..."
+# Check if service already exists
+if aws ecs describe-services --cluster default --services nginx-with-log-generator 2>/dev/null | grep -q "serviceName"; then
+    echo "   Service already exists, updating..."
+    aws ecs update-service --cluster default --service nginx-with-log-generator --task-definition nginx-with-log-generator:1 --desired-count 1 > /dev/null
+else
+    echo "   Creating new service..."
+    aws ecs create-service --cli-input-json file://service_def.json > /dev/null
+fi
+
+if [ $? -eq 0 ]; then
+    echo "   Service deployed successfully"
+else
+    echo "   Failed to deploy service"
+    exit 1
+fi
+
+echo ""
+echo "Deployment completed!"
+echo ""
+echo "To view logs in TUI:"
+echo "  kecs tui --instance <instance-name>"
+echo ""
+echo "To check pod status:"
+echo "  kubectl get pods -n default-us-east-1"
+echo ""
+echo "To view container logs directly:"
+echo "  kubectl logs -n default-us-east-1 <pod-name> nginx"
+echo "  kubectl logs -n default-us-east-1 <pod-name> log-generator"

--- a/examples/nginx-with-log-generator/service_def.json
+++ b/examples/nginx-with-log-generator/service_def.json
@@ -1,0 +1,31 @@
+{
+  "serviceName": "nginx-with-log-generator",
+  "cluster": "default",
+  "taskDefinition": "nginx-with-log-generator:1",
+  "desiredCount": 1,
+  "launchType": "FARGATE",
+  "platformVersion": "LATEST",
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-12345678", "subnet-87654321"],
+      "securityGroups": ["sg-nginx-web"],
+      "assignPublicIp": "ENABLED"
+    }
+  },
+  "deploymentConfiguration": {
+    "maximumPercent": 200,
+    "minimumHealthyPercent": 100
+  },
+  "tags": [
+    {
+      "key": "Environment",
+      "value": "development"
+    },
+    {
+      "key": "Application",
+      "value": "nginx-log-test"
+    }
+  ],
+  "enableECSManagedTags": true,
+  "propagateTags": "SERVICE"
+}

--- a/examples/nginx-with-log-generator/task_def.json
+++ b/examples/nginx-with-log-generator/task_def.json
@@ -1,0 +1,51 @@
+{
+  "family": "nginx-with-log-generator",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::000000000000:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "nginx",
+      "image": "nginx:latest",
+      "cpu": 128,
+      "memory": 256,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/nginx-with-log-generator",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "nginx"
+        }
+      }
+    },
+    {
+      "name": "log-generator",
+      "image": "curlimages/curl:latest",
+      "cpu": 128,
+      "memory": 256,
+      "essential": false,
+      "command": [
+        "/bin/sh",
+        "-c",
+        "while true; do echo 'Sending request to nginx...'; curl -s http://localhost:80/ > /dev/null && echo 'Request successful' || echo 'Request failed'; sleep 5; done"
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/nginx-with-log-generator",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "log-generator"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added new example `nginx-with-log-generator` that demonstrates continuous log generation
- Includes nginx web server with a sidecar container that sends HTTP requests every 5 seconds
- No port forwarding required for log generation

## Purpose
This example is useful for testing and demonstrating:
- Log viewing functionality in KECS TUI
- Multi-container task definitions
- Sidecar pattern implementation
- Continuous log generation without external access

## Test plan
- [x] Deploy the example using `./deploy.sh`
- [x] Verify both containers are running: `kubectl get pods -n default-us-east-1`
- [x] Check log-generator logs: `kubectl logs -n default-us-east-1 <pod-name> log-generator`
- [x] Check nginx access logs: `kubectl logs -n default-us-east-1 <pod-name> nginx`
- [ ] Test log viewing in TUI (pending log API fixes)

🤖 Generated with [Claude Code](https://claude.ai/code)