### PR TITLE
fix: Fix controlplane crash when running inside Kubernetes cluster

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_ecs_api.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api.go
@@ -864,6 +864,12 @@ func (api *DefaultECSAPI) deployLocalStackIfEnabled(cluster *storage.Cluster) {
 		// If in-cluster fails, try using cluster manager (for local development)
 		logging.Debug("In-cluster config failed (expected in local development)", "error", err)
 
+		// Check if cluster manager is available
+		if api.clusterManager == nil {
+			logging.Error("Neither in-cluster config nor cluster manager available")
+			return
+		}
+
 		// Get Kubernetes client for the specific k3d cluster
 		client, err := api.clusterManager.GetKubeClient(ctx, cluster.K8sClusterName)
 		if err != nil {

--- a/controlplane/internal/kubernetes/cluster_manager.go
+++ b/controlplane/internal/kubernetes/cluster_manager.go
@@ -2,13 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"os"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	appconfig "github.com/nandemo-ya/kecs/controlplane/internal/config"
-	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
 )
 
 // ClusterManager defines the interface for managing local Kubernetes clusters
@@ -108,35 +104,12 @@ type VolumeMount struct {
 	ContainerPath string `json:"containerPath"`
 }
 
-// NewClusterManager creates a new cluster manager based on the configuration
+// NewClusterManager is deprecated and should not be used.
+// K3d cluster manager has been moved to host/k3d package.
+// For host-side operations (TUI, CLI), use host/k3d.NewK3dClusterManager.
+// For cluster-internal operations (control plane), use in-cluster config directly.
+//
+// Deprecated: This function will panic if called. Use host/k3d package instead.
 func NewClusterManager(config *ClusterManagerConfig) (ClusterManager, error) {
-	if config == nil {
-		config = &ClusterManagerConfig{}
-	}
-
-	// Detect CI environment and enable test mode
-	if os.Getenv("GITHUB_ACTIONS") == "true" || os.Getenv("CI") == "true" {
-		config.TestMode = true
-		logging.Info("CI environment detected, enabling test mode")
-	}
-
-	// k3d is the only supported provider now
-	config.Provider = "k3d"
-
-	// Use Viper config which handles environment variables
-	viperConfig := appconfig.GetConfig()
-
-	// Set container mode from app config if not explicitly set
-	if !config.ContainerMode && viperConfig.Features.ContainerMode {
-		config.ContainerMode = true
-	}
-
-	// Set kubeconfig path from app config if not specified
-	if config.KubeconfigPath == "" {
-		config.KubeconfigPath = viperConfig.Kubernetes.KubeconfigPath
-	}
-
-	// K3d cluster manager has been moved to host/k3d package
-	// This should not be used from within the cluster
-	panic("ClusterManager should not be used from within Kubernetes cluster. Use host/k3d package for host-side operations.")
+	panic("NewClusterManager is deprecated. Use host/k3d.NewK3dClusterManager for host-side operations.")
 }


### PR DESCRIPTION
## Summary
- Fixes controlplane crash that prevented it from starting inside Kubernetes cluster
- Removes unnecessary ClusterManager initialization for in-cluster deployments
- Fixes TUI ECS cluster creation error caused by controlplane not being available

## Problem
When the controlplane was deployed inside a Kubernetes cluster (normal operation), it was trying to initialize a ClusterManager and panicking with:
```
panic: ClusterManager should not be used from within Kubernetes cluster. Use host/k3d package for host-side operations.
```

This caused:
1. Controlplane pods to be in CrashLoopBackOff state
2. TUI ECS cluster creation to fail with "connection reset by peer" error
3. API endpoints to be unavailable

## Solution
1. **Remove ClusterManager initialization in controlplane**: The control plane runs inside Kubernetes and should use in-cluster config, not ClusterManager
2. **Add helper methods**: Created `getKubeClient` and `getKubeConfig` that gracefully handle nil ClusterManager by using in-cluster config
3. **Update all ClusterManager calls**: Replaced direct calls with helper methods that work both with and without ClusterManager
4. **Deprecate NewClusterManager**: Marked as deprecated with clear migration path to host/k3d package

## Changes
- Modified `api/server.go` to skip ClusterManager initialization when running inside cluster
- Added `getKubeClient` and `getKubeConfig` helper methods in `task_helpers.go`
- Updated all direct ClusterManager calls to use helper methods
- Added nil checks in `cluster_ecs_api.go`
- Deprecated `NewClusterManager` function with clear documentation

## Test Results
- ✅ Controlplane starts successfully and reaches Ready state
- ✅ CreateCluster API works correctly
- ✅ TUI can create ECS clusters without errors
- ✅ All unit tests pass

## Testing
```bash
# Test API directly
curl -X POST http://localhost:5383/v1/CreateCluster -H "Content-Type: application/x-amz-json-1.1" -d '{"clusterName":"test-cluster"}'

# Check pod status
kubectl get pods -n kecs-system
```

🤖 Generated with Claude Code