### PR TITLE
fix: Add ALB port mappings when creating KECS instances

### DIFF
--- a/controlplane/internal/host/instance/helpers.go
+++ b/controlplane/internal/host/instance/helpers.go
@@ -66,6 +66,8 @@ func (m *Manager) createCluster(ctx context.Context, instanceName string, cfg *c
 	portMappings := map[int32]int32{
 		int32(opts.ApiPort):   apiNodePort,   // Map host API port to NodePort for ECS API
 		int32(opts.AdminPort): adminNodePort, // Map host Admin port to NodePort for Admin API
+		8080:                  30880,         // HTTP (ALB port 80 -> Host 8080 -> NodePort 30880)
+		8443:                  30443,         // HTTPS (ALB port 443 -> Host 8443 -> NodePort 30443)
 	}
 
 	// Set up data directory for direct hostPath mounting


### PR DESCRIPTION
## Summary
- Fixes missing ALB port mappings (8080→30880, 8443→30443) when creating KECS instances
- ALB listeners are now accessible without manual port forwarding

## Problem
Previously, ALB port mappings were defined in the k3d manager but not actually applied when creating instances. This caused ALB listeners created via `aws elbv2 create-listener` to be inaccessible without manual kubectl port-forward.

## Solution
Added the ALB port mappings to the `portMappings` map in `createCluster()` method in `helpers.go`, ensuring they are properly exposed when k3d clusters are created.

## Test Results
Tested by creating a new instance and verifying Docker port mappings:
```
$ docker ps --format "table {{.Names}}\t{{.Ports}}" | grep test-alb-ports
k3d-kecs-test-alb-ports-server-0   0.0.0.0:6373->30080/tcp, 0.0.0.0:6384->30081/tcp, 0.0.0.0:8443->30443/tcp, 0.0.0.0:8080->30880/tcp
```

✅ ALB ports (8080, 8443) are now properly exposed

## Related PRs
- #620: Initial ALB port mapping implementation
- #621: Fix Traefik deployment at instance creation

🤖 Generated with [Claude Code](https://claude.ai/code)