### PR TITLE
fix: Handle nil config in instance List method

### DIFF
--- a/controlplane/internal/host/instance/manager.go
+++ b/controlplane/internal/host/instance/manager.go
@@ -397,6 +397,16 @@ func (m *Manager) List(ctx context.Context) ([]InstanceInfo, error) {
 		// Load instance config to get ports
 		cfg, _ := LoadInstanceConfig(clusterInfo.Name)
 
+		// Default values if config couldn't be loaded
+		apiPort := 0
+		adminPort := 0
+		localStack := false
+		if cfg != nil {
+			apiPort = cfg.APIPort
+			adminPort = cfg.AdminPort
+			localStack = cfg.LocalStack
+		}
+
 		// Check for data directory
 		home, _ := os.UserHomeDir()
 		dataDir := filepath.Join(home, ".kecs", "instances", clusterInfo.Name, "data")
@@ -408,10 +418,10 @@ func (m *Manager) List(ctx context.Context) ([]InstanceInfo, error) {
 		instances = append(instances, InstanceInfo{
 			Name:       clusterInfo.Name,
 			Status:     status,
-			ApiPort:    cfg.APIPort,
-			AdminPort:  cfg.AdminPort,
+			ApiPort:    apiPort,
+			AdminPort:  adminPort,
 			HasData:    hasData,
-			LocalStack: cfg.LocalStack,
+			LocalStack: localStack,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Fix panic in instance manager List method when LoadInstanceConfig returns nil
- Add nil check and use default values when config cannot be loaded

## Problem
The instance manager's List method was causing a panic when LoadInstanceConfig failed to load a config file, returning nil. The code was attempting to access fields on the nil config pointer, causing a runtime panic.

## Solution
- Added nil check for the config returned by LoadInstanceConfig
- Use default values (0 for ports, false for localStack) when config is nil
- This ensures the List method can continue even when config files are missing or invalid

## Test Results
✅ All tests now pass:
- Instance manager tests: 6/6 passed
- Pre-commit hooks: All passed

Fixes the failing test that was preventing commits in other branches.