### PR TITLE
fix: Add retry mechanism for DuckDB write-write conflicts

### DIFF
--- a/controlplane/internal/controlplane/api/task_definition_ecs_api.go
+++ b/controlplane/internal/controlplane/api/task_definition_ecs_api.go
@@ -456,15 +456,20 @@ func (api *DefaultECSAPI) ListTaskDefinitions(ctx context.Context, req *generate
 		return nil, fmt.Errorf("failed to list task definition families: %w", err)
 	}
 
+	logging.Info("ListTaskDefinitions: found families", "count", len(families), "familyPrefix", familyPrefix, "status", status)
+
 	// Collect all revisions for matching families
 	var allRevisions []string
 	for _, family := range families {
+		// When listing all task definitions, we should include all statuses if not specified
 		revisions, _, err := api.storage.TaskDefinitionStore().ListRevisions(ctx, family.Family, status, 0, "")
 		if err != nil {
 			logging.Error("Failed to list revisions for family", "family", family.Family, "error", err)
 			continue
 		}
+		logging.Info("ListTaskDefinitions: found revisions", "family", family.Family, "count", len(revisions))
 		for _, rev := range revisions {
+			logging.Debug("ListTaskDefinitions: adding revision", "arn", rev.ARN)
 			allRevisions = append(allRevisions, rev.ARN)
 		}
 	}

