### PR TITLE
feat(port-forward): Add support for LoadBalancer service type

### DIFF
--- a/controlplane/internal/portforward/manager.go
+++ b/controlplane/internal/portforward/manager.go
@@ -155,9 +155,9 @@ func (m *Manager) StartServiceForward(ctx context.Context, cluster, serviceName 
 		return "", 0, fmt.Errorf("failed to get service: %w", err)
 	}
 
-	// Check if service has NodePort
+	// Check if service has NodePort (both NodePort and LoadBalancer types have NodePorts)
 	var nodePort int32
-	if service.Spec.Type == corev1.ServiceTypeNodePort && len(service.Spec.Ports) > 0 {
+	if (service.Spec.Type == corev1.ServiceTypeNodePort || service.Spec.Type == corev1.ServiceTypeLoadBalancer) && len(service.Spec.Ports) > 0 {
 		// Find the NodePort that matches our target port
 		for _, port := range service.Spec.Ports {
 			if port.Port == int32(targetPort) || targetPort == 0 {

--- a/docs-site/guides/port-forward.md
+++ b/docs-site/guides/port-forward.md
@@ -10,6 +10,7 @@ The port-forward feature allows you to:
 - 📦 Forward ports for both services and individual tasks
 - 🏷️ Use tags to dynamically select tasks
 - 💾 Persist configurations across KECS restarts
+- 🔀 Support for both NodePort and LoadBalancer service types
 
 ## Quick Start
 
@@ -113,6 +114,13 @@ aws ecs create-service \
   --task-definition api:1 \
   --network-configuration "awsvpcConfiguration={subnets=[subnet-12345678],assignPublicIp=ENABLED}"
 
+# Deploy service with ALB (LoadBalancer type)
+aws ecs create-service \
+  --service-name webapp-alb \
+  --task-definition webapp:1 \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-12345678],assignPublicIp=ENABLED}" \
+  --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/webapp-tg/xxx
+
 # Deploy database (without public IP for security)
 aws ecs create-service \
   --service-name database \
@@ -127,6 +135,9 @@ kecs port-forward start service default/frontend --local-port 3000 --target-port
 
 # Forward API service
 kecs port-forward start service default/api --local-port 8080 --target-port 8080
+
+# Forward ALB service (LoadBalancer type)
+kecs port-forward start service default/webapp-alb --local-port 8090 --target-port 80
 ```
 
 ### Step 3: Develop with Live Services
@@ -134,6 +145,7 @@ kecs port-forward start service default/api --local-port 8080 --target-port 8080
 Now you can:
 - Access frontend at `http://localhost:3000`
 - Make API calls to `http://localhost:8080`
+- Access ALB-integrated service at `http://localhost:8090`
 - Changes to your services are immediately accessible
 
 ### Step 4: Debug a Specific Task

--- a/docs/port-forward.md
+++ b/docs/port-forward.md
@@ -73,10 +73,12 @@ kecs port-forward stop --all
 
 For services with `assignPublicIp: ENABLED`:
 
-1. KECS creates a NodePort service in Kubernetes
+1. KECS creates a service in Kubernetes (NodePort or LoadBalancer type)
 2. The port-forward manager uses `k3d node edit` to map the NodePort to a host port
 3. kubectl establishes a port-forward connection from the host port to the service
 4. The connection is monitored and automatically reconnected if it fails
+
+**Note**: Port forwarding works with both NodePort and LoadBalancer service types. Services with ELB/ALB integration (LoadBalancer type) are fully supported.
 
 ### Task Port Forwarding
 
@@ -230,6 +232,23 @@ kecs port-forward start service default/admin --local-port 9090 --target-port 30
 curl http://localhost:3000  # Frontend
 curl http://localhost:8080  # API
 curl http://localhost:9090  # Admin panel
+```
+
+### ALB/ELB Service Setup
+
+```bash
+# Deploy service with ALB integration
+aws ecs create-service \
+  --service-name webapp-alb \
+  --task-definition webapp:1 \
+  --network-configuration "awsvpcConfiguration={assignPublicIp=ENABLED}" \
+  --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/webapp-tg/xxx
+
+# Forward the LoadBalancer service
+kecs port-forward start service default/webapp-alb --local-port 8080 --target-port 80
+
+# Access the service locally
+curl http://localhost:8080
 ```
 
 ### Task Debugging


### PR DESCRIPTION
## Summary
- Enable port-forwarding for services with LoadBalancer type (ELB/ALB integration)
- Update documentation with examples for ALB/ELB service port-forwarding
- Tested with multi-container-alb example service

## What Changed
1. **Port-forward manager**: Updated `StartServiceForward` method to check for both NodePort and LoadBalancer service types
2. **Documentation**: Added LoadBalancer support notes and ALB/ELB examples to both technical and user documentation

## Why
Services configured with AWS load balancers (ALB/ELB) create LoadBalancer type services in Kubernetes, not just NodePort. These services still have NodePorts that can be used for local port-forwarding, so we should support them.

## Test Plan
- [x] Tested with multi-container-alb example service
- [x] Verified port-forward works with LoadBalancer type service
- [x] Confirmed existing NodePort functionality still works
- [x] All unit tests passing

## Example
```bash
# Deploy service with ALB
aws ecs create-service \
  --service-name webapp-alb \
  --network-configuration "awsvpcConfiguration={assignPublicIp=ENABLED}" \
  --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:xxx

# Forward the LoadBalancer service
kecs port-forward start service default/webapp-alb --local-port 8090

# Access locally
curl http://localhost:8090
```

🤖 Generated with [Claude Code](https://claude.ai/code)