### PR TITLE
fix: Update controlplane binary path after binary separation

### DIFF
--- a/controlplane/internal/host/instance/helpers.go
+++ b/controlplane/internal/host/instance/helpers.go
@@ -208,6 +208,7 @@ func (m *Manager) deployControlPlane(ctx context.Context, instanceName string, c
 	}
 
 	// Create control plane config
+	logging.Info("Using control plane image", "image", cfg.Server.ControlPlaneImage)
 	controlPlaneConfig := &resources.ControlPlaneConfig{
 		Image:           cfg.Server.ControlPlaneImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,

--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -559,7 +559,7 @@ func createDeployment(config *ControlPlaneConfig) *appsv1.Deployment {
 							Name:            "controlplane",
 							Image:           config.Image,
 							ImagePullPolicy: config.ImagePullPolicy,
-							Command:         []string{"/controlplane"},
+							Command:         []string{"/kecs-server"},
 							Args:            []string{"server"},
 							Env:             envVars,
 							Ports: []corev1.ContainerPort{


### PR DESCRIPTION
## Summary

After the binary separation in #641, the controlplane was failing to start because the Kubernetes deployment manifest was still using the old `/controlplane` binary path instead of the new `/kecs-server` path.

## Problem
- Docker image builds with the new binary at `/kecs-server`
- Kubernetes deployment was still trying to execute `/controlplane`
- This caused pod startup failures with "exec: /controlplane: no such file or directory" error

## Solution
- Updated the deployment command from `/controlplane` to `/kecs-server` in `controlplane/internal/kubernetes/resources/controlplane.go`
- Added debug logging to track which control plane image is being used

## Testing
- Created new KECS instance with the fix
- Verified controlplane pod starts successfully
- All pods are now in Running state

## Related
- Fixes issues introduced in #641 (Binary separation)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>