### PR TITLE
fix: Use 'directory' instead of 'folder' in GoReleaser Homebrew config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -146,7 +146,7 @@ release:
 # Homebrew formula update
 brews:
   - name: kecs
-    folder: Formula
+    directory: Formula
     repository:
       owner: nandemo-ya
       name: homebrew-kecs


### PR DESCRIPTION
## Summary
Fix GoReleaser configuration by using the correct field name `directory` instead of `folder` for specifying the Formula path in the homebrew tap repository.

## Problem
GoReleaser v2 was failing with:
```
yaml: unmarshal errors:
  line 149: field folder not found in type config.Homebrew
```

## Solution
Changed `folder: Formula` to `directory: Formula` in the Homebrew configuration.

## GoReleaser v2 Field Names
- ❌ `folder` - Not recognized in GoReleaser v2
- ✅ `directory` - Correct field name for specifying the formula location

## Testing
Local validation with `goreleaser check` now passes successfully:
```
• checking                                  path=.goreleaser.yml
• brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
• 1 configuration file(s) validated
• thanks for using GoReleaser!
```

## Related PRs
- Fixes issue introduced in #638 where we used the wrong field name
- Part of ongoing GoReleaser configuration fixes

🤖 Generated with [Claude Code](https://claude.ai/code)