### PR TITLE
fix: Fix pod restoration after KECS instance restart

### DIFF
--- a/controlplane/internal/controllers/sync/controller.go
+++ b/controlplane/internal/controllers/sync/controller.go
@@ -430,8 +430,16 @@ func isECSManagedPod(pod *corev1.Pod) bool {
 	if val, exists := pod.Labels["kecs.dev/managed-by"]; exists && val == "kecs" {
 		return true
 	}
-	// Also check for ECS-specific labels
+	// Check for ECS-specific labels
 	if _, exists := pod.Labels["ecs.amazonaws.com/task-arn"]; exists {
+		return true
+	}
+	// Check for ecs.managed label (used in restored deployments)
+	if _, exists := pod.Labels["ecs.managed"]; exists {
+		return true
+	}
+	// Check for ecs.service label (used in restored deployments)
+	if _, exists := pod.Labels["ecs.service"]; exists {
 		return true
 	}
 	return false
@@ -446,6 +454,16 @@ func isECSManagedDeployment(deployment *appsv1.Deployment) bool {
 
 	// Check labels
 	if val, exists := deployment.Labels["kecs.dev/managed-by"]; exists && val == "kecs" {
+		return true
+	}
+
+	// Check for ecs.managed label (used in restored deployments)
+	if val, exists := deployment.Labels["ecs.managed"]; exists && val == "true" {
+		return true
+	}
+
+	// Check for ecs.service label (used in restored deployments)
+	if _, exists := deployment.Labels["ecs.service"]; exists {
 		return true
 	}
 


### PR DESCRIPTION
## Summary
This PR fixes the issue where Kubernetes pods were not being registered as ECS tasks after restarting a KECS instance with existing services.

## Problem
When restarting a KECS instance (`kecs stop` -> `kecs start`), the existing Kubernetes pods were not being recognized and registered as ECS tasks, even though the ECS services and tasks were properly restored from DuckDB.

## Root Causes
1. **Invalid Kubernetes label format**: The task definition label contained a colon (`ecs.task-definition: single-task-nginx:1`), which is invalid in Kubernetes
2. **Missing label checks**: The pod detection logic only checked for `ecs.amazonaws.com/task-arn` label, but restored deployments use different labels
3. **Incorrect namespace parsing**: The cluster name extraction didn't handle the `ecs-<cluster>` namespace format correctly
4. **Sync controller recognition**: The deployment detection logic didn't recognize restored deployments

## Changes
- Split task definition label to avoid colon in Kubernetes labels
  - Changed from `ecs.task-definition: "family:revision"`
  - To separate labels: `ecs.task-definition-family` and `ecs.task-definition-revision`
- Updated pod detection logic to recognize restored deployments
  - Added checks for `ecs.managed` and `ecs.service` labels
  - Fixed namespace parsing to handle `ecs-<cluster>` format correctly
- Updated sync controller to process restored deployments
  - Extended `isECSManagedPod` and `isECSManagedDeployment` functions

## Test Plan
1. Create a KECS instance
2. Deploy a service (e.g., `examples/single-task-nginx`)
3. Stop the KECS instance
4. Start the KECS instance again
5. Verify that:
   - Kubernetes pods are still running
   - ECS tasks are properly restored
   - `aws ecs list-tasks` shows the correct tasks

🤖 Generated with [Claude Code](https://claude.ai/code)