### PR TITLE
fix: Configure GoReleaser Homebrew PR mode correctly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -150,9 +150,12 @@ brews:
     repository:
       owner: nandemo-ya
       name: homebrew-kecs
+      branch: "{{ .ProjectName }}-{{ .Version }}"
       pull_request:
         enabled: true
         base:
+          owner: nandemo-ya
+          name: homebrew-kecs
           branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Summary
- Properly configure GoReleaser to create PRs for Homebrew formula updates instead of attempting direct pushes

## Changes
- Add `branch` template to create feature branches named 'kecs-<version>'  
- Include complete `base` configuration for PR target (owner, name, branch)
- This ensures GoReleaser creates PRs to the protected main branch

## Problem
GoReleaser was attempting to directly push to the main branch of homebrew-kecs repository, which failed due to branch protection rules requiring pull requests.

## Solution  
With this configuration, GoReleaser will:
1. Create a feature branch named `kecs-v<version>` in the homebrew-kecs repo
2. Update the Formula/kecs.rb file on that branch
3. Open a PR from the feature branch to main branch
4. Allow review and approval before merging

## Testing
- Configuration validated with `goreleaser check`
- Follows GoReleaser v2 documentation for Homebrew PR mode

Related to #635, #636, #637, #638, #639