--- a/controlplane/internal/storage/duckdb/attribute_store.go
+++ b/controlplane/internal/storage/duckdb/attribute_store.go
@@ -13,7 +13,8 @@ import (
 
 // attributeStore implements storage.AttributeStore
 type attributeStore struct {
-	db *sql.DB
+	db      *sql.DB
+	storage *DuckDBStorage
 }
 
 // Put creates or updates attributes
@@ -160,7 +161,7 @@ func (s *attributeStore) ListWithPagination(ctx context.Context, targetType, clu
 	query += fmt.Sprintf(" LIMIT $%d", argCount)
 	args = append(args, limit+1)
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.storage.QueryContextWithRecovery(ctx, query, args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to list attributes: %w", err)
 	}

--- a/controlplane/internal/storage/duckdb/task_store_test.go
+++ b/controlplane/internal/storage/duckdb/task_store_test.go
@@ -1,0 +1,194 @@
+package duckdb
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskStore_ConcurrentCreateOrUpdate(t *testing.T) {
+	// Skip test if running in CI without database
+	if testing.Short() {
+		t.Skip("Skipping database test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Create temporary database
+	dbPath := t.TempDir() + "/test.db"
+	duckDB, err := NewDuckDBStorage(dbPath)
+	require.NoError(t, err)
+	defer duckDB.Close()
+
+	// Initialize database
+	err = duckDB.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Create task store
+	store := duckDB.TaskStore()
+
+	// Prepare test task
+	baseTask := &storage.Task{
+		ID:                   "test-task-001",
+		ARN:                  "arn:aws:ecs:us-east-1:123456789012:task/default/test-task-001",
+		ClusterARN:           "arn:aws:ecs:us-east-1:123456789012:cluster/default",
+		TaskDefinitionARN:    "arn:aws:ecs:us-east-1:123456789012:task-definition/test-def:1",
+		LastStatus:           "PENDING",
+		DesiredStatus:        "RUNNING",
+		LaunchType:           "FARGATE",
+		CreatedAt:            time.Now(),
+		Containers:           "[]",
+		Version:              1,
+		EnableExecuteCommand: false,
+		Region:               "us-east-1",
+		AccountID:            "123456789012",
+	}
+
+	// Test concurrent updates
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	errors := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			// Create a copy of the task with different status
+			task := *baseTask
+			if idx%2 == 0 {
+				task.LastStatus = "RUNNING"
+			} else {
+				task.LastStatus = "PROVISIONING"
+			}
+			task.Version = int64(idx)
+
+			// Attempt to create or update
+			errors[idx] = store.CreateOrUpdate(ctx, &task)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Check that all operations succeeded (thanks to retry logic)
+	successCount := 0
+	for _, err := range errors {
+		if err == nil {
+			successCount++
+		} else {
+			t.Logf("Error occurred: %v", err)
+		}
+	}
+
+	// At least some operations should succeed
+	// With retry logic, we expect most or all to succeed
+	assert.Greater(t, successCount, 0, "At least one operation should succeed")
+	t.Logf("Success rate: %d/%d", successCount, numGoroutines)
+
+	// Verify the task was actually created/updated
+	retrievedTask, err := store.Get(ctx, "arn:aws:ecs:us-east-1:123456789012:cluster/default", "test-task-001")
+	assert.NoError(t, err)
+	assert.NotNil(t, retrievedTask)
+	if retrievedTask != nil {
+		assert.Equal(t, baseTask.ARN, retrievedTask.ARN)
+		assert.Contains(t, []string{"PENDING", "PROVISIONING", "RUNNING"}, retrievedTask.LastStatus)
+	}
+}
+
+func TestTaskStore_ConcurrentUpdate(t *testing.T) {
+	// Skip test if running in CI without database
+	if testing.Short() {
+		t.Skip("Skipping database test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Create temporary database
+	dbPath := t.TempDir() + "/test.db"
+	duckDB, err := NewDuckDBStorage(dbPath)
+	require.NoError(t, err)
+	defer duckDB.Close()
+
+	// Initialize database
+	err = duckDB.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Create task store
+	store := duckDB.TaskStore()
+
+	// Create initial task
+	initialTask := &storage.Task{
+		ID:                   "test-task-002",
+		ARN:                  "arn:aws:ecs:us-east-1:123456789012:task/default/test-task-002",
+		ClusterARN:           "arn:aws:ecs:us-east-1:123456789012:cluster/default",
+		TaskDefinitionARN:    "arn:aws:ecs:us-east-1:123456789012:task-definition/test-def:1",
+		LastStatus:           "PENDING",
+		DesiredStatus:        "RUNNING",
+		LaunchType:           "FARGATE",
+		CreatedAt:            time.Now(),
+		Containers:           "[]",
+		Version:              1,
+		EnableExecuteCommand: false,
+		Region:               "us-east-1",
+		AccountID:            "123456789012",
+	}
+
+	// Create the task first
+	err = store.Create(ctx, initialTask)
+	require.NoError(t, err)
+
+	// Test concurrent updates
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	errors := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			// Create a copy of the task with different status
+			task := *initialTask
+			task.LastStatus = "RUNNING"
+			task.Version = int64(idx + 2)
+
+			// Add some variation in the update timing
+			time.Sleep(time.Millisecond * time.Duration(idx))
+
+			// Attempt to update
+			errors[idx] = store.Update(ctx, &task)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Check that all operations succeeded (thanks to retry logic)
+	successCount := 0
+	for _, err := range errors {
+		if err == nil {
+			successCount++
+		} else {
+			t.Logf("Error occurred: %v", err)
+		}
+	}
+
+	// With retry logic, we expect most or all updates to succeed
+	assert.Greater(t, successCount, 0, "At least one update should succeed")
+	t.Logf("Update success rate: %d/%d", successCount, numGoroutines)
+
+	// Verify the task was actually updated
+	retrievedTask, err := store.Get(ctx, "arn:aws:ecs:us-east-1:123456789012:cluster/default", "test-task-002")
+	assert.NoError(t, err)
+	assert.NotNil(t, retrievedTask)
+	if retrievedTask != nil {
+		assert.Equal(t, "RUNNING", retrievedTask.LastStatus)
+		assert.Greater(t, retrievedTask.Version, int64(1))
+	}
+}


### PR DESCRIPTION
## WIP: DuckDB Write-Write Conflict Resolution

This PR implements a centralized recovery mechanism to handle DuckDB write-write conflicts that occur during controlplane restart.

## Problem
When the controlplane restarts with existing ECS services:
1. The restoration service reads from DuckDB to recreate Kubernetes resources
2. The sync controller simultaneously updates the same records  
3. This causes write-write conflicts that put DuckDB into a fatal/restricted state
4. All subsequent database operations fail until reconnection

## Solution Implemented
Added a centralized recovery mechanism in `DuckDBStorage` that:
- Detects fatal database errors (write-write conflicts, restricted mode)
- Automatically reconnects to the database
- Retries the failed operation once after recovery
- Provides wrapper methods for all database operations

## Changes
- Added `ExecuteWithRecovery`, `QueryContextWithRecovery`, `ExecContextWithRecovery`, `QueryRowContextWithRecovery` methods to DuckDBStorage
- Updated all store implementations to use recovery wrappers
- Added synchronization between restoration and sync controller startup

## Known Issues (Still Investigating)
- Tasks show as STOPPED in TUI after controlplane restart despite pods running
- ListTaskDefinitions returns empty results in some cases
- May need to downgrade go-duckdb version for stability

## Testing
1. Start KECS instance: `kecs start`
2. Deploy service: `cd examples/single-task-nginx && ./deploy.sh`
3. Restart controlplane: `make dev`
4. Check for write-write errors: `aws ecs list-clusters --endpoint-url http://localhost:5373`

## Status
🚧 **Work in Progress** - Exploring go-duckdb version downgrade as potential solution