### PR TITLE
docs: Update copyright year and add LocalStack acknowledgment

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Key Components:
 4. **State Storage**: DuckDB provides persistent storage for ECS resources
 5. **Workload Execution**: ECS tasks run as Kubernetes pods
 
+## Acknowledgments
+
+KECS integrates with [LocalStack](https://localstack.cloud/) to provide comprehensive AWS service emulation. We deeply appreciate the LocalStack team's work in making local AWS development accessible to everyone. Their excellent AWS emulation capabilities enable KECS to offer a complete local ECS development experience.
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/docs-site/.vitepress/config.js
+++ b/docs-site/.vitepress/config.js
@@ -122,7 +122,7 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2024 KECS Project'
+      copyright: 'Copyright © 2025 KECS Project'
     }
   }
 })


### PR DESCRIPTION
## Summary

This PR updates the copyright year and adds proper acknowledgment for LocalStack in the project documentation.

## Changes

### 📅 Copyright Update
- Updated copyright year from 2024 to 2025 in VitePress configuration

### 🙏 LocalStack Acknowledgment
- Added a new "Acknowledgments" section to README.md
- Expresses gratitude and respect to the LocalStack team
- Acknowledges their contribution to local AWS development
- Highlights how LocalStack enables KECS to provide a complete local ECS development experience

## Files Changed
- `docs-site/.vitepress/config.js` - Updated copyright year
- `README.md` - Added acknowledgments section

## Test Plan
- [x] Verify VitePress build succeeds with new copyright
- [x] Confirm acknowledgment section appears properly in README

🤖 Generated with [Claude Code](https://claude.ai/code)