### PR TITLE
perf: Improve cluster creation visibility and response time

### DIFF
--- a/controlplane/internal/controlplane/api/middleware.go
+++ b/controlplane/internal/controlplane/api/middleware.go
@@ -39,6 +39,12 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 
+		// Add cache control headers to prevent caching of API responses
+		// This ensures AWS CLI always gets fresh data
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+
 		// For API endpoints, set strict CSP
 		if !strings.HasPrefix(r.URL.Path, "/ui") && !strings.HasPrefix(r.URL.Path, "/ws") {
 			w.Header().Set("Content-Security-Policy", "default-src 'none'")

--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -640,6 +640,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if cmd != nil {
 				cmds = append(cmds, cmd)
 			}
+			// Reload data immediately after successful cluster creation
+			if msg.err == nil {
+				cmds = append(cmds, m.loadDataFromAPI())
+			}
 		}
 
 	case clusterFormCloseMsg:

--- a/controlplane/internal/tui/model.go
+++ b/controlplane/internal/tui/model.go
@@ -356,7 +356,7 @@ func NewModel() Model {
 
 	return Model{
 		currentView:      ViewInstances,
-		refreshInterval:  5 * time.Second,
+		refreshInterval:  2 * time.Second,
 		ready:            false,
 		commandPalette:   NewCommandPalette(),
 		apiClient:        api.NewHTTPClient("http://localhost:5373"),
@@ -374,7 +374,7 @@ func NewModelWithClient(client api.Client) Model {
 
 	return Model{
 		currentView:      ViewInstances,
-		refreshInterval:  5 * time.Second,
+		refreshInterval:  2 * time.Second,
 		ready:            false,
 		commandPalette:   NewCommandPalette(),
 		apiClient:        client,


### PR DESCRIPTION
## Summary
- Fixed issue where newly created ECS clusters took 15-30 seconds to appear in list results
- Improved TUI responsiveness for better user experience
- Added proper HTTP cache control headers to prevent client-side caching

## Changes
1. **TUI Improvements**
   - Reload data immediately after successful cluster creation
   - Reduced refresh interval from 5s to 2s for better responsiveness

2. **API Optimizations**  
   - Made namespace creation asynchronous to prevent blocking cluster visibility
   - Removed unnecessary LocalStack deployment function (already handled at instance startup)

3. **Cache Prevention**
   - Added HTTP cache control headers to ensure AWS CLI always gets fresh data
   - Headers: `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, `Expires: 0`

## Test Plan
- [x] Create cluster via TUI - verify it appears immediately
- [x] Create cluster via AWS CLI - verify immediate listing with `aws ecs list-clusters`
- [x] Verify cache headers are present in HTTP responses
- [x] Test TUI refresh interval is now 2 seconds
- [x] All existing tests pass

## Impact
These changes ensure newly created clusters appear immediately in both TUI and AWS CLI responses without any delay, significantly improving the user experience when managing ECS clusters.

🤖 Generated with [Claude Code](https://claude.ai/code)