### PR TITLE
fix: Correct ldflags package path for version information embedding

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,9 +51,10 @@ builds:
           - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Version={{.Version}}
-      - -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.Commit={{.Commit}}
-      - -X github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd.BuildDate={{.Date}}
+      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.Version={{.Version}}
+      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GitCommit={{.Commit}}
+      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.BuildDate={{.Date}}
+      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GoVersion={{.Runtime.Goversion}}
 
 archives:
   - id: kecs


### PR DESCRIPTION
## Summary

This PR fixes the version information not being embedded correctly in the released binaries.

## Problem

When installing KECS via Homebrew (v0.0.1-beta.3), the version command shows:
```
$ kecs version
KECS Control Plane
Version:    dev
Git commit: unknown
Built:      unknown
Go version: unknown
```

## Root Cause

The GoReleaser ldflags were pointing to the wrong package path:
- ❌ `github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd`
- ✅ `github.com/nandemo-ya/kecs/controlplane/internal/version`

## Solution

Updated the ldflags in `.goreleaser.yml` to use the correct package path where the version variables are actually defined.

## Changes
- Fixed package path from `internal/controlplane/cmd` to `internal/version`
- Added `GoVersion` ldflags to show Go runtime version
- Now correctly embeds `Version`, `GitCommit`, `BuildDate`, and `GoVersion`

## Verification
✅ Configuration validates successfully with `goreleaser check`

## Expected Result
After this fix, the next release will correctly show:
```
$ kecs version
KECS Control Plane
Version:    v0.0.1-beta.4
Git commit: abc123...
Built:      2025-09-24T...
Go version: go1.21.0
```

🤖 Generated with [Claude Code](https://claude.ai/code)