### PR TITLE
feat: Implement assignPublicIp Phase 2 - Dynamic port allocation

### DIFF
--- a/controlplane/internal/kubernetes/k3d_port_manager.go
+++ b/controlplane/internal/kubernetes/k3d_port_manager.go
@@ -1,0 +1,153 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
+)
+
+// K3dPortManager manages port mappings for k3d clusters
+type K3dPortManager struct {
+	clusterName string
+	portManager *PortManager
+}
+
+// NewK3dPortManager creates a new K3d port manager
+func NewK3dPortManager(clusterName string) *K3dPortManager {
+	// Default port range for dynamic allocation (32000-32999)
+	portManager := NewPortManager(32000, 32999)
+
+	return &K3dPortManager{
+		clusterName: clusterName,
+		portManager: portManager,
+	}
+}
+
+// AddPortMapping adds a port mapping to the k3d cluster's load balancer
+func (k *K3dPortManager) AddPortMapping(ctx context.Context, hostPort, nodePort int32) error {
+	// Format: k3d node edit k3d-<cluster>-serverlb --port-add <hostPort>:<nodePort>
+	nodeName := fmt.Sprintf("k3d-%s-serverlb", k.clusterName)
+	portMapping := fmt.Sprintf("%d:%d", hostPort, nodePort)
+
+	logging.Info("Adding port mapping to k3d node",
+		"node", nodeName,
+		"mapping", portMapping)
+
+	cmd := exec.CommandContext(ctx, "k3d", "node", "edit", nodeName, "--port-add", portMapping)
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf("failed to add port mapping: %w, output: %s", err, string(output))
+	}
+
+	logging.Info("Successfully added port mapping",
+		"node", nodeName,
+		"hostPort", hostPort,
+		"nodePort", nodePort)
+
+	return nil
+}
+
+// AllocateAndMapPort allocates a host port and maps it to a container port
+func (k *K3dPortManager) AllocateAndMapPort(ctx context.Context, taskARN string, containerPort int32, protocol string) (int32, error) {
+	// Allocate a host port
+	hostPort, err := k.portManager.AllocatePort(taskARN, containerPort, protocol)
+	if err != nil {
+		return 0, fmt.Errorf("failed to allocate port: %w", err)
+	}
+
+	// For k3d, we map the host port to a NodePort
+	// NodePort range in Kubernetes is typically 30000-32767
+	// We'll use a simple mapping: hostPort -> 30000 + (hostPort - 32000)
+	// This maps our range 32000-32999 to NodePort range 30000-30999
+	nodePort := 30000 + (hostPort - 32000)
+
+	// Add the port mapping to k3d
+	if err := k.AddPortMapping(ctx, hostPort, nodePort); err != nil {
+		// If mapping fails, release the allocated port
+		k.portManager.ReleasePort(hostPort)
+		return 0, fmt.Errorf("failed to add k3d port mapping: %w", err)
+	}
+
+	return hostPort, nil
+}
+
+// ReleaseTaskPorts releases all ports allocated to a task
+// Note: k3d doesn't support removing individual port mappings after cluster creation,
+// so we only release the port allocation tracking
+func (k *K3dPortManager) ReleaseTaskPorts(ctx context.Context, taskARN string) error {
+	// Get the allocated ports before releasing
+	ports := k.portManager.GetTaskPorts(taskARN)
+
+	// Release the port allocations
+	if err := k.portManager.ReleaseTaskPorts(taskARN); err != nil {
+		return fmt.Errorf("failed to release task ports: %w", err)
+	}
+
+	// Note: We cannot remove port mappings from a running k3d cluster
+	// The ports will remain mapped but unused until the cluster is recreated
+	if len(ports) > 0 {
+		logging.Warn("Released port allocations for task, but k3d port mappings remain",
+			"taskARN", taskARN,
+			"ports", ports,
+			"note", "Port mappings will be cleaned up on cluster recreation")
+	}
+
+	return nil
+}
+
+// GetNodePortForHost returns the NodePort mapped to a host port
+func (k *K3dPortManager) GetNodePortForHost(hostPort int32) int32 {
+	// Using our mapping scheme
+	return 30000 + (hostPort - 32000)
+}
+
+// GetPortManager returns the underlying port manager
+func (k *K3dPortManager) GetPortManager() *PortManager {
+	return k.portManager
+}
+
+// IsPortAvailable checks if a port is available for allocation
+func (k *K3dPortManager) IsPortAvailable(hostPort int32) bool {
+	_, allocated := k.portManager.GetAllocation(hostPort)
+	return !allocated
+}
+
+// GetClusterPortMappings retrieves current port mappings from k3d cluster
+// This is useful for syncing state after a restart
+func (k *K3dPortManager) GetClusterPortMappings(ctx context.Context) (map[int32]int32, error) {
+	// Get load balancer node info
+	nodeName := fmt.Sprintf("k3d-%s-serverlb", k.clusterName)
+
+	cmd := exec.CommandContext(ctx, "docker", "inspect", nodeName, "--format",
+		"{{range $p, $conf := .NetworkSettings.Ports}}{{$p}} -> {{(index $conf 0).HostPort}}{{println}}{{end}}")
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get port mappings: %w", err)
+	}
+
+	// Parse the output to extract port mappings
+	mappings := make(map[int32]int32)
+	lines := strings.Split(string(output), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Parse format: "30080/tcp -> 32000"
+		var containerPort, hostPort int32
+		var proto string
+		_, err := fmt.Sscanf(line, "%d/%s -> %d", &containerPort, &proto, &hostPort)
+		if err == nil {
+			mappings[hostPort] = containerPort
+		}
+	}
+
+	return mappings, nil
+}

