### PR TITLE
fix(tui): Fix instance Start/Stop functionality with case-insensitive status check

### DIFF
--- a/controlplane/internal/tui/actions.go
+++ b/controlplane/internal/tui/actions.go
@@ -16,6 +16,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -167,7 +168,7 @@ func (m Model) executeInstanceAction(action KeyAction) (Model, tea.Cmd) {
 	case ActionToggleInstance:
 		if len(m.instances) > 0 && m.instanceCursor < len(m.instances) {
 			instanceName := m.instances[m.instanceCursor].Name
-			instanceStatus := m.instances[m.instanceCursor].Status
+			instanceStatus := strings.ToLower(m.instances[m.instanceCursor].Status)
 
 			if instanceStatus == "stopped" {
 				m.confirmDialog = StartInstanceDialog(


### PR DESCRIPTION
## Summary
- Fixed TUI instance Start/Stop functionality (s key) that was not working
- Changed status comparison to be case-insensitive

## Problem
The TUI instance Start/Stop functionality was not working because the status comparison was case-sensitive. The API returns instance status as 'Running' with capital R, but the code was checking for 'running' in lowercase.

## Solution
- Added `strings.ToLower()` to convert instance status to lowercase before comparison
- This allows the Start/Stop dialog to properly appear when pressing 's' key in the instance list

## Test Plan
- [x] Built and tested locally with `./bin/kecs` TUI
- [x] Verified that pressing 's' key on a running instance shows the Stop dialog
- [x] Verified that pressing 's' key on a stopped instance shows the Start dialog
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)