### PR TITLE
fix: Add webhook RBAC permissions to controlplane ClusterRole

### DIFF
--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -198,6 +198,12 @@ func createClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{"pods", "nodes"},
 				Verbs:     []string{"get", "list"},
 			},
+			// Admission webhooks
+			{
+				APIGroups: []string{"admissionregistration.k8s.io"},
+				Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `admissionregistration.k8s.io` permissions to the controlplane ClusterRole
- Enables dynamic creation and management of MutatingWebhookConfiguration at runtime
- Fixes "User cannot create resource mutatingwebhookconfigurations" error on startup

## Problem
After merging PR #568 which added the Mutating Admission Webhook feature, the controlplane logs showed an RBAC permission error when attempting to register the webhook configuration on startup.

## Solution
Added the necessary permissions for webhook management to the ClusterRole that is dynamically created when controlplane starts. This allows the webhook to be properly registered for automatic task ID assignment to service-managed pods.

## Test plan
- [x] Build and deploy changes with `make dev`
- [x] Verify no permission errors in controlplane logs
- [x] Confirm MutatingWebhookConfiguration is created successfully
- [x] Test that service-managed pods receive task IDs automatically

🤖 Generated with [Claude Code](https://claude.ai/code)