### PR TITLE
fix: Improve TUI log viewer and task display functionality

### DIFF
--- a/controlplane/internal/controlplane/admin/logs_api.go
+++ b/controlplane/internal/controlplane/admin/logs_api.go
@@ -65,7 +65,7 @@ func (api *LogsAPI) HandleGetLogs(w http.ResponseWriter, r *http.Request) {
 	taskId := vars["taskId"]
 	containerName := vars["containerName"]
 
-	logging.Debug("HandleGetLogs called",
+	logging.Info("HandleGetLogs called",
 		"taskId", taskId,
 		"containerName", containerName,
 		"url", r.URL.String())
@@ -157,6 +157,10 @@ func (api *LogsAPI) HandleGetLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If no logs in storage, try to get from Kubernetes directly
+	logging.Info("Checking Kubernetes for logs",
+		"storageLogsCount", len(logs),
+		"hasKubeClient", api.kubeClient != nil,
+		"hasPodLogService", api.podLogService != nil)
 	if len(logs) == 0 && api.kubeClient != nil && api.podLogService != nil {
 		// If we didn't get pod info from storage, parse task ARN or use taskId as pod name
 		if namespace == "" || podName == "" {

--- a/controlplane/internal/controlplane/admin/server.go
+++ b/controlplane/internal/controlplane/admin/server.go
@@ -126,11 +126,13 @@ func (s *Server) setupRoutes() http.Handler {
 	router.HandleFunc("/config", s.handleConfig).Methods("GET")
 
 	// Register TUI API endpoints
-	if s.instanceAPI != nil {
-		s.instanceAPI.RegisterRoutes(router)
-	}
+	// IMPORTANT: ECS Proxy must be registered before instance API
+	// to ensure specific routes are matched before generic ones
 	if s.ecsProxy != nil {
 		s.ecsProxy.RegisterRoutes(router)
+	}
+	if s.instanceAPI != nil {
+		s.instanceAPI.RegisterRoutes(router)
 	}
 
 	// Register Logs API endpoints

--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -113,10 +113,21 @@ func (m Model) loadDataFromAPI() tea.Cmd {
 			}
 		}
 
-		// Load tasks if service is selected
+		// Load tasks - either for selected service or all tasks in cluster
 		var tuiTasks []Task
-		if m.selectedInstance != "" && m.selectedCluster != "" && m.selectedService != "" {
-			taskArns, err := m.apiClient.ListTasks(ctx, m.selectedInstance, m.selectedCluster, m.selectedService)
+		if m.selectedInstance != "" && m.selectedCluster != "" {
+			var taskArns []string
+			var err error
+
+			// If service is selected, get tasks for that service
+			// Otherwise, get all tasks in the cluster
+			if m.selectedService != "" {
+				taskArns, err = m.apiClient.ListTasks(ctx, m.selectedInstance, m.selectedCluster, m.selectedService)
+			} else {
+				// Get all tasks in cluster by passing empty service name
+				taskArns, err = m.apiClient.ListTasks(ctx, m.selectedInstance, m.selectedCluster, "")
+			}
+
 			if err == nil && len(taskArns) > 0 {
 				tasks, err := m.apiClient.DescribeTasks(ctx, m.selectedInstance, m.selectedCluster, taskArns)
 				if err == nil {


### PR DESCRIPTION
## Summary
- Fixed TUI log viewer to properly display logs from tasks
- Added task list endpoints to admin API for TUI integration  
- Improved task display in TUI to show all cluster tasks when no service is selected

## Changes
- Add `handleListTasks` endpoint to ECS proxy for `GET /api/instances/{name}/tasks`
- Add `handleDescribeTasks` endpoint for task descriptions
- Fix route registration order to prevent generic POST endpoint from catching specific routes
- Enable TUI to display all tasks in cluster when no service is selected
- Add debug logging to logs API for better troubleshooting
- Fix `parseTaskArn` to handle pod names directly, not just task ARNs

## Test plan
- [x] Created test task with RunTask API
- [x] Verified logs can be retrieved via API (port 5384)
- [x] Created kecs-tui-test CLI tool for testing (#564)
- [x] Confirmed logs display correctly with test tool
- [ ] TUI displays tasks in cluster view
- [ ] TUI log viewer shows logs when task selected

## Related Issues
- Continues work from #564 (TUI log viewer debugging)

🤖 Generated with [Claude Code](https://claude.ai/code)