### PR TITLE
fix(tui): Respect No selection in confirmation dialogs

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -1450,21 +1450,26 @@ func (m Model) handleConfirmDialogKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 	case "enter", " ":
 		// Execute the selected action
+		// Check if Yes was selected (focused = true)
+		wasYesSelected := m.confirmDialog.focused
+
 		err := m.confirmDialog.Execute()
 		if err != nil {
 			m.err = err
 		}
+
 		// Store pending command if any
 		cmd := m.pendingCommand
 		// Clear dialog and pending command
 		m.confirmDialog = nil
 		m.pendingCommand = nil
 		m.currentView = m.previousView
-		// Execute pending command if it exists, otherwise reload data
-		if cmd != nil {
+
+		// Only execute pending command if Yes was selected
+		if wasYesSelected && cmd != nil {
 			return m, cmd
 		}
-		// Reload data after potential deletion
+		// Reload data after potential action
 		return m, m.loadDataFromAPI()
 	case "esc":
 		// Cancel and go back (k9s style - only ESC cancels)
@@ -1474,6 +1479,7 @@ func (m Model) handleConfirmDialogKeys(msg tea.KeyMsg) (Model, tea.Cmd) {
 		m.confirmDialog = nil
 		m.pendingCommand = nil // Clear pending command on cancel
 		m.currentView = m.previousView
+		return m, m.loadDataFromAPI()
 	}
 	return m, nil
 }


### PR DESCRIPTION
## Summary
- Fixed a bug where selecting "No" in TUI confirmation dialogs would still execute the pending action
- Affects Delete Instance, Stop Task, and other confirmation dialogs

## Problem
When users selected "No" in confirmation dialogs (e.g., Delete Instance), the action would still proceed despite the user's choice to cancel.

## Root Cause
The `handleConfirmDialogKeys` function was executing `m.pendingCommand` whenever it was not nil, regardless of whether Yes or No was selected in the dialog.

## Solution
- Capture the dialog's focused state (`wasYesSelected`) before executing the dialog
- Only execute `m.pendingCommand` when Yes is selected (`wasYesSelected && cmd != nil`)
- Ensure consistent behavior for ESC key (properly cancels the action)

## Changes
- Modified `controlplane/internal/tui/app.go`:
  - Added check to capture whether Yes was selected before executing dialog
  - Changed condition to only execute pending command when Yes is selected
  - Added data reload after ESC for consistency

## Testing
- Built and tested locally
- Confirmed that selecting "No" in Delete Instance dialog no longer deletes the instance
- Verified other confirmation dialogs also respect the No selection
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)