### PR TITLE
fix(tui): Enable log viewer search functionality with slash key

### DIFF
--- a/controlplane/internal/tui/log_viewer.go
+++ b/controlplane/internal/tui/log_viewer.go
@@ -481,3 +481,8 @@ func (m LogViewerModel) View() string {
 		footer,
 	)
 }
+
+// IsSearchFocused returns whether the search bar is currently focused
+func (m LogViewerModel) IsSearchFocused() bool {
+	return m.searchBar.Focused()
+}


### PR DESCRIPTION
## Summary
Fixes log viewer search/filtering functionality that was not working due to global action handling intercepting the '/' key.

## Problem
- When pressing '/' in the log viewer, the global search mode was being activated instead of the log viewer's internal search bar
- The log viewer couldn't receive keyboard input for its search functionality
- Users couldn't filter logs by search terms

## Solution
- Handle ViewLogs keys before processing global actions in app.go's Update method
- This allows the log viewer to process all keys directly, including '/'
- Added IsSearchFocused() method to LogViewerModel for proper ESC key handling

## Changes
- Modified app.go to prioritize ViewLogs key handling
- Added IsSearchFocused() method to log_viewer.go
- Fixed ESC key behavior to only exit log viewer when search bar is not focused

## Testing
After this fix, in the log viewer:
- Press '/' to focus the search bar
- Type search terms to filter logs in real-time
- Press ESC to clear the search (without exiting log viewer)
- Press ESC again (when search is not focused) to exit log viewer

Fixes the log filtering issue reported during TUI usage.