### PR TITLE
fix: Use Git tag with v prefix for version embedding

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ builds:
           - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.Version={{.Version}}
+      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.Version={{.Tag}}
       - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GitCommit={{.Commit}}
       - -X github.com/nandemo-ya/kecs/controlplane/internal/version.BuildDate={{.Date}}
       - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GoVersion=go1.25


### PR DESCRIPTION
## Summary
Fix GoReleaser configuration to preserve the 'v' prefix in embedded version strings, ensuring correct Docker image tag selection.

## Problem
When KECS is installed via Homebrew, it uses the `latest` Docker image tag instead of the specific version tag (e.g., `v0.0.1-beta.4`).

### Root Cause
1. GoReleaser's `{{.Version}}` strips the 'v' prefix from git tags
   - Git tag: `v0.0.1-beta.4`
   - Embedded version: `0.0.1-beta.4` (without 'v')
2. The `computeControlPlaneImage()` function checks if version starts with 'v'
3. When it doesn't, it defaults to using `latest` tag

## Solution
Use `{{.Tag}}` instead of `{{.Version}}` in ldflags to preserve the full git tag including the 'v' prefix.

## Testing
After this change, binaries built by GoReleaser will:
- Embed version as `v0.0.1-beta.4` (with 'v' prefix)
- Correctly select Docker image `ghcr.io/nandemo-ya/kecs:v0.0.1-beta.4`
- No longer default to `latest` tag for released versions

🤖 Generated with [Claude Code](https://claude.ai/code)