### PR TITLE
fix(tui): Fix navigation and shortcuts after instance creation

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -428,14 +428,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.taskDefEditor = nil
 
 	case closeFormMsg:
-		// Close the instance creation form and go back to instances view
+		// Close the instance creation form
 		if m.currentView == ViewInstanceCreate {
-			m.currentView = ViewInstances
 			if m.instanceForm != nil {
 				m.instanceForm.Reset()
 			}
-			// Reload instances list
-			cmds = append(cmds, m.loadMockDataCmd())
+
+			// If an instance was created and selected, go to Clusters view
+			// Otherwise, go back to Instances view
+			if m.selectedInstance != "" {
+				m.currentView = ViewClusters
+				m.clusterCursor = 0
+				// Load data for the selected instance
+				cmds = append(cmds, m.loadDataFromAPI())
+			} else {
+				m.currentView = ViewInstances
+				// Reload instances list
+				cmds = append(cmds, m.loadMockDataCmd())
+			}
 		}
 
 	case instanceCreationStatusMsg:

--- a/controlplane/internal/tui/keybindings.go
+++ b/controlplane/internal/tui/keybindings.go
@@ -142,7 +142,6 @@ func (r *KeyBindingsRegistry) registerViewBindings() {
 	// Instances view
 	r.registerViewKeys(ViewInstances, []KeyBinding{
 		{Keys: []string{"enter"}, Description: "Select", Action: ActionSelect},
-		{Keys: []string{"n"}, Description: "New instance", Action: ActionNewInstance},
 		{Keys: []string{"s"}, Description: "Start/Stop", Action: ActionToggleInstance},
 		{Keys: []string{"d"}, Description: "Delete", Action: ActionDeleteInstance},
 		{Keys: []string{"t"}, Description: "Task defs", Action: ActionNavigateTaskDefs,


### PR DESCRIPTION
## Summary
Fixes the issue where the 'n' key showed "New Instance" instead of "Create Cluster" after creating a new instance.

## Problem
When a user creates a new instance through the TUI, the view should navigate to the Clusters view for that instance. However, the following issues were observed:
1. After instance creation, the view stayed in Instances view instead of moving to Clusters view
2. The 'n' key showed "New Instance" shortcut instead of "Create Cluster" 
3. Duplicate shortcuts: both 'n' and 'i' keys could create new instances

## Solution
1. **Fixed navigation flow**: After instance creation, properly navigate to Clusters view when an instance is selected
2. **Removed duplicate shortcut**: Removed 'n' key from Instances view (keeping only 'i' key as the global shortcut for instance creation)
3. **Proper view switching**: Enhanced the `closeFormMsg` handler to check if an instance was selected and navigate accordingly

## Changes
- Modified `closeFormMsg` handler in `app.go` to navigate to Clusters view when an instance is selected
- Removed duplicate 'n' key binding from Instances view in `keybindings.go`
- Kept 'i' key as the only global shortcut for creating instances

## Testing
- Create a new instance using 'i' key
- After creation, verify that:
  - View switches to Clusters view
  - 'n' key now shows "Create cluster" (not "New instance")
  - Navigation shortcuts work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)