### PR TITLE
feat(tui): Multiple TUI improvements and fixes

### DIFF
--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -448,9 +448,6 @@ func (m *Model) isInDialogView() bool {
 
 func (m *Model) goBack() {
 	switch m.currentView {
-	case ViewClusters:
-		m.currentView = ViewInstances
-		m.selectedInstance = ""
 	case ViewServices:
 		m.currentView = ViewClusters
 		m.selectedCluster = ""

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -2667,7 +2667,13 @@ func (m Model) renderResourcePanelWithHeight(panelHeight int) string {
 	case ViewTaskDefinitionFamilies:
 		content = m.renderTaskDefFamiliesList(contentHeight)
 	case ViewTaskDefinitionRevisions:
-		content = m.renderTaskDefRevisionsList(contentHeight, m.width-8)
+		if m.showTaskDefJSON {
+			// Show two-column view with JSON
+			content = m.renderTaskDefRevisionsTwoColumn(contentHeight)
+		} else {
+			// Show only the revisions list
+			content = m.renderTaskDefRevisionsList(contentHeight, m.width-8)
+		}
 	default:
 		content = "View not implemented"
 	}

--- a/controlplane/internal/tui/task_def_editor.go
+++ b/controlplane/internal/tui/task_def_editor.go
@@ -495,12 +495,14 @@ func (e *TaskDefinitionEditor) saveTaskDefinition() tea.Cmd {
 		return nil
 	}
 
+	// Store the JSON content to pass to the API
+	jsonContent := e.content
+
 	return func() tea.Msg {
-		// In a real implementation, this would call the API
-		// For now, just return a success message
-		return editorSaveMsg{
-			family:   e.family,
-			revision: 1, // Would be determined by API
+		// Return a message with the JSON content to be saved
+		return editorSaveRequestMsg{
+			family:      e.family,
+			jsonContent: jsonContent,
 		}
 	}
 }
@@ -785,6 +787,11 @@ func (e *TaskDefinitionEditor) moveToPrevWord(lines []string) {
 type editorSaveMsg struct {
 	family   string
 	revision int
+}
+
+type editorSaveRequestMsg struct {
+	family      string
+	jsonContent string
 }
 
 type editorQuitMsg struct{}


### PR DESCRIPTION
## Summary
This PR includes multiple TUI improvements and bug fixes to enhance the user experience, particularly around task definition management and navigation.

## Changes

### Navigation Improvements
- 🔧 Fixed ESC key not working on Clusters screen (it's now the home view after hiding Instances view)
- 🔧 Removed ViewInstances checks from navigation logic since it's now hidden by default
- 🔧 Updated Home action (h key) to navigate to Clusters view instead of the hidden Instances view

### UI Enhancements
- ✨ Added footer to main layout for displaying:
  - Clipboard messages when yanking (y key)
  - Search input when in search mode (/)
  - Command input when in command mode (:)
- 🔧 Fixed task definition JSON display to properly show in two-column layout when toggled (Enter key)

### Task Definition Editor Fixes
- 🔧 Fixed Task Definition Editor not loading content when editing an existing revision
- 🔧 Fixed ESC key behavior in vim modes:
  - In Insert/Command mode: ESC returns to Normal mode (proper vim behavior)
  - In Normal mode: ESC exits the editor
- ✨ Implemented actual task definition save functionality:
  - `:w` command now calls the API to register the task definition
  - Creates a new revision that persists in the system
  - Shows success message and returns to revisions list

## Test Plan
- [x] Verified ESC key works correctly in all views
- [x] Tested navigation between views works as expected
- [x] Confirmed footer displays clipboard messages when yanking
- [x] Tested task definition JSON toggle displays correctly
- [x] Verified task definition editor loads content properly
- [x] Tested vim mode ESC key behavior in editor
- [x] Confirmed `:w` saves task definition to API

## Screenshots
The changes improve the overall TUI experience with better navigation, visual feedback, and functional task definition management.

🤖 Generated with Claude Code