### PR TITLE
feat: Add cluster-level tasks view in TUI

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -849,6 +849,15 @@ func (m Model) handleInstancesKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.taskDefFamilyCursor = 0
 			return m, m.loadTaskDefinitionFamiliesCmd()
 		}
+	case "T":
+		// Navigate to all tasks in cluster (uppercase T)
+		if m.selectedInstance != "" && m.selectedCluster != "" {
+			m.currentView = ViewTasks
+			m.taskCursor = 0
+			// Clear service selection to show all cluster tasks
+			m.selectedService = ""
+			return m, m.loadDataFromAPI()
+		}
 	case "/":
 		m.searchMode = true
 		m.searchQuery = ""
@@ -929,6 +938,15 @@ func (m Model) handleClustersKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.currentView = ViewTaskDefinitionFamilies
 			m.taskDefFamilyCursor = 0
 			return m, m.loadTaskDefinitionFamiliesCmd()
+		}
+	case "T":
+		// Navigate to all tasks in selected cluster (uppercase T)
+		if m.selectedInstance != "" && m.selectedCluster != "" {
+			m.currentView = ViewTasks
+			m.taskCursor = 0
+			// Clear service selection to show all cluster tasks
+			m.selectedService = ""
+			return m, m.loadDataFromAPI()
 		}
 	}
 	return m, nil
@@ -1098,6 +1116,16 @@ func (m Model) handleTasksKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case "c":
 		m.currentView = ViewClusters
 		m.selectedCluster = ""
+	case "esc", "b":
+		// Go back to previous view
+		if m.selectedService != "" {
+			// If we came from services view, go back to services
+			m.currentView = ViewServices
+		} else {
+			// If we came from clusters view (showing all tasks), go back to clusters
+			m.currentView = ViewClusters
+		}
+		m.selectedTask = ""
 	case "s":
 		m.currentView = ViewServices
 		m.selectedService = ""

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -110,6 +110,7 @@ func (m Model) getHeaderShortcuts() string {
 		shortcuts = []string{
 			keyStyle.Render("<↵>") + sepStyle.Render(" Select"),
 			keyStyle.Render("<n>") + sepStyle.Render(" Create"),
+			keyStyle.Render("<T>") + sepStyle.Render(" Tasks"),
 			keyStyle.Render("<ESC>") + sepStyle.Render(" Back"),
 			keyStyle.Render("<:>") + sepStyle.Render(" Cmd"),
 			keyStyle.Render("<?>") + sepStyle.Render(" Help"),
@@ -229,8 +230,15 @@ func (m Model) renderBreadcrumb() string {
 
 	if m.selectedService != "" {
 		parts = append(parts, ">", m.selectedService)
+	}
 
-		if m.currentView == ViewTasks {
+	// Show Tasks breadcrumb whether service is selected or not
+	if m.currentView == ViewTasks {
+		if m.selectedService == "" {
+			// Showing all tasks in cluster
+			parts = append(parts, ">", "[All Tasks]")
+		} else {
+			// Showing tasks for specific service
 			parts = append(parts, ">", "[Tasks]")
 		}
 	}
@@ -523,19 +531,25 @@ func (m Model) renderSummary() string {
 		}
 
 	case ViewTasks:
-		if m.selectedService != "" {
-			running := 0
-			healthy := 0
-			for _, task := range m.tasks {
-				if task.Status == "RUNNING" {
-					running++
-					if task.Health == "HEALTHY" {
-						healthy++
-					}
+		running := 0
+		healthy := 0
+		for _, task := range m.tasks {
+			if task.Status == "RUNNING" {
+				running++
+				if task.Health == "HEALTHY" {
+					healthy++
 				}
 			}
+		}
+
+		if m.selectedService != "" {
+			// Tasks for specific service
 			summary = fmt.Sprintf("Service: %s | Tasks: %d | Running: %d | Healthy: %d",
 				m.selectedService, len(m.tasks), running, healthy)
+		} else {
+			// All tasks in cluster
+			summary = fmt.Sprintf("Cluster: %s | All Tasks: %d | Running: %d | Healthy: %d",
+				m.selectedCluster, len(m.tasks), running, healthy)
 		}
 
 	case ViewLogs:
@@ -1277,6 +1291,7 @@ func (m Model) renderShortcutsColumn(width, height int) string {
 			keyStyle.Render("<i>")+" "+descStyle.Render("Instances"),
 			keyStyle.Render("<s>")+" "+descStyle.Render("Services"),
 			keyStyle.Render("<t>")+" "+descStyle.Render("Task defs"),
+			keyStyle.Render("<T>")+" "+descStyle.Render("All tasks"),
 		)
 	case ViewServices:
 		leftShortcuts = append(leftShortcuts,
@@ -1291,6 +1306,7 @@ func (m Model) renderShortcutsColumn(width, height int) string {
 		leftShortcuts = append(leftShortcuts,
 			keyStyle.Render("<enter>")+" "+descStyle.Render("Describe"),
 			keyStyle.Render("<l>")+" "+descStyle.Render("Logs"),
+			keyStyle.Render("<esc>")+" "+descStyle.Render("Back"),
 			keyStyle.Render("<t>")+" "+descStyle.Render("Task defs"),
 		)
 	case ViewLogs:


### PR DESCRIPTION
  ## Summary
  - Add cluster-level tasks view in TUI for viewing all tasks in a cluster
  - Press `T` key (uppercase) to show all tasks in the selected cluster
  - Enables visibility of standalone tasks created via RunTask API

  ## Changes
  - Add `T` key handler in cluster view to navigate to all tasks
  - Show `[All Tasks]` in breadcrumb to distinguish from service-specific task views
  - Implement navigation back to cluster view with `esc` or `b` keys
  - Maintain backward compatibility with existing service → tasks navigation

  ## Motivation
  Tasks created with RunTask API are not associated with any service, making them invisible through the traditional service-based navigation. This feature provides direct access to view
  all tasks in a cluster, including standalone tasks.

  ## Test plan
  1. Run `make dev` for hot reload
  2. Navigate to cluster view in TUI
  3. Press `T` key to view all tasks
  4. Select a task and press `l` to view logs
  5. Press `esc` or `b` to return to cluster view

  🤖 Generated with [Claude Code](https://claude.ai/code)