### PR TITLE
fix: Fix TUI log viewer to display actual Kubernetes pod logs

### DIFF
--- a/controlplane/internal/controlplane/admin/logs_api.go
+++ b/controlplane/internal/controlplane/admin/logs_api.go
@@ -1,10 +1,12 @@
 package admin
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +17,7 @@ import (
 	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
 	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
 )
@@ -57,6 +60,8 @@ func (api *LogsAPI) RegisterRoutes(router *mux.Router) {
 	router.HandleFunc("/api/tasks/{taskId}/containers/{containerName}/logs", api.HandleGetLogs).Methods("GET")
 	router.HandleFunc("/api/tasks/{taskId}/containers/{containerName}/logs/stream", api.HandleStreamLogs).Methods("GET")
 	router.HandleFunc("/api/tasks/{taskId}/containers/{containerName}/logs/ws", api.HandleWebSocketLogs).Methods("GET")
+	// Add /v1/GetTaskLogs endpoint for KECS TUI
+	router.HandleFunc("/v1/GetTaskLogs", api.HandleGetTaskLogs).Methods("POST")
 	logging.Info("Log API endpoints registered successfully")
 }
 
@@ -596,4 +601,316 @@ func extractPodInfoFromTaskAttributes(task *storage.Task) (namespace, podName st
 	}
 
 	return namespace, podName
