### PR TITLE
feat(tui): Improve instance navigation with horizontal carousel

### DIFF
--- a/controlplane/internal/host/instance/manager.go
+++ b/controlplane/internal/host/instance/manager.go
@@ -396,8 +396,6 @@ func (m *Manager) List(ctx context.Context) ([]InstanceInfo, error) {
 
 		// Load instance config to get ports
 		cfg, _ := LoadInstanceConfig(clusterInfo.Name)
-
-		// Default values if config couldn't be loaded
 		apiPort := 0
 		adminPort := 0
 		localStack := false

--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -126,10 +126,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if !dialogActive {
 			if keyStr == "tab" {
-				return m.switchToNextInstance()
+				cmd := m.switchToNextInstance()
+				return m, cmd
 			}
 			if keyStr == "shift+tab" {
-				return m.switchToPreviousInstance()
+				cmd := m.switchToPreviousInstance()
+				return m, cmd
 			}
 		}
 
@@ -174,6 +176,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.ready = true
+		// Update carousel parameters when window size changes
+		m.calculateMaxVisibleInstances()
+		m.updateCarouselOffset()
 
 	case spinner.TickMsg:
 		// Update spinner if deleting

--- a/controlplane/internal/tui/keybindings.go
+++ b/controlplane/internal/tui/keybindings.go
@@ -126,6 +126,7 @@ func (r *KeyBindingsRegistry) registerGlobalBindings() {
 		{Keys: []string{"r"}, Description: "Refresh", Action: ActionRefresh, Global: true},
 		{Keys: []string{"h"}, Description: "Home", Action: ActionGoHome, Global: true},
 		{Keys: []string{"ctrl+i"}, Description: "Switch instance", Action: ActionSwitchInstance, Global: true},
+		{Keys: []string{"D"}, Description: "Delete instance", Action: ActionDeleteInstance, Global: true},
 	}
 
 	for _, binding := range globalBindings {

--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -646,9 +646,9 @@ func (m *Model) updateCarouselOffset() {
 }
 
 // switchToNextInstance switches to the next instance in the carousel
-func (m Model) switchToNextInstance() (Model, tea.Cmd) {
+func (m *Model) switchToNextInstance() tea.Cmd {
 	if len(m.instances) <= 1 {
-		return m, nil
+		return nil
 	}
 
 	currentIdx := m.getSelectedInstanceIndex()
@@ -667,20 +667,20 @@ func (m Model) switchToNextInstance() (Model, tea.Cmd) {
 
 	// Load data for the new instance
 	if m.useMockData {
-		return m, mock.LoadAllData(
+		return mock.LoadAllData(
 			m.selectedInstance,
 			m.selectedCluster,
 			m.selectedService,
 			m.selectedTask,
 		)
 	}
-	return m, m.loadDataFromAPI()
+	return m.loadDataFromAPI()
 }
 
 // switchToPreviousInstance switches to the previous instance in the carousel
-func (m Model) switchToPreviousInstance() (Model, tea.Cmd) {
+func (m *Model) switchToPreviousInstance() tea.Cmd {
 	if len(m.instances) <= 1 {
-		return m, nil
+		return nil
 	}
 
 	currentIdx := m.getSelectedInstanceIndex()
@@ -702,12 +702,12 @@ func (m Model) switchToPreviousInstance() (Model, tea.Cmd) {
 
 	// Load data for the new instance
 	if m.useMockData {
-		return m, mock.LoadAllData(
+		return mock.LoadAllData(
 			m.selectedInstance,
 			m.selectedCluster,
 			m.selectedService,
 			m.selectedTask,
 		)
 	}
-	return m, m.loadDataFromAPI()
+	return m.loadDataFromAPI()
 }

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -178,20 +178,39 @@ func (m Model) renderInstanceCarousel() string {
 		return emptyStateStyle.Render("No KECS instances | Press i to create instance")
 	}
 
-	// Calculate visible instances
-	m.calculateMaxVisibleInstances()
-	m.updateCarouselOffset()
+	// Calculate visible instances (read-only in render)
+	avgInstanceWidth := 20 // Average width per instance name + spacing
+	indicatorWidth := 4    // Space for "◀ " and " ▶"
+	padding := 4           // General padding
+
+	availableWidth := m.width - indicatorWidth - padding
+	maxVisibleInstances := availableWidth / avgInstanceWidth
+	if maxVisibleInstances < 1 {
+		maxVisibleInstances = 1
+	}
+
+	// Calculate carousel offset for current selection
+	selectedIdx := m.getSelectedInstanceIndex()
+	carouselOffset := m.instanceCarouselOffset
+
+	// Adjust offset if needed (but don't modify state)
+	if selectedIdx < carouselOffset {
+		carouselOffset = selectedIdx
+	}
+	if selectedIdx >= carouselOffset+maxVisibleInstances {
+		carouselOffset = selectedIdx - maxVisibleInstances + 1
+	}
 
 	var items []string
 
 	// Add left navigation indicator if needed
-	if m.instanceCarouselOffset > 0 {
+	if carouselOffset > 0 {
 		items = append(items, dimStyle.Render("◀"))
 	}
 
 	// Determine the range of instances to display
-	startIdx := m.instanceCarouselOffset
-	endIdx := startIdx + m.maxVisibleInstances
+	startIdx := carouselOffset
+	endIdx := startIdx + maxVisibleInstances
 	if endIdx > len(m.instances) {
 		endIdx = len(m.instances)
 	}
@@ -1480,6 +1499,7 @@ func (m Model) renderGlobalShortcutsLine(width int) string {
 		ActionMoveUp,
 		ActionMoveDown,
 		ActionBack,
+		ActionDeleteInstance,
 		ActionHelp,
 		ActionRefresh,
 		ActionQuit,
@@ -2073,6 +2093,7 @@ func (m Model) renderHelpContent(maxHeight int) string {
 		keyStyle.Render("<y>") + "           " + descStyle.Render("Copy full details"),
 		"",
 		lipgloss.NewStyle().Bold(true).Underline(true).Render("Application:"),
+		keyStyle.Render("<D>") + "           " + descStyle.Render("Delete current instance"),
 		keyStyle.Render("<ctrl-c>") + "     " + descStyle.Render("Quit application"),
 		"",
 		lipgloss.NewStyle().Bold(true).Underline(true).Render("JSON View (Task Defs):"),


### PR DESCRIPTION
## Summary
- Replace vertical instance list with horizontal carousel navigation
- Auto-select first instance on startup for streamlined UX
- Add D key binding for deleting current instance
- Fix tab/shift+tab instance switching to properly load data

## Changes
1. **Instance carousel navigation**
   - Implemented horizontal carousel for instance switching
   - Tab/Shift+Tab keys switch between instances
   - Visual indicators show selected instance

2. **Auto-selection behavior**
   - Automatically select first instance when instances exist
   - Skip instance list view and go directly to clusters
   - Show "no instances" view only when empty

3. **Delete instance functionality**
   - Added D (capital) key binding for deleting current instance
   - Shows confirmation dialog before deletion
   - Displayed in global menu and help view

4. **Bug fixes**
   - Fixed nil pointer dereference in instance manager List method
   - Fixed state persistence issues with pointer receivers
   - Ensure tab switching loads new instance data properly

## Test plan
- [x] Start TUI with existing instances - should auto-select first and show clusters
- [x] Tab/Shift+Tab switches instances and loads their data
- [x] D key shows delete confirmation dialog
- [x] Help view (?) shows D key in Application section
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)