### PR TITLE
cleanup: Remove deprecated KECS_TUI_DEBUG_LOG environment variable

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -3,8 +3,6 @@ package tui
 import (
 	"fmt"
 	"io"
-	"log"
-	"os"
 	"strings"
 	"time"
 
@@ -158,34 +156,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case TaskDefinitionsFetchedMsg:
 		// Handle fetched task definitions and open dialog
-		if msg.Error != nil {
-			// Still show dialog with fallback data if there was an error
-			if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-				if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-					logger := log.New(f, "", log.LstdFlags)
-					logger.Printf("Error fetching task definitions: %v\n", msg.Error)
-					f.Close()
-				}
-			}
-		}
+		// Show dialog even if there was an error (with fallback data)
 		m.serviceUpdateDialog = NewServiceUpdateDialog(msg.ServiceName, msg.CurrentTaskDef, msg.TaskDefs)
 		return m, nil
 	case ServiceUpdatedMsg:
 		// Handle service update completion
 		m.updatingInProgress = false
-
-		// Log the result for debugging
-		if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-			if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-				logger := log.New(f, "", log.LstdFlags)
-				if msg.Success {
-					logger.Printf("Service updated successfully: %s to %s\n", msg.ServiceName, msg.TaskDef)
-				} else {
-					logger.Printf("Service update failed: %v\n", msg.Error)
-				}
-				f.Close()
-			}
-		}
 
 		if msg.Success {
 			// Refresh services to show updated task definition
@@ -198,19 +174,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ServiceScaledMsg:
 		// Handle service scaling completion
 		m.scalingInProgress = false
-
-		// Log the result for debugging
-		if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-			if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-				logger := log.New(f, "", log.LstdFlags)
-				if msg.Success {
-					logger.Printf("Service scaled successfully: %s to %d\n", msg.ServiceName, msg.DesiredCount)
-				} else {
-					logger.Printf("Service scaling failed: %v\n", msg.Error)
-				}
-				f.Close()
-			}
-		}
 
 		if msg.Success {
 			// Refresh services to show updated count

--- a/controlplane/internal/tui/service_scale_handler.go
+++ b/controlplane/internal/tui/service_scale_handler.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"log"
-	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -73,15 +71,6 @@ func (m Model) executeServiceScale() (Model, tea.Cmd) {
 	desiredCount := d.GetDesiredCount()
 	serviceName := d.serviceName
 
-	// Log to file for debugging (optional)
-	if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-		if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-			logger := log.New(f, "", log.LstdFlags)
-			logger.Printf("Scaling service: %s to %d\n", serviceName, desiredCount)
-			f.Close()
-		}
-	}
-
 	// Close dialog and show progress
 	m.serviceScaleDialog = nil
 	m.scalingInProgress = true
@@ -109,16 +98,6 @@ func (m Model) executeServiceScale() (Model, tea.Cmd) {
 // scaleService creates a command to scale the service
 func (m Model) scaleService(serviceNameOrArn string, serviceName string, desiredCount int) tea.Cmd {
 	return func() tea.Msg {
-		// Log to file for debugging (optional)
-		if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-			if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-				logger := log.New(f, "", log.LstdFlags)
-				logger.Printf("API Call: UpdateServiceDesiredCount - instance: %s, cluster: %s, service: %s, desired: %d\n",
-					m.selectedInstance, m.selectedCluster, serviceName, desiredCount)
-				f.Close()
-			}
-		}
-
 		// Call UpdateService API
 		err := m.apiClient.UpdateServiceDesiredCount(
 			m.selectedInstance,

--- a/controlplane/internal/tui/service_update_handler.go
+++ b/controlplane/internal/tui/service_update_handler.go
@@ -2,8 +2,6 @@ package tui
 
 import (
 	"context"
-	"log"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -75,15 +73,6 @@ func (m Model) executeServiceUpdate() (Model, tea.Cmd) {
 	d := m.serviceUpdateDialog
 	newTaskDef := d.GetSelectedTaskDef()
 	serviceName := d.serviceName
-
-	// Log to file for debugging (optional)
-	if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-		if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-			logger := log.New(f, "", log.LstdFlags)
-			logger.Printf("Updating service: %s to task def: %s\n", serviceName, newTaskDef)
-			f.Close()
-		}
-	}
 
 	// Close dialog and show progress
 	m.serviceUpdateDialog = nil
@@ -202,16 +191,6 @@ type TaskDefinitionsFetchedMsg struct {
 // updateService creates a command to update the service
 func (m Model) updateService(serviceName string, taskDef string) tea.Cmd {
 	return func() tea.Msg {
-		// Log to file for debugging (optional)
-		if logFile := os.Getenv("KECS_TUI_DEBUG_LOG"); logFile != "" {
-			if f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-				logger := log.New(f, "", log.LstdFlags)
-				logger.Printf("API Call: UpdateService - instance: %s, cluster: %s, service: %s, taskDef: %s\n",
-					m.selectedInstance, m.selectedCluster, serviceName, taskDef)
-				f.Close()
-			}
-		}
-
 		// Call UpdateService API
 		err := m.apiClient.UpdateServiceTaskDefinition(
 			m.selectedInstance,


### PR DESCRIPTION
## Summary
- Removed the deprecated `KECS_TUI_DEBUG_LOG` environment variable-based debug logging
- This has been replaced by the new DebugLogger that automatically writes to `~/.kecs/tui-debug.log`

## Changes

### Removed Old Debug Logging
- Removed all `KECS_TUI_DEBUG_LOG` environment variable checks
- Removed associated file I/O operations for debug logging
- Cleaned up unused imports (`log` and `os`) from affected files

### Affected Files
- `app.go`: Removed 3 debug logging blocks
- `service_scale_handler.go`: Removed 2 debug logging blocks
- `service_update_handler.go`: Removed 2 debug logging blocks

## Benefits
The new DebugLogger implementation provides:
- **Automatic log location**: No need to set environment variables
- **Consistent location**: Always writes to `~/.kecs/tui-debug.log`
- **Centralized logging**: Singleton pattern ensures single log instance
- **Better structure**: Timestamps and structured logging format
- **Simplified code**: Less boilerplate for logging

## Test plan
- [x] Build the project with `make build`
- [x] Run unit tests with `make test`
- [x] Verify TUI runs without the environment variable
- [x] Confirm debug logs are still written to `~/.kecs/tui-debug.log` when using the new DebugLogger

🤖 Generated with [Claude Code](https://claude.ai/code)