### PR TITLE
fix: Fix GoReleaser configuration for GitHub Actions CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,9 @@ version: 2
 
 before:
   hooks:
-    - sh -c "cd controlplane && go mod tidy"
-    - sh -c "cd controlplane && go mod download"
+    # Working directory is handled by builds.dir, so we can use simple commands
+    - go mod tidy -C ./controlplane
+    - go mod download -C ./controlplane
 
 builds:
   - id: kecs
@@ -64,7 +65,7 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - README.md
       - LICENSE
@@ -75,7 +76,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
Fix GoReleaser configuration to resolve build errors in GitHub Actions CI/CD pipeline.

## Problem
The GoReleaser workflow was failing with:
- `cd: executable file not found in $PATH` error in before hooks
- Several deprecation warnings that could cause future failures

## Solution
1. **Before hooks fix**: Replace `cd` command with `go mod -C` flag which is supported in CI environment
2. **Fix deprecated configurations**:
   - `snapshot.name_template` → `snapshot.version_template`
   - `archives.format_overrides.format` → `archives.format_overrides.formats`
3. Keep `brews` section (though deprecated) as it still works and changing to `homebrew` causes validation errors

## Test Results
- Local validation: `goreleaser check` passes with only a non-blocking deprecation warning about `brews`
- Configuration is now compatible with GoReleaser v2

## Related Issues
- Follows up on PR #633 (binary separation)
- Resolves GoReleaser CI failures preventing releases

🤖 Generated with [Claude Code](https://claude.ai/code)