### PR TITLE
fix: Remove unsupported 'after' field from GoReleaser v2 config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,44 +9,9 @@ before:
     - go mod tidy -C ./controlplane
     - go mod download -C ./controlplane
 
-# After all artifacts are built, notarize macOS archives
-# This runs after archives are created but before release
-after:
-  hooks:
-    # Notarize macOS archives (tar.gz files)
-    - cmd: sh
-      dir: ./dist
-      # Only run on macOS runners and when credentials are available
-      env:
-        - APPLE_ID={{ .Env.APPLE_ID }}
-        - APPLE_PASSWORD={{ .Env.NOTARIZATION_PASSWORD }}
-        - APPLE_TEAM_ID={{ .Env.APPLE_TEAM_ID }}
-      # Script to notarize all macOS archives
-      stdin: |
-        #!/bin/sh
-        if [ -z "$APPLE_ID" ] || [ -z "$APPLE_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
-          echo "Skipping notarization: credentials not configured"
-          exit 0
-        fi
-
-        # Find all macOS archives
-        # Note: We continue on notarization failures to not block releases
-        for file in *_Darwin_*.tar.gz; do
-          if [ -f "$file" ]; then
-            echo "Notarizing $file..."
-
-            # Submit for notarization
-            if xcrun notarytool submit "$file" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --wait; then
-              echo "Successfully notarized $file"
-            else
-              echo "Warning: Notarization failed for $file, continuing with release..."
-            fi
-          fi
-        done
+# Notarization will be handled as a post-archive hook
+# Note: GoReleaser v2 doesn't support 'after' hooks anymore
+# We'll need to handle notarization differently if needed
 
 builds:
   - id: kecs


### PR DESCRIPTION
## Summary

This PR fixes the GoReleaser configuration to be compatible with v2, which was causing the release workflow to fail.

## Problem

The release workflow was failing with the following error:
```
yaml: unmarshal errors:
  line 14: field after not found in type config.Project
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.12.2/arm64/goreleaser' failed with exit code 1
```

## Solution

GoReleaser v2 has removed support for the `after` field that was being used for macOS notarization. This PR removes the deprecated field to fix the configuration.

## Changes
- Removed the unsupported `after` field and its associated notarization hooks
- Added a comment noting that notarization will need to be handled differently if required

## Verification
✅ Configuration now validates successfully with `goreleaser check`

## Impact
This fix will allow releases to be created successfully again. macOS notarization will need to be implemented using a different approach if required in the future.

🤖 Generated with [Claude Code](https://claude.ai/code)