+}
+
+// GetTaskLogsRequest represents the request for getting task logs
+type GetTaskLogsRequest struct {
+	Cluster    string `json:"cluster"`
+	TaskArn    string `json:"taskArn"`
+	Follow     bool   `json:"follow,omitempty"`
+	Timestamps bool   `json:"timestamps,omitempty"`
+	Since      string `json:"since,omitempty"`
+	Tail       *int64 `json:"tail,omitempty"`
+}
+
+// GetTaskLogsResponse represents the response for getting task logs
+type GetTaskLogsResponse struct {
+	Logs []TaskLogEntry `json:"logs"`
+}
+
+// TaskLogEntry represents a single log entry
+type TaskLogEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Level     string    `json:"level"`
+	Message   string    `json:"message"`
+	Container string    `json:"container,omitempty"`
+}
+
+// HandleGetTaskLogs handles the /v1/GetTaskLogs API request
+func (api *LogsAPI) HandleGetTaskLogs(w http.ResponseWriter, r *http.Request) {
+	var req GetTaskLogsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.sendError(w, http.StatusBadRequest, "InvalidParameterValue", "Invalid request body")
+		return
+	}
+
+	// Extract task ID from ARN
+	taskID := extractTaskIDFromArn(req.TaskArn)
+	if taskID == "" {
+		api.sendError(w, http.StatusBadRequest, "InvalidParameterValue", "Invalid task ARN")
+		return
+	}
+
+	// Get task from storage to validate it exists
+	ctx := r.Context()
+	if api.storage != nil && api.storage.TaskStore() != nil {
+		clusterArn := fmt.Sprintf("arn:aws:ecs:us-east-1:000000000000:cluster/%s", req.Cluster)
+		_, err := api.storage.TaskStore().Get(ctx, clusterArn, taskID)
+		if err != nil {
+			api.sendError(w, http.StatusNotFound, "ResourceNotFoundException", fmt.Sprintf("Task not found: %s", taskID))
+			return
+		}
+	}
+
+	// Get Kubernetes client
+	if api.kubeClient == nil {
+		logging.Error("Kubernetes client not initialized")
+		api.sendError(w, http.StatusInternalServerError, "InternalError", "Failed to connect to Kubernetes")
+		return
+	}
+
+	// Extract namespace and pod name from task ARN
+	namespace, podName := extractNamespaceAndPodName(req.TaskArn)
+
+	logging.Debug("Fetching logs for task",
+		"taskArn", req.TaskArn,
+		"namespace", namespace,
+		"podName", podName)
+
+	// Get pod logs
+	logs, err := api.getPodLogs(ctx, namespace, podName, req)
+	if err != nil {
+		logging.Error("Failed to get pod logs", "pod", podName, "error", err)
+		api.sendError(w, http.StatusInternalServerError, "InternalError", fmt.Sprintf("Failed to get logs: %v", err))
+		return
+	}
+
+	// Send response
+	response := GetTaskLogsResponse{
+		Logs: logs,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logging.Error("Failed to encode response", "error", err)
+	}
+}
+
+// getPodLogs retrieves logs from a Kubernetes pod
+func (api *LogsAPI) getPodLogs(ctx context.Context, namespace, podName string, req GetTaskLogsRequest) ([]TaskLogEntry, error) {
+	// In KECS, the podName passed here is actually the task ID
+	// We need to find the pod by the kecs.dev/task-id label
+	var pod *corev1.Pod
+
+	// Try to find by task-id label first (most common case)
+	logging.Debug("Looking for pod by task-id label",
+		"namespace", namespace,
+		"taskId", podName)
+
+	labelSelector := fmt.Sprintf("kecs.dev/task-id=%s", podName)
+	pods, err := api.kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+
+	if err == nil && len(pods.Items) > 0 {
+		pod = &pods.Items[0]
+		logging.Debug("Found pod by task-id label",
+			"podName", pod.Name,
+			"taskId", podName)
+	} else {
+		// Fallback: try to get the pod directly by name
+		directPod, directErr := api.kubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if directErr == nil {
+			pod = directPod
+			logging.Debug("Found pod by direct name",
+				"podName", pod.Name)
+		} else {
+			// Last attempt: find pod with matching name pattern
+			allPods, listErr := api.kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+			if listErr != nil {
+				return nil, fmt.Errorf("failed to list pods: %w", listErr)
+			}
+
+			// Find pod that contains the task ID or matches the pattern
+			for _, p := range allPods.Items {
+				if p.Name == podName || strings.Contains(p.Name, podName) {
+					pod = &p
+					logging.Debug("Found pod by name pattern",
+						"podName", p.Name,
+						"pattern", podName)
+					break
+				}
+			}
+
+			if pod == nil {
+				return nil, fmt.Errorf("pod not found for task: %s in namespace %s", podName, namespace)
+			}
+		}
+	}
+
+	logging.Debug("Found pod for logs",
+		"podName", pod.Name,
+		"namespace", pod.Namespace,
+		"containerCount", len(pod.Spec.Containers))
+
+	// Build pod log options
+	opts := &corev1.PodLogOptions{
+		Timestamps: req.Timestamps,
+		Follow:     req.Follow,
+	}
+
+	if req.Tail != nil {
+		opts.TailLines = req.Tail
+	}
+
+	if req.Since != "" {
+		// Parse duration (e.g., "5m", "1h")
+		duration, err := time.ParseDuration(req.Since)
+		if err == nil {
+			sinceSeconds := int64(duration.Seconds())
+			opts.SinceSeconds = &sinceSeconds
+		}
+	}
+
+	var allLogs []TaskLogEntry
+
+	// Get logs from each container
+	for _, container := range pod.Spec.Containers {
+		opts.Container = container.Name
+
+		// Get log stream
+		logReq := api.kubeClient.CoreV1().Pods(namespace).GetLogs(pod.Name, opts)
+		stream, err := logReq.Stream(ctx)
+		if err != nil {
+			logging.Warn("Failed to get logs for container", "container", container.Name, "error", err)
+			continue
+		}
+		defer stream.Close()
+
+		// Parse logs
+		scanner := bufio.NewScanner(stream)
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Parse log entry
+			entry := api.parseLogLine(line, container.Name, req.Timestamps)
+			allLogs = append(allLogs, entry)
+
+			// For follow mode, we'd need to handle this differently (e.g., SSE or WebSocket)
+			if req.Follow {
+				// TODO: Implement streaming logs
+				break
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			logging.Warn("Error reading logs", "container", container.Name, "error", err)
+		}
+	}
+
+	// Sort logs by timestamp for multi-container tasks
+	api.sortLogsByTimestamp(allLogs)
+
+	return allLogs, nil
+}
+
+// parseLogLine parses a log line into a TaskLogEntry
+func (api *LogsAPI) parseLogLine(line, containerName string, hasTimestamp bool) TaskLogEntry {
+	entry := TaskLogEntry{
+		Timestamp: time.Now(),
+		Level:     "INFO",
+		Message:   line,
+		Container: containerName,
+	}
+
+	// If timestamps are included, parse them
+	if hasTimestamp {
+		// Kubernetes log format with timestamp: "2025-01-08T10:30:45.123456789Z message"
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) >= 2 {
+			if t, err := time.Parse(time.RFC3339Nano, parts[0]); err == nil {
+				entry.Timestamp = t
+				entry.Message = parts[1]
+			}
+		}
+	}
+
+	// Determine log level from message content
+	lowerMsg := strings.ToLower(entry.Message)
+	if strings.Contains(lowerMsg, "error") || strings.Contains(lowerMsg, "fatal") || strings.Contains(lowerMsg, "panic") {
+		entry.Level = "ERROR"
+	} else if strings.Contains(lowerMsg, "warn") || strings.Contains(lowerMsg, "warning") {
+		entry.Level = "WARN"
+	} else if strings.Contains(lowerMsg, "debug") || strings.Contains(lowerMsg, "trace") {
+		entry.Level = "DEBUG"
+	}
+
+	return entry
+}
+
+// extractTaskIDFromArn extracts the task ID from a task ARN
+func extractTaskIDFromArn(arn string) string {
+	// ARN format: arn:aws:ecs:region:account:task/cluster-name/task-id
+	// or just task-id
+	parts := strings.Split(arn, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return arn
+}
+
+// extractNamespaceAndPodName extracts namespace and pod name from a task ARN
+func extractNamespaceAndPodName(arn string) (namespace, podName string) {
+	// KECS Task ARN format: arn:aws:ecs:region:account:task/cluster/task-id
+	// Example: arn:aws:ecs:us-east-1:000000000000:task/default/83ac405d374b412b97f64facff832a33
+	//
+	// In KECS, namespace is derived from cluster name and region
+	// namespace = "{cluster}-{region}" (e.g., "default-us-east-1")
+
+	// Extract region from ARN
+	var region string
+	if strings.HasPrefix(arn, "arn:aws:ecs:") {
+		arnParts := strings.Split(arn, ":")
+		if len(arnParts) >= 4 {
+			region = arnParts[3] // region is the 4th part
+		}
+	}
+
+	// Default region if not found
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	// Extract the part after "task/"
+	parts := strings.Split(arn, "task/")
+	if len(parts) < 2 {
+		// Fallback to default namespace and use the whole ARN as task ID
+		return fmt.Sprintf("default-%s", region), arn
+	}
+
+	// Split by "/" to get cluster and task ID
+	taskParts := strings.Split(parts[1], "/")
+	if len(taskParts) >= 2 {
+		// taskParts[0] is the cluster name (e.g., "default")
+		// taskParts[1] is the task ID (e.g., "83ac405d374b412b97f64facff832a33")
+		cluster := taskParts[0]
+		taskID := taskParts[1]
+		// Construct namespace from cluster and region
+		namespace = fmt.Sprintf("%s-%s", cluster, region)
+		return namespace, taskID
+	}
+
+	// If only one part, assume default cluster
+	if len(taskParts) == 1 {
+		return fmt.Sprintf("default-%s", region), taskParts[0]
+	}
+
+	return fmt.Sprintf("default-%s", region), arn
+}
+
+// sortLogsByTimestamp sorts log entries by timestamp
+func (api *LogsAPI) sortLogsByTimestamp(logs []TaskLogEntry) {
+	sort.Slice(logs, func(i, j int) bool {
+		return logs[i].Timestamp.Before(logs[j].Timestamp)
+	})
+}
+
+// sendError sends an error response in AWS ECS API format
+func (api *LogsAPI) sendError(w http.ResponseWriter, statusCode int, errorType, message string) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(map[string]string{
+		"__type":  errorType,
+		"message": message,
+	})
 }

