### PR TITLE
fix: Add webhook service and port to controlplane deployment

### DIFF
--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -364,6 +364,32 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 				Type: corev1.ServiceTypeNodePort,
 			},
 		},
+		// Webhook Service
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kecs-webhook",
+				Namespace: ControlPlaneNamespace,
+				Labels: map[string]string{
+					LabelManagedBy: "true",
+					LabelComponent: "controlplane",
+					LabelType:      "webhook",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					LabelApp: ControlPlaneName,
+				},
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "webhook",
+						Port:       443,
+						TargetPort: intstr.FromInt(9443),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+				Type: corev1.ServiceTypeClusterIP,
+			},
+		},
 		// Legacy Admin Service (ClusterIP for backward compatibility)
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -499,6 +525,11 @@ func createDeployment(config *ControlPlaneConfig) *appsv1.Deployment {
 								{
 									Name:          "admin",
 									ContainerPort: ControlPlaneInternalAdminPort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "webhook",
+									ContainerPort: 9443,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},


### PR DESCRIPTION
## Summary
- Add kecs-webhook Service to expose the mutating webhook server
- Add webhook container port (9443) to the controlplane Deployment
- Fixes issue where service-managed pods were not getting `kecs.dev/task-id` labels

## Problem
The webhook server was running in the controlplane container but was not accessible because:
1. No Kubernetes Service was created to expose the webhook port
2. The container port was not declared in the Deployment spec

This caused the MutatingWebhookConfiguration to fail when trying to call the webhook, preventing automatic task ID assignment to pods.

## Solution
Added the missing webhook Service and container port configuration to `controlplane.go`:
- Service: `kecs-webhook` exposing port 443 → targetPort 9443
- Container port: 9443 for the webhook server

## Test plan
- [x] Build and deploy the updated controlplane
- [x] Verify webhook service is created in kecs-system namespace
- [x] Deploy a test service (nginx-with-log-generator)
- [x] Confirm pods receive `kecs.dev/task-id` labels

🤖 Generated with [Claude Code](https://claude.ai/code)