### PR TITLE
refactor: Unify service creation and restoration logic

### DIFF
--- a/controlplane/internal/controlplane/api/server.go
+++ b/controlplane/internal/controlplane/api/server.go
@@ -93,8 +93,8 @@ func NewServer(port int, kubeconfig string, storage storage.Storage, localStackC
 		storage:    storage,
 	}
 
-	// Initialize service manager
-	serviceManager := kubernetes.NewServiceManager(storage)
+	// Initialize service manager with region and account ID
+	serviceManager := kubernetes.NewServiceManagerWithConfig(storage, region, accountID)
 	s.serviceManager = serviceManager
 	logging.Info("ServiceManager initialized", "nil", serviceManager == nil)
 

--- a/controlplane/internal/controlplane/api/service_ecs_api.go
+++ b/controlplane/internal/controlplane/api/service_ecs_api.go
@@ -33,13 +33,13 @@ func (api *DefaultECSAPI) getServiceManager() (*kubernetes.ServiceManager, error
 	// In test mode, we can return a ServiceManager
 	// as the ServiceManager handles test mode internally
 	if config.GetBool("features.testMode") {
-		return kubernetes.NewServiceManager(api.storage), nil
+		return kubernetes.NewServiceManagerWithConfig(api.storage, api.region, api.accountID), nil
 	}
 
 	// Create a new ServiceManager instance
 	// Note: This creates a new instance which may not have the proper in-cluster configuration
 	logging.Warn("Creating new ServiceManager instance - this should be avoided in production")
-	return kubernetes.NewServiceManager(api.storage), nil
+	return kubernetes.NewServiceManagerWithConfig(api.storage, api.region, api.accountID), nil
 }
 
 // CreateService implements the CreateService operation


### PR DESCRIPTION
## Summary
- Unified service creation and restoration logic to eliminate code duplication
- Fixed inconsistencies between normal service creation and restoration after KECS restart
- Ensured both paths use the same ServiceConverter logic

## Problem
The fundamental issue was that `RestoreService` and `CreateService` used different code paths to create Kubernetes deployments, causing inconsistencies in pod annotations and labels after KECS restart.

## Solution
1. Added `region` and `accountID` fields to `ServiceManager`
2. Refactored `RestoreService` to use `ServiceConverter` instead of duplicating logic
3. Removed duplicate helper functions that were only used by the old restoration logic
4. Updated all `ServiceManager` instantiations to pass region and accountID

## Changes
- Modified `ServiceManager` to include region and accountID configuration
- Refactored `RestoreService` to use `ServiceConverter.ConvertServiceToDeploymentWithNetworkConfig`
- Removed 3 duplicate helper functions (~190 lines of code)
- Updated callers to use `NewServiceManagerWithConfig`

## Benefits
- **Code consolidation**: Service creation logic is now in one place (ServiceConverter)
- **Consistency**: Both creation and restoration paths use identical logic
- **Maintainability**: Future changes automatically apply to both paths
- **Bug prevention**: Eliminates possibility of divergence between the two paths

## Test plan
- [x] Unit tests pass
- [x] Build successful
- [ ] Manual testing of service restoration after KECS restart
- [ ] Verify pod annotations and labels are consistent

🤖 Generated with [Claude Code](https://claude.ai/code)