### PR TITLE
fix: Specify Formula folder path for Homebrew updates in GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -146,6 +146,7 @@ release:
 # Homebrew formula update
 brews:
   - name: kecs
+    folder: Formula
     repository:
       owner: nandemo-ya
       name: homebrew-kecs


### PR DESCRIPTION
## Summary
Fix the Homebrew formula file path in GoReleaser configuration to correctly update `Formula/kecs.rb` instead of `kecs.rb` at the root.

## Problem
GoReleaser was failing with:
```
homebrew formula: could not update "kecs.rb": PUT https://api.github.com/repos/nandemo-ya/homebrew-kecs/contents/kecs.rb: 409 Repository rule violations found
Changes must be made through a pull request.
```

The issue was twofold:
1. The formula file is located at `Formula/kecs.rb`, not at the repository root
2. The homebrew-kecs repository has branch protection enabled (which we already addressed with PR configuration in #637)

## Solution
Added `folder: Formula` to the Homebrew configuration in `.goreleaser.yml` to specify the correct directory path.

## File Structure in homebrew-kecs
```
homebrew-kecs/
├── Formula/
│   ├── kecs.rb       # Main formula (this is what needs updating)
│   └── kecs-dev.rb   # Development formula
├── README.md
└── LICENSE
```

## Related PRs
- Follows #637 (added PR-based updates, but path was still incorrect)
- Part of ongoing GoReleaser fixes for successful releases

🤖 Generated with [Claude Code](https://claude.ai/code)