### PR TITLE
fix: Fix control plane health check by using correct internal ports

### DIFF
--- a/controlplane/internal/instance/helpers.go
+++ b/controlplane/internal/instance/helpers.go
@@ -159,8 +159,8 @@ func (m *Manager) deployControlPlane(ctx context.Context, instanceName string, c
 		CPULimit:        "1000m",
 		MemoryLimit:     "1Gi",
 		StorageSize:     "10Gi",
-		APIPort:         80,
-		AdminPort:       int32(opts.AdminPort),
+		APIPort:         resources.ControlPlaneInternalAPIPort,
+		AdminPort:       resources.ControlPlaneInternalAdminPort,
 		LogLevel:        cfg.Server.LogLevel,
 	}
 

--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -36,6 +36,10 @@ const (
 	LabelComponent = "kecs.dev/component"
 	LabelType      = "kecs.dev/type"
 	LabelApp       = "app"
+
+	// Internal ports - Control plane always listens on these ports inside the container
+	ControlPlaneInternalAPIPort   = 5373
+	ControlPlaneInternalAdminPort = 5374
 )
 
 // ControlPlaneResources contains all resources needed for the control plane
@@ -87,8 +91,8 @@ func DefaultControlPlaneConfig() *ControlPlaneConfig {
 		CPULimit:        "1000m",
 		MemoryLimit:     "1Gi",
 		StorageSize:     "10Gi",
-		APIPort:         80,
-		AdminPort:       5374,
+		APIPort:         ControlPlaneInternalAPIPort,
+		AdminPort:       ControlPlaneInternalAdminPort,
 		LogLevel:        "info",
 	}
 }
@@ -319,7 +323,7 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 					{
 						Name:       "http",
 						Port:       config.APIPort,
-						TargetPort: intstr.FromInt(5373),
+						TargetPort: intstr.FromInt(ControlPlaneInternalAPIPort),
 						Protocol:   corev1.ProtocolTCP,
 						NodePort:   30080, // Fixed NodePort for external access
 					},
@@ -346,7 +350,7 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 					{
 						Name:       "admin",
 						Port:       config.AdminPort,
-						TargetPort: intstr.FromInt(int(config.AdminPort)),
+						TargetPort: intstr.FromInt(ControlPlaneInternalAdminPort),
 						Protocol:   corev1.ProtocolTCP,
 						NodePort:   30081, // Fixed NodePort for admin API
 					},
@@ -373,7 +377,7 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 					{
 						Name:       "admin",
 						Port:       config.AdminPort,
-						TargetPort: intstr.FromInt(int(config.AdminPort)),
+						TargetPort: intstr.FromInt(ControlPlaneInternalAdminPort),
 						Protocol:   corev1.ProtocolTCP,
 					},
 				},
@@ -483,12 +487,12 @@ func createDeployment(config *ControlPlaneConfig) *appsv1.Deployment {
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "api",
-									ContainerPort: 5373,
+									ContainerPort: ControlPlaneInternalAPIPort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 								{
 									Name:          "admin",
-									ContainerPort: int32(config.AdminPort),
+									ContainerPort: ControlPlaneInternalAdminPort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},


### PR DESCRIPTION
## Summary
- Fixed control plane health check failures caused by incorrect port configuration
- Ensured control plane uses correct internal ports (API: 5373, Admin: 5374)

## Problem
The control plane's startup probe was failing with "connection refused" errors because the port configuration was incorrectly using host ports as container ports.

## Solution
This fix ensures:
- Control plane API always listens on port 5373 internally
- Control plane Admin always listens on port 5374 internally
- Services correctly target these fixed internal ports
- Container ports are properly configured to match the actual listening ports

## Test Plan
- [x] Built and tested locally with hot-reload
- [x] Verified control plane pod becomes ready (1/1) without restarts
- [x] Confirmed health checks pass successfully
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)