### PR TITLE
feat(port-forward): Implement Phase 2 - Basic Commands

### DIFF
--- a/controlplane/internal/controlplane/cmd/portforward.go
+++ b/controlplane/internal/controlplane/cmd/portforward.go
@@ -27,6 +27,20 @@ var portForwardCmd = &cobra.Command{
 This command provides background port forwarding with automatic management and configuration file support.`,
 }
 
+// getKubeconfigPath returns the kubeconfig path for the given instance
+func getKubeconfigPath(instanceName string) string {
+	return fmt.Sprintf("/tmp/kecs-%s.config", instanceName)
+}
+
+// getInstanceName returns the instance name from environment or default
+func getInstanceName() string {
+	instanceName := os.Getenv("KECS_INSTANCE")
+	if instanceName == "" {
+		instanceName = "default"
+	}
+	return instanceName
+}
+
 var portForwardStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start port forwarding",
@@ -45,14 +59,9 @@ var portForwardStartServiceCmd = &cobra.Command{
 		cluster := parts[0]
 		serviceName := parts[1]
 
-		// Get instance name from environment or flag
-		instanceName := os.Getenv("KECS_INSTANCE")
-		if instanceName == "" {
-			instanceName = "default"
-		}
-
-		// Get kubeconfig for the instance
-		kubeconfigPath := fmt.Sprintf("/tmp/kecs-%s.config", instanceName)
+		// Get instance name and kubeconfig path
+		instanceName := getInstanceName()
+		kubeconfigPath := getKubeconfigPath(instanceName)
 		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 			return fmt.Errorf("kubeconfig not found for instance %s. Is KECS running?", instanceName)
 		}
@@ -98,14 +107,9 @@ var portForwardStartTaskCmd = &cobra.Command{
 		cluster := parts[0]
 		taskID := parts[1]
 
-		// Get instance name from environment or flag
-		instanceName := os.Getenv("KECS_INSTANCE")
-		if instanceName == "" {
-			instanceName = "default"
-		}
-
-		// Get kubeconfig for the instance
-		kubeconfigPath := fmt.Sprintf("/tmp/kecs-%s.config", instanceName)
+		// Get instance name and kubeconfig path
+		instanceName := getInstanceName()
+		kubeconfigPath := getKubeconfigPath(instanceName)
 		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 			return fmt.Errorf("kubeconfig not found for instance %s. Is KECS running?", instanceName)
 		}

--- a/controlplane/internal/controlplane/cmd/portforward.go
+++ b/controlplane/internal/controlplane/cmd/portforward.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
+	"github.com/nandemo-ya/kecs/controlplane/internal/portforward"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	localPort   int
+	targetPort  int
+	allForwards bool
+)
+
+var portForwardCmd = &cobra.Command{
+	Use:   "port-forward",
+	Short: "Manage port forwarding for ECS services and tasks",
+	Long: `Manage port forwarding from your local machine to ECS services and tasks running in KECS.
+
+This command provides background port forwarding with automatic management and configuration file support.`,
+}
+
+var portForwardStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start port forwarding",
+}
+
+var portForwardStartServiceCmd = &cobra.Command{
+	Use:   "service <cluster>/<service-name>",
+	Short: "Start port forwarding to an ECS service",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parts := strings.Split(args[0], "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid format: expected <cluster>/<service-name>")
+		}
+
+		cluster := parts[0]
+		serviceName := parts[1]
+
+		// Get instance name from environment or flag
+		instanceName := os.Getenv("KECS_INSTANCE")
+		if instanceName == "" {
+			instanceName = "default"
+		}
+
+		// Get kubeconfig for the instance
+		kubeconfigPath := fmt.Sprintf("/tmp/kecs-%s.config", instanceName)
+		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+			return fmt.Errorf("kubeconfig not found for instance %s. Is KECS running?", instanceName)
+		}
+
+		// Create Kubernetes client
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to build config: %w", err)
+		}
+
+		k8sClient, err := kubernetes.NewClient(config)
+		if err != nil {
+			return fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
+
+		// Create port forward manager
+		manager := portforward.NewManager(instanceName, k8sClient)
+
+		// Start port forwarding for the service
+		forwardID, assignedPort, err := manager.StartServiceForward(context.Background(), cluster, serviceName, localPort, targetPort)
+		if err != nil {
+			return fmt.Errorf("failed to start port forward: %w", err)
+		}
+
+		fmt.Printf("Port forwarding started successfully\n")
+		fmt.Printf("Forward ID: %s\n", forwardID)
+		fmt.Printf("Forwarding localhost:%d -> %s/%s\n", assignedPort, cluster, serviceName)
+
+		return nil
+	},
+}
+
+var portForwardStartTaskCmd = &cobra.Command{
+	Use:   "task <cluster>/<task-id>",
+	Short: "Start port forwarding to an ECS task",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parts := strings.Split(args[0], "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid format: expected <cluster>/<task-id>")
+		}
+
+		cluster := parts[0]
+		taskID := parts[1]
+
+		// Get instance name from environment or flag
+		instanceName := os.Getenv("KECS_INSTANCE")
+		if instanceName == "" {
+			instanceName = "default"
+		}
+
+		// Get kubeconfig for the instance
+		kubeconfigPath := fmt.Sprintf("/tmp/kecs-%s.config", instanceName)
+		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+			return fmt.Errorf("kubeconfig not found for instance %s. Is KECS running?", instanceName)
+		}
+
+		// Create Kubernetes client
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to build config: %w", err)
+		}
+
+		k8sClient, err := kubernetes.NewClient(config)
+		if err != nil {
+			return fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
+
+		// Create port forward manager
+		manager := portforward.NewManager(instanceName, k8sClient)
+
+		// Start port forwarding for the task
+		forwardID, assignedPort, err := manager.StartTaskForward(context.Background(), cluster, taskID, localPort, targetPort)
+		if err != nil {
+			return fmt.Errorf("failed to start port forward: %w", err)
+		}
+
+		fmt.Printf("Port forwarding started successfully\n")
+		fmt.Printf("Forward ID: %s\n", forwardID)
+		fmt.Printf("Forwarding localhost:%d -> %s/%s\n", assignedPort, cluster, taskID)
+
+		return nil
+	},
+}
+
+var portForwardListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all active port forwards",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get instance name from environment or flag
+		instanceName := os.Getenv("KECS_INSTANCE")
+		if instanceName == "" {
+			instanceName = "default"
+		}
+
+		// Create port forward manager (k8s client not needed for list)
+		manager := portforward.NewManager(instanceName, nil)
+
+		// List all active port forwards
+		forwards, err := manager.ListForwards()
+		if err != nil {
+			return fmt.Errorf("failed to list port forwards: %w", err)
+		}
+
+		if len(forwards) == 0 {
+			fmt.Println("No active port forwards")
+			return nil
+		}
+
+		// Display forwards in a table
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tTYPE\tTARGET\tLOCAL PORT\tSTATUS")
+		fmt.Fprintln(w, "--\t----\t------\t----------\t------")
+
+		for _, fwd := range forwards {
+			target := fmt.Sprintf("%s/%s", fwd.Cluster, fwd.TargetName)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n",
+				fwd.ID, fwd.Type, target, fwd.LocalPort, fwd.Status)
+		}
+
+		w.Flush()
+		return nil
+	},
+}
+
+var portForwardStopCmd = &cobra.Command{
+	Use:   "stop [forward-id]",
+	Short: "Stop port forwarding",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get instance name from environment or flag
+		instanceName := os.Getenv("KECS_INSTANCE")
+		if instanceName == "" {
+			instanceName = "default"
+		}
+
+		// Create port forward manager (k8s client not needed for stop)
+		manager := portforward.NewManager(instanceName, nil)
+
+		if allForwards {
+			// Stop all forwards
+			err := manager.StopAllForwards()
+			if err != nil {
+				return fmt.Errorf("failed to stop all port forwards: %w", err)
+			}
+			fmt.Println("All port forwards stopped")
+		} else {
+			// Stop specific forward
+			if len(args) == 0 {
+				return fmt.Errorf("forward-id required when not using --all")
+			}
+
+			forwardID := args[0]
+			err := manager.StopForward(forwardID)
+			if err != nil {
+				return fmt.Errorf("failed to stop port forward: %w", err)
+			}
+			fmt.Printf("Port forward %s stopped\n", forwardID)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(portForwardCmd)
+
+	// Add subcommands
+	portForwardCmd.AddCommand(portForwardStartCmd)
+	portForwardCmd.AddCommand(portForwardListCmd)
+	portForwardCmd.AddCommand(portForwardStopCmd)
+
+	// Add start subcommands
+	portForwardStartCmd.AddCommand(portForwardStartServiceCmd)
+	portForwardStartCmd.AddCommand(portForwardStartTaskCmd)
+
+	// Add flags
+	portForwardStartServiceCmd.Flags().IntVar(&localPort, "local-port", 0, "Local port to forward (0 for auto-assign)")
+	portForwardStartServiceCmd.Flags().IntVar(&targetPort, "target-port", 0, "Target port on the service")
+
+	portForwardStartTaskCmd.Flags().IntVar(&localPort, "local-port", 0, "Local port to forward (0 for auto-assign)")
+	portForwardStartTaskCmd.Flags().IntVar(&targetPort, "target-port", 0, "Target port on the task")
+
+	portForwardStopCmd.Flags().BoolVar(&allForwards, "all", false, "Stop all port forwards")
+}

--- a/controlplane/internal/kubernetes/client.go
+++ b/controlplane/internal/kubernetes/client.go
@@ -1,0 +1,25 @@
+package kubernetes
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Client wraps the Kubernetes clientset for KECS operations
+type Client struct {
+	Clientset kubernetes.Interface
+	Config    *rest.Config
+}
+
+// NewClient creates a new Kubernetes client from the given config
+func NewClient(config *rest.Config) (*Client, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		Clientset: clientset,
+		Config:    config,
+	}, nil
+}

--- a/controlplane/internal/portforward/manager.go
+++ b/controlplane/internal/portforward/manager.go
@@ -1,0 +1,381 @@
+package portforward
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
+	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ForwardType represents the type of port forward
+type ForwardType string
+
+const (
+	ForwardTypeService ForwardType = "service"
+	ForwardTypeTask    ForwardType = "task"
+)
+
+// ForwardStatus represents the status of a port forward
+type ForwardStatus string
+
+const (
+	StatusActive  ForwardStatus = "active"
+	StatusStopped ForwardStatus = "stopped"
+	StatusError   ForwardStatus = "error"
+)
+
+// Forward represents a port forward configuration
+type Forward struct {
+	ID         string        `json:"id"`
+	Type       ForwardType   `json:"type"`
+	Cluster    string        `json:"cluster"`
+	TargetName string        `json:"targetName"`
+	LocalPort  int           `json:"localPort"`
+	TargetPort int           `json:"targetPort"`
+	Status     ForwardStatus `json:"status"`
+	CreatedAt  time.Time     `json:"createdAt"`
+	UpdatedAt  time.Time     `json:"updatedAt"`
+	Error      string        `json:"error,omitempty"`
+}
+
+// Manager manages port forwards for a KECS instance
+type Manager struct {
+	instanceName string
+	k8sClient    *kubernetes.Client
+	stateDir     string
+	forwards     map[string]*Forward
+	forwarders   map[string]*portForwarder
+	mu           sync.RWMutex
+}
+
+// portForwarder holds the active port forwarding connection
+type portForwarder struct {
+	stopCh  chan struct{}
+	readyCh chan struct{}
+	errCh   chan error
+}
+
+// NewManager creates a new port forward manager
+func NewManager(instanceName string, k8sClient *kubernetes.Client) *Manager {
+	homeDir, _ := os.UserHomeDir()
+	stateDir := filepath.Join(homeDir, ".kecs", "instances", instanceName, "port-forwards")
+
+	m := &Manager{
+		instanceName: instanceName,
+		k8sClient:    k8sClient,
+		stateDir:     stateDir,
+		forwards:     make(map[string]*Forward),
+		forwarders:   make(map[string]*portForwarder),
+	}
+
+	// Ensure state directory exists
+	os.MkdirAll(stateDir, 0755)
+
+	// Load existing state
+	m.loadState()
+
+	return m
+}
+
+// StartServiceForward starts port forwarding to a service
+func (m *Manager) StartServiceForward(ctx context.Context, cluster, serviceName string, localPort, targetPort int) (string, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Generate forward ID
+	forwardID := fmt.Sprintf("svc-%s-%s-%d", cluster, serviceName, time.Now().Unix())
+
+	// Auto-assign local port if not specified
+	if localPort == 0 {
+		localPort = m.findAvailablePort()
+	}
+
+	// Default target port to 80 if not specified
+	if targetPort == 0 {
+		targetPort = 80
+	}
+
+	// Create forward configuration
+	forward := &Forward{
+		ID:         forwardID,
+		Type:       ForwardTypeService,
+		Cluster:    cluster,
+		TargetName: serviceName,
+		LocalPort:  localPort,
+		TargetPort: targetPort,
+		Status:     StatusActive,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+
+	// Get the namespace for the cluster
+	namespace := fmt.Sprintf("%s-%s", cluster, "us-east-1") // Default region
+
+	// Get the service to find NodePort
+	service, err := m.k8sClient.Clientset.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to get service: %w", err)
+	}
+
+	// Check if service has NodePort
+	var nodePort int32
+	if service.Spec.Type == corev1.ServiceTypeNodePort && len(service.Spec.Ports) > 0 {
+		// Find the NodePort that matches our target port
+		for _, port := range service.Spec.Ports {
+			if port.Port == int32(targetPort) || targetPort == 0 {
+				nodePort = port.NodePort
+				if targetPort == 0 {
+					targetPort = int(port.Port)
+				}
+				break
+			}
+		}
+
+		if nodePort == 0 && len(service.Spec.Ports) > 0 {
+			// If no matching port found, use the first one
+			nodePort = service.Spec.Ports[0].NodePort
+			targetPort = int(service.Spec.Ports[0].Port)
+		}
+	}
+
+	if nodePort == 0 {
+		return "", 0, fmt.Errorf("service %s does not have NodePort configured. Ensure assignPublicIp is enabled", serviceName)
+	}
+
+	// TODO: In Phase 4, we will implement k3d node edit to map the port
+	// For now, we'll just track the configuration
+
+	logging.Info("Port forward configuration created",
+		"id", forwardID,
+		"service", serviceName,
+		"localPort", localPort,
+		"nodePort", nodePort)
+
+	// Save forward configuration
+	m.forwards[forwardID] = forward
+	m.saveState()
+
+	return forwardID, localPort, nil
+}
+
+// StartTaskForward starts port forwarding to a task
+func (m *Manager) StartTaskForward(ctx context.Context, cluster, taskID string, localPort, targetPort int) (string, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Generate forward ID
+	forwardID := fmt.Sprintf("task-%s-%s-%d", cluster, taskID[:8], time.Now().Unix())
+
+	// Auto-assign local port if not specified
+	if localPort == 0 {
+		localPort = m.findAvailablePort()
+	}
+
+	// Default target port to 80 if not specified
+	if targetPort == 0 {
+		targetPort = 80
+	}
+
+	// Create forward configuration
+	forward := &Forward{
+		ID:         forwardID,
+		Type:       ForwardTypeTask,
+		Cluster:    cluster,
+		TargetName: taskID,
+		LocalPort:  localPort,
+		TargetPort: targetPort,
+		Status:     StatusActive,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+
+	// Get the namespace for the cluster
+	namespace := fmt.Sprintf("%s-%s", cluster, "us-east-1") // Default region
+
+	// Find the pod for this task
+	pods, err := m.k8sClient.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("ecs.task.id=%s", taskID),
+	})
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to find pod for task: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return "", 0, fmt.Errorf("no pod found for task %s", taskID)
+	}
+
+	pod := &pods.Items[0]
+
+	// Check if the pod's service has NodePort
+	// TODO: In Phase 4, we will implement actual port forwarding
+	// For now, we'll just track the configuration
+
+	logging.Info("Port forward configuration created for task",
+		"id", forwardID,
+		"task", taskID,
+		"pod", pod.Name,
+		"localPort", localPort,
+		"targetPort", targetPort)
+
+	// Save forward configuration
+	m.forwards[forwardID] = forward
+	m.saveState()
+
+	return forwardID, localPort, nil
+}
+
+// ListForwards lists all port forwards
+func (m *Manager) ListForwards() ([]*Forward, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var forwards []*Forward
+	for _, fwd := range m.forwards {
+		forwards = append(forwards, fwd)
+	}
+
+	return forwards, nil
+}
+
+// StopForward stops a specific port forward
+func (m *Manager) StopForward(forwardID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	forward, exists := m.forwards[forwardID]
+	if !exists {
+		return fmt.Errorf("forward %s not found", forwardID)
+	}
+
+	// Stop the forwarder if it exists
+	if forwarder, ok := m.forwarders[forwardID]; ok {
+		close(forwarder.stopCh)
+		delete(m.forwarders, forwardID)
+	}
+
+	// Update status
+	forward.Status = StatusStopped
+	forward.UpdatedAt = time.Now()
+
+	// Remove from active forwards
+	delete(m.forwards, forwardID)
+
+	m.saveState()
+
+	logging.Info("Port forward stopped", "id", forwardID)
+
+	return nil
+}
+
+// StopAllForwards stops all port forwards
+func (m *Manager) StopAllForwards() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for forwardID, forwarder := range m.forwarders {
+		close(forwarder.stopCh)
+		delete(m.forwarders, forwardID)
+	}
+
+	// Clear all forwards
+	m.forwards = make(map[string]*Forward)
+
+	m.saveState()
+
+	logging.Info("All port forwards stopped")
+
+	return nil
+}
+
+// findAvailablePort finds an available local port
+func (m *Manager) findAvailablePort() int {
+	// Start from a random port in the dynamic range
+	basePort := 30000 + rand.Intn(10000)
+
+	for i := 0; i < 100; i++ {
+		port := basePort + i
+
+		// Check if port is already in use by our forwards
+		inUse := false
+		for _, fwd := range m.forwards {
+			if fwd.LocalPort == port {
+				inUse = true
+				break
+			}
+		}
+		if inUse {
+			continue
+		}
+
+		// Check if port is available on the system
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err == nil {
+			listener.Close()
+			return port
+		}
+	}
+
+	// Fallback to any available port
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.Port
+}
+
+// loadState loads the saved state from disk
+func (m *Manager) loadState() error {
+	stateFile := filepath.Join(m.stateDir, "state.json")
+
+	data, err := ioutil.ReadFile(stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No state file yet
+		}
+		return err
+	}
+
+	var forwards []*Forward
+	if err := json.Unmarshal(data, &forwards); err != nil {
+		return err
+	}
+
+	for _, fwd := range forwards {
+		// Only restore active forwards
+		if fwd.Status == StatusActive {
+			m.forwards[fwd.ID] = fwd
+		}
+	}
+
+	return nil
+}
+
+// saveState saves the current state to disk
+func (m *Manager) saveState() error {
+	var forwards []*Forward
+	for _, fwd := range m.forwards {
+		forwards = append(forwards, fwd)
+	}
+
+	data, err := json.MarshalIndent(forwards, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	stateFile := filepath.Join(m.stateDir, "state.json")
+	return ioutil.WriteFile(stateFile, data, 0644)
+}

--- a/controlplane/internal/portforward/manager.go
+++ b/controlplane/internal/portforward/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -341,7 +340,7 @@ func (m *Manager) findAvailablePort() int {
 func (m *Manager) loadState() error {
 	stateFile := filepath.Join(m.stateDir, "state.json")
 
-	data, err := ioutil.ReadFile(stateFile)
+	data, err := os.ReadFile(stateFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil // No state file yet
@@ -377,5 +376,5 @@ func (m *Manager) saveState() error {
 	}
 
 	stateFile := filepath.Join(m.stateDir, "state.json")
-	return ioutil.WriteFile(stateFile, data, 0644)
+	return os.WriteFile(stateFile, data, 0644)
 }

--- a/examples/single-task-nginx/service_def.json
+++ b/examples/single-task-nginx/service_def.json
@@ -13,6 +13,12 @@
       "rollback": true
     }
   },
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-12345678"],
+      "assignPublicIp": "ENABLED"
+    }
+  },
   "enableECSManagedTags": true,
   "propagateTags": "SERVICE",
   "tags": [


### PR DESCRIPTION
## Summary
Implements Phase 2 of the port-forward feature from ADR-0026 (#693), adding basic CLI commands for managing port forwards.

This PR adds the foundation for the `kecs port-forward` command with basic subcommands (start, list, stop) and a manager package for handling port forward state.

## Changes
- ✨ Add `kecs port-forward` command structure with subcommands
- 📦 Create port-forward manager package for state management
- 🔧 Add kubernetes client wrapper for future port-forward operations
- 💾 Implement state persistence for tracking port forwards

## Implementation Status (ADR-0026 Phases)
- [x] Phase 1: Core Infrastructure (PR #694 - Merged)
  - NodePort service creation when assignPublicIp is enabled
  - Database schema for NodePort tracking
- [x] **Phase 2: Basic Commands (This PR)**
  - `kecs port-forward start` for services and tasks
  - `kecs port-forward list` to show active forwards
  - `kecs port-forward stop` to terminate forwards
- [ ] Phase 3: Advanced Features (Next)
  - Tag-based task discovery
  - Configuration file support
- [ ] Phase 4: Auto-Management
  - k3d integration for actual port mapping
  - Auto-reconnection logic
- [ ] Phase 5: Polish and Documentation

## Test Plan
The commands are implemented but actual port forwarding functionality will be added in Phase 4 when we integrate with k3d's dynamic port configuration API.

```bash
# Build and test CLI
cd controlplane && go build -tags kecs_cli -o ../bin/kecs ./cmd/controlplane

# Check command help
./bin/kecs port-forward --help
./bin/kecs port-forward start --help

# Commands will track configuration but won't establish actual forwarding yet
# That will be implemented in Phase 4 with k3d integration
```

## Related Issues
- Addresses #588: Implement assignPublicIp support with kecs port-forward command
- Follows ADR-0026: Port Forward Management for KECS

🤖 Generated with [Claude Code](https://claude.ai/code)