--- a/controlplane/internal/kubernetes/port_manager.go
+++ b/controlplane/internal/kubernetes/port_manager.go
@@ -1,0 +1,201 @@
+package kubernetes
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
+)
+
+// PortRange defines the range of ports available for allocation
+type PortRange struct {
+	Start int32
+	End   int32
+}
+
+// PortAllocation represents a port allocation for a task
+type PortAllocation struct {
+	TaskARN       string
+	HostPort      int32
+	ContainerPort int32
+	Protocol      string
+}
+
+// PortManager manages dynamic port allocation for tasks with assignPublicIp
+type PortManager struct {
+	mu          sync.RWMutex
+	portRange   PortRange
+	allocations map[int32]*PortAllocation // hostPort -> allocation
+	taskPorts   map[string][]int32        // taskARN -> []hostPort
+	nextPort    int32
+}
+
+// NewPortManager creates a new port manager with the specified port range
+func NewPortManager(start, end int32) *PortManager {
+	return &PortManager{
+		portRange:   PortRange{Start: start, End: end},
+		allocations: make(map[int32]*PortAllocation),
+		taskPorts:   make(map[string][]int32),
+		nextPort:    start,
+	}
+}
+
+// AllocatePort allocates a port for a task
+func (pm *PortManager) AllocatePort(taskARN string, containerPort int32, protocol string) (int32, error) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	// Find an available port
+	var allocatedPort int32
+	found := false
+
+	// Try to find an unused port starting from nextPort
+	for i := pm.nextPort; i <= pm.portRange.End; i++ {
+		if _, exists := pm.allocations[i]; !exists {
+			allocatedPort = i
+			found = true
+			pm.nextPort = i + 1
+			break
+		}
+	}
+
+	// If not found, wrap around and search from the beginning
+	if !found {
+		for i := pm.portRange.Start; i < pm.nextPort; i++ {
+			if _, exists := pm.allocations[i]; !exists {
+				allocatedPort = i
+				found = true
+				pm.nextPort = i + 1
+				break
+			}
+		}
+	}
+
+	if !found {
+		return 0, fmt.Errorf("no available ports in range %d-%d", pm.portRange.Start, pm.portRange.End)
+	}
+
+	// Reset nextPort if it exceeds the range
+	if pm.nextPort > pm.portRange.End {
+		pm.nextPort = pm.portRange.Start
+	}
+
+	// Create allocation
+	allocation := &PortAllocation{
+		TaskARN:       taskARN,
+		HostPort:      allocatedPort,
+		ContainerPort: containerPort,
+		Protocol:      protocol,
+	}
+
+	pm.allocations[allocatedPort] = allocation
+	pm.taskPorts[taskARN] = append(pm.taskPorts[taskARN], allocatedPort)
+
+	logging.Info("Allocated port for task",
+		"taskARN", taskARN,
+		"hostPort", allocatedPort,
+		"containerPort", containerPort,
+		"protocol", protocol)
+
+	return allocatedPort, nil
+}
+
+// ReleasePort releases a specific port
+func (pm *PortManager) ReleasePort(hostPort int32) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	allocation, exists := pm.allocations[hostPort]
+	if !exists {
+		return fmt.Errorf("port %d is not allocated", hostPort)
+	}
+
+	// Remove from allocations
+	delete(pm.allocations, hostPort)
+
+	// Remove from task ports
+	if ports, exists := pm.taskPorts[allocation.TaskARN]; exists {
+		newPorts := []int32{}
+		for _, p := range ports {
+			if p != hostPort {
+				newPorts = append(newPorts, p)
+			}
+		}
+		if len(newPorts) > 0 {
+			pm.taskPorts[allocation.TaskARN] = newPorts
+		} else {
+			delete(pm.taskPorts, allocation.TaskARN)
+		}
+	}
+
+	logging.Info("Released port",
+		"hostPort", hostPort,
+		"taskARN", allocation.TaskARN)
+
+	return nil
+}
+
+// ReleaseTaskPorts releases all ports allocated to a task
+func (pm *PortManager) ReleaseTaskPorts(taskARN string) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	ports, exists := pm.taskPorts[taskARN]
+	if !exists {
+		return nil // No ports allocated for this task
+	}
+
+	for _, port := range ports {
+		delete(pm.allocations, port)
+		logging.Info("Released port for task",
+			"taskARN", taskARN,
+			"hostPort", port)
+	}
+
+	delete(pm.taskPorts, taskARN)
+
+	return nil
+}
+
+// GetTaskPorts returns all ports allocated to a task
+func (pm *PortManager) GetTaskPorts(taskARN string) []int32 {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	ports := pm.taskPorts[taskARN]
+	result := make([]int32, len(ports))
+	copy(result, ports)
+	return result
+}
+
+// GetAllocation returns the allocation for a specific port
+func (pm *PortManager) GetAllocation(hostPort int32) (*PortAllocation, bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	allocation, exists := pm.allocations[hostPort]
+	if !exists {
+		return nil, false
+	}
+
+	// Return a copy to prevent modification
+	result := *allocation
+	return &result, true
+}
+
+// GetAllocatedPortsCount returns the number of allocated ports
+func (pm *PortManager) GetAllocatedPortsCount() int {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	return len(pm.allocations)
+}
+
+// GetAvailablePortsCount returns the number of available ports
+func (pm *PortManager) GetAvailablePortsCount() int {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	total := int(pm.portRange.End - pm.portRange.Start + 1)
+	return total - len(pm.allocations)
+}


