### PR TITLE
feat: Auto-create Kubernetes Ingress resources for ELBv2 listeners

### DIFF
--- a/controlplane/internal/controlplane/api/server.go
+++ b/controlplane/internal/controlplane/api/server.go
@@ -413,6 +413,8 @@ func NewServer(port int, kubeconfig string, storage storage.Storage, localStackC
 	// This requires Kubernetes client for load balancer operations
 	if kubeClient != nil {
 		elbv2Integration := elbv2.NewK8sIntegration(s.region, s.accountID)
+		// Set the Kubernetes clients
+		elbv2Integration.SetKubernetesClients(kubeClient, nil)
 		s.elbv2Integration = elbv2Integration
 
 		// Initialize ELBv2 API and router with wrapper for form data support


### PR DESCRIPTION
## Summary
- Implemented automatic Kubernetes Ingress resource creation when ELBv2 listeners are created
- Changed from Traefik IngressRoute CRDs to standard Kubernetes Ingress resources
- Enables proper ALB traffic routing using Host header-based routing

## Changes
- Changed to create standard Kubernetes Ingress resources instead of Traefik IngressRoute CRDs
- Added Kubernetes client initialization to ELBv2 integration
- Implemented robust load balancer name extraction from ARN
- Implemented consistent DNS name generation for Host header routing
- Added `SetKubernetesClients` method to properly initialize clients

## Test plan
- [x] Unit tests pass
- [ ] Verify ELBv2 listener creation with multi-container-webapp example
- [ ] Confirm Ingress resources are automatically created
- [ ] Verify ALB routing works with Host headers

## Related
- Standard Ingress resources are required because the global Traefik instance uses the `kubernetesingress` provider

🤖 Generated with [Claude Code](https://claude.ai/code)