### PR TITLE
fix: Fix GoReleaser module path error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,9 @@ before:
 
 builds:
   - id: kecs
-    main: ./controlplane/cmd/controlplane
+    main: ./cmd/controlplane
     binary: kecs
+    dir: ./controlplane  # Set working directory to controlplane where go.mod exists
     env:
       - CGO_ENABLED=0  # kecs CLI doesn't need DuckDB (only controlplane in container needs it)
     goos:


### PR DESCRIPTION
## Summary
Fix GoReleaser failing with "cannot find main module" error

## Problem
GoReleaser was failing during the build phase with:
```
build failed: exit status 1: go: cannot find main module, but found .git/config in /home/runner/work/kecs/kecs
    to create a module there, run:
    go mod init
```

This occurred because:
- The go.mod file is in the `controlplane/` directory
- GoReleaser was running from the project root where no go.mod exists

## Solution
Added `dir: ./controlplane` to the build configuration to:
- Set the correct working directory for the Go build process
- Ensure GoReleaser finds the go.mod file
- Adjusted the main path to be relative to the controlplane directory

## Changes
- Set `dir: ./controlplane` in the build configuration
- Changed main path from `./controlplane/cmd/controlplane` to `./cmd/controlplane` (relative to dir)

## Test plan
- [x] GoReleaser configuration validates locally
- [ ] GoReleaser workflow builds successfully
- [ ] Release artifacts are created properly

🤖 Generated with [Claude Code](https://claude.ai/code)