### PR TITLE
fix: Fix GoReleaser before hooks cd command error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,8 @@ version: 2
 
 before:
   hooks:
-    - cd controlplane && go mod tidy
-    - cd controlplane && go mod download
+    - sh -c "cd controlplane && go mod tidy"
+    - sh -c "cd controlplane && go mod download"
 
 builds:
   - id: kecs


### PR DESCRIPTION
## Summary
Fix GoReleaser before hooks failing with `"cd": executable file not found in $PATH` error

## Problem
GoReleaser was failing during the before hooks execution with:
```
hook failed: shell: 'cd controlplane': exec: "cd": executable file not found in $PATH
```

This is because `cd` is a shell builtin command, not an executable file in the PATH.

## Solution
Wrap the commands in `sh -c` to execute them in a shell context:
- Before: `cd controlplane && go mod tidy`
- After: `sh -c "cd controlplane && go mod tidy"`

## Test plan
- [x] GoReleaser configuration validates locally
- [ ] GoReleaser workflow runs successfully on tag push
- [ ] Before hooks execute without errors

🤖 Generated with [Claude Code](https://claude.ai/code)