--- a/controlplane/internal/tui/commands.go
+++ b/controlplane/internal/tui/commands.go
@@ -154,15 +154,23 @@ func (m Model) loadDataFromAPI() tea.Cmd {
 						// For now, we don't have IP information in the API response
 						// This would need to be added to the API response
 
+						// Extract container names
+						var containerNames []string
+						for _, container := range task.Containers {
+							containerNames = append(containerNames, container.Name)
+						}
+
 						tuiTasks[i] = Task{
-							ID:      extractTaskID(task.TaskArn),
-							Service: serviceName,
-							Status:  task.LastStatus,
-							Health:  health,
-							CPU:     parseCPU(task.Cpu),
-							Memory:  task.Memory,
-							IP:      ip,
-							Age:     time.Since(task.CreatedAt),
+							ID:         extractTaskID(task.TaskArn),
+							ARN:        task.TaskArn,
+							Service:    serviceName,
+							Status:     task.LastStatus,
+							Health:     health,
+							CPU:        parseCPU(task.Cpu),
+							Memory:     task.Memory,
+							IP:         ip,
+							Age:        time.Since(task.CreatedAt),
+							Containers: containerNames,
 						}
 					}
 				}
@@ -713,7 +721,7 @@ func (m Model) viewTaskLogsCmd(taskArn string, containerName string) tea.Cmd {
 			apiClient = NewMockLogAPIClient()
 		} else {
 			// Use real API client with the correct endpoint
-			// Logs API is now on admin port (5374)
+			// Logs API is on the admin port
 			var adminPort int = 5374 // default admin port
 			for _, inst := range m.instances {
 				if inst.Name == m.selectedInstance {


### PR DESCRIPTION
## Summary
- Fixed TUI log viewer to display actual Kubernetes pod logs instead of mock data
- Unified log viewer behavior between task list view and task detail view
- Both views now correctly display logs when pressing 'L' key

## Changes
- Moved `GetTaskLogs` endpoint from API port (5373) to Admin port (5374) for better architectural separation (KECS-specific endpoints should be on Admin port, not AWS ECS-compatible API port)
- Fixed log API client to use correct endpoint with POST method and JSON body
- Added proper Kubernetes client initialization in logs API handler
- Fixed namespace extraction to use `cluster-region` format for KECS pod lookup
- Unified log viewer handling between task list and task detail views
- Fixed LogViewer initialization to properly trigger log loading
- Populated ARN and Containers fields in Task struct for log viewer functionality
- Connected to actual pod logs using `kecs.dev/task-id` label

## Test Plan
- [x] Start KECS instance
- [x] Deploy nginx-with-log-generator example
- [x] Open TUI and navigate to tasks
- [x] Press 'L' on a task in task list view - verify logs display
- [x] Navigate to task details and press 'L' - verify logs display
- [x] Verify logs show actual pod output, not mock data

🤖 Generated with [Claude Code](https://claude.ai/code)