### PR TITLE
fix: Accept pods with kecs.dev/service label as KECS-managed

### DIFF
--- a/controlplane/internal/webhook/pod_mutator.go
+++ b/controlplane/internal/webhook/pod_mutator.go
@@ -121,12 +121,17 @@ func (m *PodMutator) mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admi
 		pod.Labels = make(map[string]string)
 	}
 
-	if pod.Labels["kecs.dev/managed-by"] != "kecs" {
+	// Check if this is a KECS-managed pod
+	// Either it has kecs.dev/managed-by label or it's a service pod with kecs.dev/service label
+	isKECSManaged := pod.Labels["kecs.dev/managed-by"] == "kecs" || pod.Labels["kecs.dev/service"] != ""
+
+	if !isKECSManaged {
 		// Not a KECS pod, allow without mutation
 		logging.Debug("Pod not managed by KECS, skipping mutation",
 			"pod", pod.Name,
 			"namespace", pod.Namespace,
-			"managed-by", pod.Labels["kecs.dev/managed-by"])
+			"managed-by", pod.Labels["kecs.dev/managed-by"],
+			"service", pod.Labels["kecs.dev/service"])
 		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}


### PR DESCRIPTION
## Summary
- Modified webhook to treat pods with either `kecs.dev/managed-by=kecs` OR `kecs.dev/service` labels as KECS-managed pods
- This fixes the issue where ReplicaSet-created pods during restoration don't get task-id labels

## Problem
After KECS instance restart, restored pods were missing the `kecs.dev/task-id` label. Investigation revealed:

1. The webhook was configured correctly with namespace selector
2. Test pods created directly with `kecs.dev/managed-by=kecs` label got task-id labels correctly
3. Pods created by ReplicaSets during restoration didn't get task-id labels

The root cause: Kubernetes ReplicaSets only copy selector-matching labels to pod templates. Our Deployment selector includes `app` and `kecs.dev/service` but NOT `kecs.dev/managed-by`. Therefore, ReplicaSet-created pods only have the service label, not the managed-by label.

## Solution
Modified the webhook to accept pods with either:
- `kecs.dev/managed-by=kecs` (existing behavior)
- `kecs.dev/service` label present (new behavior)

This ensures all KECS service pods get task-id labels, whether created directly or through ReplicaSets.

## Test Plan
1. Deploy this change
2. Create a service with replicas
3. Restart KECS instance
4. Verify restored pods have task-id labels
5. Verify direct pod creation still works

## Related Issues
- Follows up on #605, #606, and #607

🤖 Generated with [Claude Code](https://claude.ai/code)