### PR TITLE
fix: Fix release workflows for Go module path issues

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -36,9 +36,9 @@ jobs:
           # For now, we'll build on macOS runners for macOS binaries
       
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,17 +61,20 @@ jobs:
 
       - name: Build macOS binaries
         run: |
+          # Navigate to controlplane directory where go.mod exists
+          cd controlplane
+          
           # Build for macOS amd64
           CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build \
             -ldflags "-s -w -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version=${{ github.ref_name }}" \
-            -o kecs-darwin-amd64 \
-            ./controlplane/cmd/controlplane
+            -o ../kecs-darwin-amd64 \
+            ./cmd/controlplane
           
           # Build for macOS arm64
           CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build \
             -ldflags "-s -w -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version=${{ github.ref_name }}" \
-            -o kecs-darwin-arm64 \
-            ./controlplane/cmd/controlplane
+            -o ../kecs-darwin-arm64 \
+            ./cmd/controlplane
           
           # Create archives
           tar czf kecs_${{ github.ref_name }}_Darwin_x86_64.tar.gz kecs-darwin-amd64 README.md LICENSE

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -64,6 +64,9 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
+          # Navigate to controlplane directory where go.mod exists
+          cd controlplane
+          
           # Set cross-compilation environment for Linux ARM64
           if [ "${{ matrix.goos }}" = "linux" ] && [ "${{ matrix.goarch }}" = "arm64" ]; then
             export CC=aarch64-linux-gnu-gcc
@@ -73,8 +76,8 @@ jobs:
           # Build the binary
           go build \
             -ldflags "-s -w -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version=${{ steps.version.outputs.version }}" \
-            -o kecs-${{ matrix.goos }}-${{ matrix.goarch }} \
-            ./controlplane/cmd/controlplane
+            -o ../kecs-${{ matrix.goos }}-${{ matrix.goarch }} \
+            ./cmd/controlplane
 
       - name: Create archive
         run: |


### PR DESCRIPTION
## Summary
This PR fixes issues with release workflows that were preventing builds from succeeding.

## Problems Fixed
1. **GoReleaser version compatibility**: Updated action from v5 to v6 to support config version 2
2. **Go module not found error**: Fixed "cannot find main module" error in both workflows

## Changes
- Updated GoReleaser action to v6 with proper version specification for v2 config
- Added navigation to `controlplane` directory where `go.mod` exists before building
- Adjusted build output paths to work from within the controlplane directory

## Test Plan
- [x] Verified workflow syntax is correct
- [ ] Will be tested on next tag push
- [ ] Release binaries workflow will create binaries correctly
- [ ] GoReleaser workflow will work with version 2 config

## Related Issues
Fixes build failures seen in recent release attempts.

🤖 Generated with [Claude Code](https://claude.ai/code)