### PR TITLE
fix: Switch to GitHub-hosted runners for public repository

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted, linux, medium]
+    runs-on: ubuntu-24.04
     # Skip tests on tag pushes
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     defaults:
@@ -88,7 +88,7 @@ jobs:
   build-and-push:
     name: Build and Push Docker image
     needs: [test]
-    runs-on: [self-hosted, linux, medium]
+    runs-on: ubuntu-24.04
     # Run on main branch pushes and tags, not on PRs
     # For tags, test job is skipped so we use always() to ensure this runs
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux, small]
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   # Single job using GoReleaser for all platforms
   goreleaser:
-    runs-on: [self-hosted, linux, medium]  # Use self-hosted runner for better performance
+    runs-on: ubuntu-24.04  # Use GitHub-hosted runner for public repo
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-all:
     name: Check All Components
-    runs-on: [self-hosted, linux, medium]
+    runs-on: ubuntu-24.04
     
     steps:
       - name: Checkout code

--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test-phases:
-    runs-on: [self-hosted, aws-testable, large]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Replace all self-hosted runners with GitHub-hosted runners (ubuntu-24.04)
- Public repositories cannot use self-hosted runners for security reasons

## Changes
- `build-and-release.yml`: Updated test and build-and-push jobs
- `claude.yml`: Updated to ubuntu-24.04
- `goreleaser.yml`: Updated with comment about public repo
- `pr-tests.yml`: Updated to ubuntu-24.04
- `scenario-tests.yml`: Updated to ubuntu-24.04

## Why
GitHub restricts self-hosted runners on public repositories to prevent security risks from untrusted code in pull requests from forks. Using GitHub-hosted runners is the recommended approach for public OSS projects.

## Test Plan
This PR itself will test that the workflows run correctly with GitHub-hosted runners.