### PR TITLE
feat(port-forward): Implement NodePort service creation for assignPublicIp (Phase 1)

### DIFF
--- a/controlplane/internal/storage/duckdb/duckdb.go
+++ b/controlplane/internal/storage/duckdb/duckdb.go
@@ -299,6 +299,9 @@ func (s *DuckDBStorage) createServicesTable(ctx context.Context) error {
 		account_id VARCHAR NOT NULL,
 		deployment_name VARCHAR,
 		namespace VARCHAR,
+		node_ports VARCHAR,
+		has_node_port BOOLEAN NOT NULL DEFAULT false,
+		assign_public_ip BOOLEAN NOT NULL DEFAULT false,
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL
 	)`

--- a/controlplane/internal/storage/interfaces.go
+++ b/controlplane/internal/storage/interfaces.go
@@ -356,6 +356,11 @@ type Service struct {
 	DeploymentName string `json:"deploymentName,omitempty"`
 	Namespace      string `json:"namespace,omitempty"`
 
+	// NodePort information (for port-forward support)
+	NodePorts      string `json:"nodePorts,omitempty"`      // JSON array of allocated NodePort numbers
+	HasNodePort    bool   `json:"hasNodePort"`              // Whether service uses NodePort
+	AssignPublicIp bool   `json:"assignPublicIp,omitempty"` // Whether assignPublicIp was enabled
+
 	// Service registry metadata for service discovery
 	ServiceRegistryMetadata map[string]string `json:"serviceRegistryMetadata,omitempty"`
 


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the port-forward feature as per ADR-0026 (#693), enabling automatic NodePort service creation when tasks have `assignPublicIp` enabled.

## Changes

- ✅ Modified service converter to check for `assignPublicIp` flag in network configuration
- ✅ Create NodePort services when `assignPublicIp` is ENABLED
- ✅ Add database fields to track NodePort allocations and assignPublicIp status
- ✅ Prioritize LoadBalancer type when both assignPublicIp and target groups are present
- ✅ Add proper annotations to indicate port-forward support

## Key Implementation Details

### Service Converter Changes
- Checks `NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp` field
- Creates NodePort services when the value is "ENABLED"
- Adds `kecs.dev/assign-public-ip` annotation for tracking
- Ensures compatibility with existing load balancer configurations

### Database Schema Updates
Added three new fields to the Service struct:
- `NodePorts`: JSON array to store allocated NodePort numbers
- `HasNodePort`: Boolean flag to indicate if service uses NodePort  
- `AssignPublicIp`: Boolean to track if assignPublicIp was enabled

## Testing

- ✅ All existing tests pass
- ✅ Build successful
- ✅ Pre-commit hooks passed (go-fmt, go-vet, controlplane-test)

## Related Issues

- Closes #588 (partially - Phase 1 implementation)
- Implements ADR-0026 from #693

## Next Steps (Future PRs)

1. **Phase 2**: Port allocation and management in ServiceManager
2. **Phase 3**: Port forward state storage and CLI commands
3. **Phase 4**: k3d integration for dynamic port mapping
4. **Phase 5**: Auto-reconnection and health monitoring

🤖 Generated with [Claude Code](https://claude.ai/code)