### PR TITLE
fix: Remove objectSelector from webhook to fix task-id label application

### DIFF
--- a/controlplane/internal/webhook/registration.go
+++ b/controlplane/internal/webhook/registration.go
@@ -76,12 +76,8 @@ func (r *WebhookRegistrar) Register(ctx context.Context, caBundle []byte) error 
 						"kecs.dev/managed": "true",
 					},
 				},
-				// Only mutate pods with KECS labels
-				ObjectSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"kecs.dev/managed-by": "kecs",
-					},
-				},
+				// ObjectSelector removed - filtering is done within the webhook handler
+				// to avoid blocking pods that don't have the label yet
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
Removed the objectSelector from the webhook configuration to fix the issue where task-id labels were not being added to pods during service restoration.

## Problem
The webhook configuration had both:
- `namespaceSelector`: Filters by namespace labels ✅
- `objectSelector`: Filters by pod labels ❌

The objectSelector required pods to already have the `kecs.dev/managed-by: kecs` label, but:
1. Pods created by ReplicaSet already have this label from the pod template
2. The webhook checks for this label internally anyway
3. This created a chicken-and-egg problem where the webhook wouldn't be called for pods that need the label

## Solution
Removed the objectSelector since:
- The namespaceSelector already provides sufficient filtering (only KECS-managed namespaces)
- The webhook handler internally checks for the `kecs.dev/managed-by` label
- This allows the webhook to process all pods in KECS-managed namespaces and decide internally

## Test Plan
- [x] Build and unit tests pass
- [ ] Deploy the change to a test environment
- [ ] Create a new service and verify task-id labels are added
- [ ] Stop and restart KECS instance
- [ ] Verify restored pods have task-id labels

## Related Issues
- Follows up on #605 which added namespace labels but didn't fully resolve the issue

🤖 Generated with [Claude Code](https://claude.ai/code)