### PR TITLE
feat(tui): Hide navigation panel on welcome screen

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -922,6 +922,26 @@ func (m Model) View() string {
 		return m.renderUpdatingProgress()
 	}
 
+	// Check if we should show the welcome screen (no instances)
+	if len(m.instances) == 0 && m.currentView == ViewInstances {
+		// Welcome screen - no navigation panel, use full screen for welcome message
+		welcomeContent := m.renderNoInstancesView()
+		footer := m.renderFooter()
+
+		// Use full height for welcome content
+		availableHeight := m.height - 1 // -1 for footer
+		welcomePanel := lipgloss.NewStyle().
+			Height(availableHeight).
+			Width(m.width).
+			Render(welcomeContent)
+
+		return lipgloss.JoinVertical(lipgloss.Top,
+			welcomePanel,
+			footer,
+		)
+	}
+
+	// Normal layout with navigation panel
 	// Calculate exact heights for panels
 	footerHeight := 1
 	availableHeight := m.height - footerHeight

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -764,39 +764,48 @@ func (m Model) renderSummary() string {
 
 // renderNoInstancesView renders a view when no instances exist
 func (m Model) renderNoInstancesView() string {
-	// Center the content
-	height := m.height - 10 // Account for header, footer, etc.
-	width := m.width - 4
+	// Use the full available height
+	height := m.height - 1 // -1 for footer only
 
-	// Create the welcome message
-	var lines []string
-	lines = append(lines, "")
-	lines = append(lines, "  🚀 Welcome to KECS")
-	lines = append(lines, "")
-	lines = append(lines, "  No KECS instances found.")
-	lines = append(lines, "")
-	lines = append(lines, "  Press 'i' to create your first instance")
-	lines = append(lines, "  Press '?' for help")
-	lines = append(lines, "")
+	// Create styled welcome message components
+	emojiStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#f9e2af")).
+		Bold(true)
 
-	// Center the content vertically
-	topPadding := (height - len(lines)) / 2
-	if topPadding > 0 {
-		padding := make([]string, topPadding)
-		lines = append(padding, lines...)
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#f5c2e7")).
+		Bold(true)
+
+	messageStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#a6adc8"))
+
+	keyStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#a6e3a1")).
+		Bold(true)
+
+	descStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#9399b2"))
+
+	// Build the welcome content
+	lines := []string{
+		emojiStyle.Render("🚀") + " " + titleStyle.Render("Welcome to KECS"),
+		"",
+		messageStyle.Render("No KECS instances found."),
+		"",
+		"Press " + keyStyle.Render("'i'") + " " + descStyle.Render("to create your first instance"),
+		"Press " + keyStyle.Render("'?'") + " " + descStyle.Render("for help"),
 	}
 
-	// Join all lines
-	content := strings.Join(lines, "\n")
+	content := lipgloss.JoinVertical(lipgloss.Center, lines...)
 
-	// Apply styling
-	style := lipgloss.NewStyle().
-		Width(width).
-		Height(height).
-		Align(lipgloss.Center).
-		AlignVertical(lipgloss.Center)
-
-	return style.Render(content)
+	// Center the content both horizontally and vertically
+	return lipgloss.Place(
+		m.width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		content,
+	)
 }
 
 // renderInstancesList renders the instances list with the given height constraint


### PR DESCRIPTION
## Summary
- Hide navigation panel when no instances exist to provide cleaner welcome screen
- Use full screen height for welcome message
- Improve welcome message styling with better colors and formatting

## Changes
1. **Welcome Screen Layout**
   - Detect when no instances exist and show welcome screen
   - Skip navigation panel rendering for welcome view
   - Use full available height for centered welcome content

2. **Welcome Message Styling**
   - Improved color scheme with styled key hints
   - Better visual hierarchy with emoji and title styling
   - Clear instructions for creating first instance

## Screenshots
Before: Navigation panel takes 30% of screen even when empty
After: Full screen welcome message with clean, centered layout

## Test plan
- [x] Start TUI with no instances - shows full screen welcome
- [x] Press 'i' to create instance - works as expected  
- [x] After creating instance - shows normal layout with navigation panel
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)