### PR TITLE
refactor: Simplify TUI layout to single-column with horizontal shortcuts

### DIFF
--- a/controlplane/internal/tui/keybindings.go
+++ b/controlplane/internal/tui/keybindings.go
@@ -239,6 +239,30 @@ func (r *KeyBindingsRegistry) GetViewAction(view ViewType, key string) (KeyActio
 	return "", false
 }
 
+// mergeUniqueKeys merges two key slices, removing duplicates while preserving order
+func mergeUniqueKeys(existing, new []string) []string {
+	keySet := make(map[string]bool)
+	var result []string
+
+	// Add existing keys first (preserving order)
+	for _, key := range existing {
+		if !keySet[key] {
+			keySet[key] = true
+			result = append(result, key)
+		}
+	}
+
+	// Add new keys that aren't already present
+	for _, key := range new {
+		if !keySet[key] {
+			keySet[key] = true
+			result = append(result, key)
+		}
+	}
+
+	return result
+}
+
 // GetGlobalBindings returns all global key bindings in a stable order
 func (r *KeyBindingsRegistry) GetGlobalBindings() []KeyBinding {
 	// Define the order of global actions for consistent display
@@ -259,8 +283,8 @@ func (r *KeyBindingsRegistry) GetGlobalBindings() []KeyBinding {
 	uniqueBindings := make(map[KeyAction]KeyBinding)
 	for _, binding := range r.globalBindings {
 		if existing, found := uniqueBindings[binding.Action]; found {
-			// Merge keys from duplicate bindings
-			existing.Keys = append(existing.Keys, binding.Keys...)
+			// Merge keys from duplicate bindings (removing duplicates)
+			existing.Keys = mergeUniqueKeys(existing.Keys, binding.Keys)
 			uniqueBindings[binding.Action] = existing
 		} else {
 			uniqueBindings[binding.Action] = binding
@@ -338,8 +362,8 @@ func (r *KeyBindingsRegistry) GetViewBindings(view ViewType) []KeyBinding {
 	uniqueBindings := make(map[KeyAction]KeyBinding)
 	for _, binding := range viewMap {
 		if existing, found := uniqueBindings[binding.Action]; found {
-			// Merge keys from duplicate bindings
-			existing.Keys = append(existing.Keys, binding.Keys...)
+			// Merge keys from duplicate bindings (removing duplicates)
+			existing.Keys = mergeUniqueKeys(existing.Keys, binding.Keys)
 			uniqueBindings[binding.Action] = existing
 		} else {
 			uniqueBindings[binding.Action] = binding


### PR DESCRIPTION
## Summary
This PR refactors the TUI layout to provide a cleaner, more efficient use of terminal space.

### Major Changes:
- **Removed complex 2-column layout** in favor of simpler single-column design
- **Moved shortcuts to bottom** of navigation panel as single-line displays
- **Removed width constraints** from header and breadcrumb for full-width display
- **Fixed duplicate key display issue** in shortcuts (e.g., "^U/PgUp/^U/PgUp")
- **Improved breadcrumb format** to "Cluster(name) > Service(name)" style
- **Removed unnecessary separator lines** to save vertical space
- **Allow full task IDs** in breadcrumb without truncation
- **Ensured shortcuts are always visible** with dynamic height calculation

### Before:
- Complex 2-column layout with shortcuts on the right
- Width-restricted header and breadcrumb causing unnecessary line wrapping
- Duplicate keys in shortcut display
- Multiple separator lines wasting space
- Truncated task IDs in breadcrumb

### After:
- Clean single-column layout
- Full-width header and breadcrumb
- Shortcuts displayed as single lines at the bottom
- Proper key deduplication
- Optimized vertical space usage

## Test Plan
- [x] Build and run TUI locally
- [x] Test navigation between different views
- [x] Verify shortcuts are always visible
- [x] Test with different terminal widths
- [x] Confirm no duplicate keys in shortcuts
- [x] All unit tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)