### PR TITLE
fix: Restore port mappings when restarting KECS instances

### DIFF
--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -60,8 +60,8 @@ func init() {
 
 	startCmd.Flags().StringVar(&startInstanceName, "instance", "", "KECS instance name (auto-generated if not specified)")
 	startCmd.Flags().StringVar(&startDataDir, "data-dir", "", "Data directory (default: ~/.kecs/data)")
-	startCmd.Flags().IntVar(&startApiPort, "api-port", 5373, "AWS API port")
-	startCmd.Flags().IntVar(&startAdminPort, "admin-port", 5374, "Admin API port")
+	startCmd.Flags().IntVar(&startApiPort, "api-port", 0, "AWS API port (default: 5373)")
+	startCmd.Flags().IntVar(&startAdminPort, "admin-port", 0, "Admin API port (default: 5374)")
 	startCmd.Flags().StringVar(&startConfigFile, "config", "", "Configuration file path")
 	startCmd.Flags().StringVar(&startAdditionalLocalServices, "additional-localstack-services", "", "Additional LocalStack services (comma-separated, e.g., s3,dynamodb,sqs)")
 	startCmd.Flags().DurationVar(&startTimeout, "timeout", 10*time.Minute, "Timeout for cluster creation")

--- a/controlplane/internal/host/instance/helpers.go
+++ b/controlplane/internal/host/instance/helpers.go
@@ -187,6 +187,24 @@ func (m *Manager) deployControlPlane(ctx context.Context, instanceName string, c
 		return fmt.Errorf("failed to create data directory: %w", err)
 	}
 
+	// Calculate NodePort for API access
+	apiNodePort := int32(opts.ApiPort)
+	if apiNodePort < 30000 {
+		apiNodePort = apiNodePort + 22000
+	}
+	if apiNodePort < 30000 || apiNodePort > 32767 {
+		apiNodePort = 30080 // fallback to default
+	}
+
+	// Calculate NodePort for Admin access
+	adminNodePort := int32(opts.AdminPort)
+	if adminNodePort < 30000 {
+		adminNodePort = adminNodePort + 22000
+	}
+	if adminNodePort < 30000 || adminNodePort > 32767 {
+		adminNodePort = 30081 // fallback to default
+	}
+
 	// Create control plane config
 	controlPlaneConfig := &resources.ControlPlaneConfig{
 		Image:           cfg.Server.ControlPlaneImage,
@@ -199,6 +217,8 @@ func (m *Manager) deployControlPlane(ctx context.Context, instanceName string, c
 		DataHostPath:    dataDir,                                 // Use hostPath for data persistence
 		APIPort:         80,                                      // Service port (external facing)
 		AdminPort:       resources.ControlPlaneInternalAdminPort, // Admin service port
+		APINodePort:     apiNodePort,                             // NodePort for API access
+		AdminNodePort:   adminNodePort,                           // NodePort for Admin access
 		LogLevel:        cfg.Server.LogLevel,
 	}
 

--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -76,6 +76,10 @@ type ControlPlaneConfig struct {
 	APIPort   int32
 	AdminPort int32
 
+	// NodePorts for external access
+	APINodePort   int32
+	AdminNodePort int32
+
 	// Features
 	Debug    bool
 	LogLevel string
@@ -340,7 +344,7 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 						Port:       config.APIPort,
 						TargetPort: intstr.FromInt(ControlPlaneInternalAPIPort),
 						Protocol:   corev1.ProtocolTCP,
-						NodePort:   30080, // Fixed NodePort for external access
+						NodePort:   config.APINodePort, // Dynamic NodePort from config
 					},
 				},
 				Type: corev1.ServiceTypeNodePort,
@@ -367,7 +371,7 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 						Port:       config.AdminPort,
 						TargetPort: intstr.FromInt(ControlPlaneInternalAdminPort),
 						Protocol:   corev1.ProtocolTCP,
-						NodePort:   30081, // Fixed NodePort for admin API
+						NodePort:   config.AdminNodePort, // Dynamic NodePort from config
 					},
 				},
 				Type: corev1.ServiceTypeNodePort,


### PR DESCRIPTION
## Summary
This PR fixes the issue where custom port configurations were lost when restarting KECS instances, especially during the DNS fix workaround.

## Problem
When restarting a KECS instance with custom ports (e.g., `--api-port 8080 --admin-port 8081`), the ports would revert to defaults (5373/5374) instead of preserving the original configuration. This was particularly problematic when the DNS fix workaround was triggered during cluster restart.

## Solution
1. **Added `StartClusterWithPorts` method**: Preserves port mappings when restarting clusters with DNS fix workaround
2. **Fixed port allocation logic**: Load saved configurations before allocating new ports for existing instances
3. **Dynamic NodePort calculation**: Calculate NodePorts based on host port configurations
4. **Fixed command-line defaults**: Changed default port values from 5373/5374 to 0 to allow config file values to be used
5. **Removed config overwriting**: Prevented instance configurations from being overwritten during restart

## Changes
- Added `StartClusterWithPorts` method to k3d manager
- Modified `restartInstance` to use saved port configurations
- Fixed command-line argument defaults to allow config file values precedence
- Added dynamic NodePort calculation based on host ports
- Fixed port allocation logic to check existing instances first

## Testing
Tested with:
1. Creating instance with custom ports: `kecs start --instance test --api-port 8080 --admin-port 8081`
2. Stopping instance: `kecs stop --instance test`
3. Restarting instance: `kecs start --instance test`
4. Verified ports are preserved and API is accessible on original ports
5. Verified data persistence (DuckDB) works correctly with hostPath volumes

## Related Issues
- Part of the broader fix for instance restart reliability
- Works in conjunction with the hostPath volume implementation for data persistence

🤖 Generated with [Claude Code](https://claude.ai/code)