### PR TITLE
docs: Update documentation for binary separation architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,18 @@ KECS (Kubernetes-based ECS Compatible Service) is a standalone service that prov
 
 ### Building and Running
 ```bash
-make build          # Build the binary to bin/kecs
-make run            # Build and run the application
+make build          # Build both CLI and server binaries
+make build-cli      # Build CLI binary only (bin/kecs - no DuckDB/CGO)
+make build-server   # Build server binary (bin/kecs-server - with DuckDB/CGO)
+make run            # Build and run CLI
+make run-server     # Build and run server
 make all            # Clean, format, vet, test, and build
 ```
+
+#### Binary Architecture
+KECS is split into two binaries to resolve cross-compilation issues:
+- **kecs** (CLI): Lightweight client without DuckDB, cross-platform compatible
+- **kecs-server**: Full server with DuckDB support, runs in containers
 
 ### Container-based Execution
 ```bash

--- a/README.md
+++ b/README.md
@@ -105,9 +105,17 @@ kecs stop  # Shows a list to select from
 
 ```bash
 git clone https://github.com/nandemo-ya/kecs.git
-cd kecs/controlplane
-make build
+cd kecs
+make build          # Build both CLI and server binaries
+# or
+make build-cli      # Build CLI only (cross-platform compatible)
+make build-server   # Build server with DuckDB support
 ```
+
+#### Binary Architecture
+KECS uses a dual-binary architecture:
+- **kecs** (CLI): Command-line interface for managing KECS instances (no CGO dependencies)
+- **kecs-server**: Server binary with DuckDB support for data persistence (runs in containers)
 
 ### Development Setup
 
@@ -209,8 +217,14 @@ docker compose up
 #### Building Docker Images
 
 ```bash
-# Build API image
+# Build main Docker image (with kecs-server binary)
+make docker-build
+
+# Build API-only image
 make docker-build-api
+
+# Build for local k3d registry (development)
+make docker-build-dev
 ```
 
 ## API Endpoints


### PR DESCRIPTION
## Summary
Update documentation to reflect the new binary separation architecture introduced in PR #633.

## Changes
- **CLAUDE.md**: 
  - Added separate `make build-cli` and `make build-server` commands
  - Explained the dual-binary architecture (kecs CLI vs kecs-server)
  
- **README.md**:
  - Updated installation instructions with new build targets
  - Added binary architecture explanation
  - Updated Docker build commands documentation

## Context
Following the merge of PR #633, the project now uses two separate binaries:
- `kecs`: CLI without DuckDB (cross-platform compatible)
- `kecs-server`: Server with DuckDB support (runs in containers)

This documentation update ensures users understand the new build system.

🤖 Generated with [Claude Code](https://claude.ai/code)