### PR TITLE
fix: Correct GoReleaser main path for build directory context

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ before:
 
 builds:
   - id: kecs
-    main: ../cmd/controlplane
+    main: ./cmd/controlplane
     binary: kecs
     dir: ./controlplane  # Set working directory to controlplane where go.mod exists
     env:


### PR DESCRIPTION
## Summary
Fix GoReleaser main path to work correctly with the build directory context.

## Problem
GoReleaser was failing with:
```
build failed: couldn't find main file: stat cmd/controlplane: no such file or directory
```

The issue was that the `main` path was set to `../cmd/controlplane` which, when combined with `dir: ./controlplane`, was looking for the file outside the correct directory structure.

## Solution
Change `main` path from `../cmd/controlplane` to `./cmd/controlplane` since the working directory is already set to `./controlplane`.

## Directory Structure Context
```
kecs/
├── controlplane/
│   ├── go.mod
│   └── cmd/
│       └── controlplane/
│           └── main.go
```

With `dir: ./controlplane`, GoReleaser changes to the `controlplane` directory, so the main file is at `./cmd/controlplane` relative to that directory.

## Related
- Follows PR #635 (GoReleaser hooks fixes)
- Part of ongoing efforts to fix CI/CD pipeline for releases

🤖 Generated with [Claude Code](https://claude.ai/code)