### PR TITLE
fix: Use git describe format for Docker image tags

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -65,16 +65,17 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Git describe
+        id: git_describe
+        run: echo "GIT_DESCRIBE=$(git describe --tags --always)" >> $GITHUB_OUTPUT
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=raw,value=${{ steps.git_describe.outputs.GIT_DESCRIBE }}
+            type=raw,value=latest
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
## Summary
- Restore the `git describe --tags --always` format for Docker image tags
- Replace metadata-action's default tag formats with more informative version tags

## Changes
- Add a step to run `git describe --tags --always` and capture the output
- Update docker/metadata-action to use `type=raw` with the git describe output
- Keep the `latest` tag alongside the version tag

## Why this change?
The previous CI workflow used `git describe` which provided informative tags like:
- `v0.1.0` for exact tag matches
- `v0.1.0-5-g0847872` showing 5 commits ahead of v0.1.0 with commit hash

The consolidated workflow changed to using `type=sha` which only gives `sha-0847872`, losing the valuable distance-from-tag information useful during development.

## Test plan
- [ ] CI workflow runs successfully
- [ ] Docker images are tagged with git describe format
- [ ] Both versioned tag and `latest` tag are created

🤖 Generated with [Claude Code](https://claude.ai/code)