### PR TITLE
feat: Add Vector deployment progress to TUI instance creation

### DIFF
--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -282,15 +282,20 @@ func (m Model) monitorInstanceCreation(instanceName string, hasLocalStack bool) 
 		// Start a background monitoring goroutine
 		startTime := time.Now()
 
-		// Define initial steps
+		// Define initial steps (must match backend status messages exactly)
 		steps := []CreationStep{
 			{Name: "Creating k3d cluster", Status: "running"},
+			{Name: "Creating namespace", Status: "pending"},
 			{Name: "Deploying control plane", Status: "pending"},
 		}
 
 		if hasLocalStack {
 			steps = append(steps, CreationStep{Name: "Starting LocalStack", Status: "pending"})
 		}
+
+		// Add Vector deployment step
+		steps = append(steps, CreationStep{Name: "Deploying Vector", Status: "pending"})
+
 		steps = append(steps, CreationStep{Name: "Finalizing", Status: "pending"})
 
 		// Return initial status immediately


### PR DESCRIPTION
## Summary
- Added Vector deployment progress step to TUI instance creation dialog
- Added namespace creation step to match backend status messages
- Provides better visibility into the instance creation process

## Changes
The TUI now shows the following steps when creating a new instance:
1. Creating k3d cluster
2. Creating namespace
3. Deploying control plane
4. Starting LocalStack (if enabled)
5. **Deploying Vector** (new)
6. Finalizing

## Why this change?
Vector is deployed for log aggregation in every KECS instance, but users didn't have visibility into this step. Now they can see that Vector is being deployed as part of the instance creation process.

## Implementation Details
- Updated `monitorInstanceCreation` function to include Vector deployment step
- Added namespace creation step to match the exact status messages from the backend
- The step names must match exactly what the backend reports for progress tracking to work correctly

## Test Plan
- [x] Build and test locally
- [ ] Create a new instance via TUI and verify Vector progress is shown
- [ ] Verify the progress updates correctly during instance creation

🤖 Generated with [Claude Code](https://claude.ai/code)