### PR TITLE
fix: Fix GoReleaser workflow errors

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -46,6 +46,7 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
   # Build macOS binaries on macOS runner
+  # Required for CGO dependencies like DuckDB
   goreleaser-darwin:
     runs-on: macos-latest
     steps:
@@ -64,18 +65,21 @@ jobs:
           # Navigate to controlplane directory where go.mod exists
           cd controlplane
           
-          # Build for macOS amd64
+          # Build for macOS amd64 with CGO enabled
           CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build \
             -ldflags "-s -w -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version=${{ github.ref_name }}" \
             -o ../kecs-darwin-amd64 \
             ./cmd/controlplane
-          
-          # Build for macOS arm64
+
+          # Build for macOS arm64 with CGO enabled
           CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build \
             -ldflags "-s -w -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version=${{ github.ref_name }}" \
             -o ../kecs-darwin-arm64 \
             ./cmd/controlplane
           
+          # Go back to root directory for archives
+          cd ..
+
           # Create archives
           tar czf kecs_${{ github.ref_name }}_Darwin_x86_64.tar.gz kecs-darwin-amd64 README.md LICENSE
           tar czf kecs_${{ github.ref_name }}_Darwin_arm64.tar.gz kecs-darwin-arm64 README.md LICENSE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,8 @@ version: 2
 
 before:
   hooks:
-    - go mod tidy
-    - go mod download
+    - cd controlplane && go mod tidy
+    - cd controlplane && go mod download
 
 builds:
   - id: kecs


### PR DESCRIPTION
## Summary
- Fix GoReleaser workflow build errors
- Keep macos-latest runner for proper CGO/DuckDB support

## Issues Fixed

### 1. go mod tidy error
**Error**: `go mod tidy: exit status 1: go: go.mod file not found`
**Fix**: Run `go mod tidy` and `go mod download` in the `controlplane` directory where go.mod exists

### 2. Darwin build tar error  
**Error**: `tar: kecs-darwin-amd64: Cannot stat: No such file or directory`
**Fix**: Return to root directory (cd ..) before creating tar archives

### 3. macOS runner requirement
**Decision**: Keep macos-latest runner despite higher cost because:
- KECS depends on DuckDB which requires CGO to be enabled
- Cross-compilation from Linux with CGO is not feasible
- CGO_ENABLED=0 builds would lose DuckDB functionality

## Changes
- Modified `.goreleaser.yml` to run hooks in correct directory
- Fixed `.github/workflows/goreleaser.yml` build paths
- Kept macos-latest runner for full CGO support

## Test plan
- [ ] GoReleaser workflow runs without errors
- [ ] go mod tidy executes in controlplane directory
- [ ] Darwin builds successfully create tar archives  
- [ ] macOS binaries retain full DuckDB functionality

🤖 Generated with [Claude Code](https://claude.ai/code)