### PR TITLE
fix: Port-forward task label selector

### DIFF
--- a/controlplane/internal/portforward/manager.go
+++ b/controlplane/internal/portforward/manager.go
@@ -217,7 +217,7 @@ func (m *Manager) StartTaskForward(ctx context.Context, cluster, taskID string, 
 
 	// Find the pod for this task
 	pods, err := m.k8sClient.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("ecs.task.id=%s", taskID),
+		LabelSelector: fmt.Sprintf("kecs.dev/task-id=%s", taskID),
 	})
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to find pod for task: %w", err)


### PR DESCRIPTION
## Summary
- Fixed incorrect label selector in task port-forward command
- Changed from `ecs.task.id` to `kecs.dev/task-id` to match actual pod labels

## Problem
The task port-forward command was failing to find pods because it used the wrong label selector. KECS creates pods with the label `kecs.dev/task-id` but the port-forward manager was searching for `ecs.task.id`.

## Solution
Updated the label selector in `StartTaskForward` method to use the correct label.

## Test Results
Tested with single-task-nginx deployment:
- ✅ Service port-forward works
- ✅ Task port-forward now finds pods correctly
- ✅ List command shows active forwards
- ✅ Stop command removes forwards

Note: Phase 2 only stores configuration without creating actual port mappings (as per ADR-0026).