### PR DESCRIPTION
## Summary
- Implemented dynamic port allocation for tasks with assignPublicIp enabled
- Tasks can now be accessed from the host without needing kubectl port-forward
- Port range 32000-32999 for host ports, mapped to NodePort range 30000-30999

## Implementation Details

### New Components
1. **PortManager** (`port_manager.go`)
   - Thread-safe port allocation management
   - Tracks allocated ports per task
   - Port range: 32000-32999

2. **K3dPortManager** (`k3d_port_manager.go`)
   - k3d-specific implementation using `k3d node edit --port-add`
   - Maps host ports to NodePorts
   - Handles port lifecycle (allocate/release)

3. **TaskManager Integration**
   - Modified CreateTask to allocate ports for assignPublicIp tasks
   - Creates NodePort services for external access
   - Modified StopTask to release allocated ports
   - Stores public IP and port info in task attachments

## How It Works
When a task is created with `assignPublicIp: true`:
1. Each container port gets a dynamically allocated host port
2. k3d load balancer is updated with the new port mapping
3. A NodePort service is created to route traffic
4. Task attachments include the public IP (127.0.0.1) and allocated ports

## Testing
Can be tested with the multi-container-webapp example:
```bash
# Deploy with assignPublicIp enabled
cd examples/multi-container-webapp
./deploy.sh

# Access the application directly (no port-forward needed)
# Check task details for allocated ports
aws ecs describe-tasks --cluster multi-container-webapp-cluster --tasks <task-arn>
```

## Related to
- Part of assignPublicIp implementation roadmap
- Follows Phase 1 PR #617 (Global Traefik consolidation)

🤖 Generated with [Claude Code](https://claude.ai/code)