### PR TITLE
fix: Fix All Tasks view in TUI to properly display tasks

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -851,13 +851,8 @@ func (m Model) handleInstancesKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 	case "T":
 		// Navigate to all tasks in cluster (uppercase T)
-		if m.selectedInstance != "" && m.selectedCluster != "" {
-			m.currentView = ViewTasks
-			m.taskCursor = 0
-			// Clear service selection to show all cluster tasks
-			m.selectedService = ""
-			return m, m.loadDataFromAPI()
-		}
+		// This key is not valid from instances view since no cluster is selected
+		// User must first navigate to a cluster
 	case "/":
 		m.searchMode = true
 		m.searchQuery = ""
@@ -941,12 +936,18 @@ func (m Model) handleClustersKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 	case "T":
 		// Navigate to all tasks in selected cluster (uppercase T)
-		if m.selectedInstance != "" && m.selectedCluster != "" {
-			m.currentView = ViewTasks
-			m.taskCursor = 0
-			// Clear service selection to show all cluster tasks
-			m.selectedService = ""
-			return m, m.loadDataFromAPI()
+		if m.selectedInstance != "" && len(m.clusters) > 0 {
+			// Select current cluster if not already selected
+			if m.selectedCluster == "" && m.clusterCursor < len(m.clusters) {
+				m.selectedCluster = m.clusters[m.clusterCursor].Name
+			}
+			if m.selectedCluster != "" {
+				m.currentView = ViewTasks
+				m.taskCursor = 0
+				// Clear service selection to show all cluster tasks
+				m.selectedService = ""
+				return m, m.loadDataFromAPI()
+			}
 		}
 	}
 	return m, nil

--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -133,12 +133,36 @@ func (m Model) loadDataFromAPI() tea.Cmd {
 				if err == nil {
 					tuiTasks = make([]Task, len(tasks))
 					for i, task := range tasks {
+						// Extract service name from task if available
+						serviceName := ""
+						if task.ServiceName != "" {
+							serviceName = task.ServiceName
+						} else if m.selectedService != "" {
+							serviceName = m.selectedService
+						}
+
+						// Determine health status
+						health := "UNKNOWN"
+						if task.HealthStatus != "" {
+							health = task.HealthStatus
+						} else if task.LastStatus == "RUNNING" {
+							health = "HEALTHY" // Assume healthy if running
+						}
+
+						// Extract IP if available
+						ip := ""
+						// For now, we don't have IP information in the API response
+						// This would need to be added to the API response
+
 						tuiTasks[i] = Task{
-							ID:     extractTaskID(task.TaskArn),
-							Status: task.LastStatus,
-							CPU:    parseCPU(task.Cpu),
-							Memory: task.Memory,
-							Age:    time.Since(task.CreatedAt),
+							ID:      extractTaskID(task.TaskArn),
+							Service: serviceName,
+							Status:  task.LastStatus,
+							Health:  health,
+							CPU:     parseCPU(task.Cpu),
+							Memory:  task.Memory,
+							IP:      ip,
+							Age:     time.Since(task.CreatedAt),
 						}
 					}
 				}

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -1082,11 +1082,11 @@ func (m Model) renderServicesList(maxHeight int) string {
 
 // renderTasksList renders the tasks list with the given height constraint
 func (m Model) renderTasksList(maxHeight int) string {
-	if m.selectedInstance == "" || m.selectedCluster == "" || m.selectedService == "" {
+	if m.selectedInstance == "" || m.selectedCluster == "" {
 		return lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#666666")).
 			Italic(true).
-			Render("No service selected. Press 's' to go to services.")
+			Render("No cluster selected.")
 	}
 
 	// Colors for tasks
@@ -1144,6 +1144,21 @@ func (m Model) renderTasksList(maxHeight int) string {
 
 	// Get filtered tasks
 	filteredTasks := m.filterTasks(m.tasks)
+
+	// If no tasks, show appropriate message
+	if len(filteredTasks) == 0 {
+		emptyMsg := ""
+		if m.selectedService == "" {
+			emptyMsg = "No tasks in this cluster. Press 'r' to refresh."
+		} else {
+			emptyMsg = "No tasks for this service. Press 'r' to refresh."
+		}
+		rows = append(rows, lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#666666")).
+			Italic(true).
+			Render(emptyMsg))
+		return strings.Join(rows, "\n")
+	}
 
 	// Calculate visible range with scrolling
 	visibleRows := maxHeight - 2


### PR DESCRIPTION
## Summary
- Fix TUI All Tasks view to properly display tasks when accessed via 'T' key
- Fix 'T' key handler to work correctly from cluster view
- Add proper handling for empty task lists

## Changes
- Fix `renderTasksList` to show tasks when no service is selected (All Tasks view)
- Add empty task list handling with appropriate messages
- Include Service and Health fields in Task struct when loading from API
- Fix 'T' key handler to auto-select current cluster when navigating

## Problem
When viewing All Tasks via the 'T' key from cluster view, tasks were not displayed even though the summary showed "All Tasks: 1 | Running: 1". The list showed "No service selected" message instead of the actual tasks.

## Solution
- Modified the render logic to handle the case where no service is selected (All Tasks view)
- Added proper task field population when loading from API
- Fixed the 'T' key handler to ensure cluster is selected before navigation

## Test plan
1. Start KECS TUI
2. Navigate to a cluster 
3. Press 'T' to view all tasks in the cluster
4. Verify tasks are displayed correctly
5. Press 'l' to view logs for a selected task
6. Press 'esc' or 'b' to navigate back

🤖 Generated with [Claude Code](https://claude.ai/code)