### PR TITLE
feat: Implement remaining PostgreSQL storage stores

### DIFF
--- a/controlplane/internal/storage/postgres/account_setting_store.go
+++ b/controlplane/internal/storage/postgres/account_setting_store.go
@@ -1,0 +1,266 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type accountSettingStore struct {
+	db *sql.DB
+}
+
+// Upsert creates or updates an account setting
+func (s *accountSettingStore) Upsert(ctx context.Context, setting *storage.AccountSetting) error {
+	if setting.ID == "" {
+		setting.ID = uuid.New().String()
+	}
+
+	now := time.Now()
+	if setting.CreatedAt.IsZero() {
+		setting.CreatedAt = now
+	}
+	setting.UpdatedAt = now
+
+	query := `
+	INSERT INTO account_settings (
+		id, name, value, principal_arn, is_default,
+		region, account_id, created_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9
+	) ON CONFLICT (principal_arn, name) DO UPDATE SET
+		value = EXCLUDED.value,
+		is_default = EXCLUDED.is_default,
+		region = EXCLUDED.region,
+		account_id = EXCLUDED.account_id,
+		updated_at = EXCLUDED.updated_at`
+
+	_, err := s.db.ExecContext(ctx, query,
+		setting.ID, setting.Name, setting.Value,
+		setting.PrincipalARN, setting.IsDefault,
+		toNullString(setting.Region), toNullString(setting.AccountID),
+		setting.CreatedAt, setting.UpdatedAt,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to upsert account setting: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves an account setting by principal ARN and name
+func (s *accountSettingStore) Get(ctx context.Context, principalARN, name string) (*storage.AccountSetting, error) {
+	query := `
+	SELECT id, name, value, principal_arn, is_default,
+		region, account_id, created_at, updated_at
+	FROM account_settings
+	WHERE principal_arn = $1 AND name = $2`
+
+	var setting storage.AccountSetting
+	var region, accountID sql.NullString
+
+	err := s.db.QueryRowContext(ctx, query, principalARN, name).Scan(
+		&setting.ID, &setting.Name, &setting.Value,
+		&setting.PrincipalARN, &setting.IsDefault,
+		&region, &accountID,
+		&setting.CreatedAt, &setting.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get account setting: %w", err)
+	}
+
+	setting.Region = fromNullString(region)
+	setting.AccountID = fromNullString(accountID)
+
+	return &setting, nil
+}
+
+// GetDefault retrieves the default account setting by name
+func (s *accountSettingStore) GetDefault(ctx context.Context, name string) (*storage.AccountSetting, error) {
+	query := `
+	SELECT id, name, value, principal_arn, is_default,
+		region, account_id, created_at, updated_at
+	FROM account_settings
+	WHERE name = $1 AND is_default = true`
+
+	var setting storage.AccountSetting
+	var region, accountID sql.NullString
+
+	err := s.db.QueryRowContext(ctx, query, name).Scan(
+		&setting.ID, &setting.Name, &setting.Value,
+		&setting.PrincipalARN, &setting.IsDefault,
+		&region, &accountID,
+		&setting.CreatedAt, &setting.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get default account setting: %w", err)
+	}
+
+	setting.Region = fromNullString(region)
+	setting.AccountID = fromNullString(accountID)
+
+	return &setting, nil
+}
+
+// List retrieves account settings with filtering
+func (s *accountSettingStore) List(ctx context.Context, filters storage.AccountSettingFilters) ([]*storage.AccountSetting, string, error) {
+	// Parse the next token to get offset
+	offset := 0
+	if filters.NextToken != "" {
+		if _, err := fmt.Sscanf(filters.NextToken, "%d", &offset); err != nil {
+			return nil, "", fmt.Errorf("invalid next token: %w", err)
+		}
+	}
+
+	query := `
+	SELECT id, name, value, principal_arn, is_default,
+		region, account_id, created_at, updated_at
+	FROM account_settings
+	WHERE 1=1`
+
+	args := []interface{}{}
+	argNum := 1
+
+	if filters.Name != "" {
+		query += fmt.Sprintf(" AND name = $%d", argNum)
+		args = append(args, filters.Name)
+		argNum++
+	}
+
+	if filters.Value != "" {
+		query += fmt.Sprintf(" AND value = $%d", argNum)
+		args = append(args, filters.Value)
+		argNum++
+	}
+
+	if filters.PrincipalARN != "" {
+		query += fmt.Sprintf(" AND principal_arn = $%d", argNum)
+		args = append(args, filters.PrincipalARN)
+		argNum++
+	}
+
+	// Handle effective settings
+	if filters.EffectiveSettings {
+		// When requesting effective settings, we need to get both defaults and overrides
+		// This would typically be handled at a higher layer by combining results
+		// For now, we'll just return all settings for the principal
+	}
+
+	query += " ORDER BY name, principal_arn"
+
+	if filters.MaxResults > 0 {
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
+		args = append(args, filters.MaxResults, offset)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list account settings: %w", err)
+	}
+	defer rows.Close()
+
+	var settings []*storage.AccountSetting
+	for rows.Next() {
+		var setting storage.AccountSetting
+		var region, accountID sql.NullString
+
+		err := rows.Scan(
+			&setting.ID, &setting.Name, &setting.Value,
+			&setting.PrincipalARN, &setting.IsDefault,
+			&region, &accountID,
+			&setting.CreatedAt, &setting.UpdatedAt,
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to scan account setting: %w", err)
+		}
+
+		setting.Region = fromNullString(region)
+		setting.AccountID = fromNullString(accountID)
+
+		settings = append(settings, &setting)
+	}
+
+	// Generate next token if there are more results
+	newNextToken := ""
+	if filters.MaxResults > 0 && len(settings) == filters.MaxResults {
+		newNextToken = fmt.Sprintf("%d", offset+filters.MaxResults)
+	}
+
+	return settings, newNextToken, nil
+}
+
+// Delete removes an account setting
+func (s *accountSettingStore) Delete(ctx context.Context, principalARN, name string) error {
+	query := `
+	DELETE FROM account_settings
+	WHERE principal_arn = $1 AND name = $2`
+
+	result, err := s.db.ExecContext(ctx, query, principalARN, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete account setting: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// SetDefault sets a default account setting
+func (s *accountSettingStore) SetDefault(ctx context.Context, name, value string) error {
+	setting := &storage.AccountSetting{
+		ID:           uuid.New().String(),
+		Name:         name,
+		Value:        value,
+		PrincipalARN: "default",
+		IsDefault:    true,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	query := `
+	INSERT INTO account_settings (
+		id, name, value, principal_arn, is_default,
+		region, account_id, created_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9
+	) ON CONFLICT (principal_arn, name) DO UPDATE SET
+		value = EXCLUDED.value,
+		updated_at = EXCLUDED.updated_at`
+
+	_, err := s.db.ExecContext(ctx, query,
+		setting.ID, setting.Name, setting.Value,
+		setting.PrincipalARN, setting.IsDefault,
+		nil, nil, // region and account_id are null for defaults
+		setting.CreatedAt, setting.UpdatedAt,
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return storage.ErrResourceAlreadyExists
+		}
+		return fmt.Errorf("failed to set default account setting: %w", err)
+	}
+
+	return nil
+}

--- a/controlplane/internal/storage/postgres/attribute_store.go
+++ b/controlplane/internal/storage/postgres/attribute_store.go
@@ -1,0 +1,189 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type attributeStore struct {
+	db *sql.DB
+}
+
+// Put creates or updates attributes
+func (s *attributeStore) Put(ctx context.Context, attributes []*storage.Attribute) error {
+	if len(attributes) == 0 {
+		return nil
+	}
+
+	// Use a transaction for batch insert/update
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	query := `
+	INSERT INTO attributes (
+		id, name, value, target_type, target_id, cluster,
+		region, account_id, created_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+	) ON CONFLICT (name, target_type, target_id, cluster) DO UPDATE SET
+		value = EXCLUDED.value,
+		updated_at = EXCLUDED.updated_at`
+
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	now := time.Now()
+	for _, attr := range attributes {
+		if attr.ID == "" {
+			attr.ID = uuid.New().String()
+		}
+		if attr.CreatedAt.IsZero() {
+			attr.CreatedAt = now
+		}
+		attr.UpdatedAt = now
+
+		_, err = stmt.ExecContext(ctx,
+			attr.ID, attr.Name, toNullString(attr.Value),
+			attr.TargetType, attr.TargetID, attr.Cluster,
+			toNullString(attr.Region), toNullString(attr.AccountID),
+			attr.CreatedAt, attr.UpdatedAt,
+		)
+		if err != nil {
+			if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+				// This shouldn't happen due to ON CONFLICT, but handle it anyway
+				continue
+			}
+			return fmt.Errorf("failed to put attribute: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes attributes
+func (s *attributeStore) Delete(ctx context.Context, cluster string, attributes []*storage.Attribute) error {
+	if len(attributes) == 0 {
+		return nil
+	}
+
+	// Use a transaction for batch delete
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	query := `
+	DELETE FROM attributes
+	WHERE cluster = $1 AND name = $2 AND target_type = $3 AND target_id = $4`
+
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, attr := range attributes {
+		_, err = stmt.ExecContext(ctx, cluster, attr.Name, attr.TargetType, attr.TargetID)
+		if err != nil {
+			return fmt.Errorf("failed to delete attribute: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// ListWithPagination retrieves attributes with pagination
+func (s *attributeStore) ListWithPagination(ctx context.Context, targetType, cluster string, limit int, nextToken string) ([]*storage.Attribute, string, error) {
+	// Parse the next token to get offset
+	offset := 0
+	if nextToken != "" {
+		if _, err := fmt.Sscanf(nextToken, "%d", &offset); err != nil {
+			return nil, "", fmt.Errorf("invalid next token: %w", err)
+		}
+	}
+
+	query := `
+	SELECT id, name, value, target_type, target_id, cluster,
+		region, account_id, created_at, updated_at
+	FROM attributes
+	WHERE 1=1`
+
+	args := []interface{}{}
+	argNum := 1
+
+	if targetType != "" {
+		query += fmt.Sprintf(" AND target_type = $%d", argNum)
+		args = append(args, targetType)
+		argNum++
+	}
+
+	if cluster != "" {
+		query += fmt.Sprintf(" AND cluster = $%d", argNum)
+		args = append(args, cluster)
+		argNum++
+	}
+
+	query += " ORDER BY name, target_id"
+
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
+		args = append(args, limit, offset)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list attributes: %w", err)
+	}
+	defer rows.Close()
+
+	var attributes []*storage.Attribute
+	for rows.Next() {
+		var attr storage.Attribute
+		var value, region, accountID sql.NullString
+
+		err := rows.Scan(
+			&attr.ID, &attr.Name, &value,
+			&attr.TargetType, &attr.TargetID, &attr.Cluster,
+			&region, &accountID,
+			&attr.CreatedAt, &attr.UpdatedAt,
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to scan attribute: %w", err)
+		}
+
+		attr.Value = fromNullString(value)
+		attr.Region = fromNullString(region)
+		attr.AccountID = fromNullString(accountID)
+
+		attributes = append(attributes, &attr)
+	}
+
+	// Generate next token if there are more results
+	newNextToken := ""
+	if limit > 0 && len(attributes) == limit {
+		newNextToken = fmt.Sprintf("%d", offset+limit)
+	}
+
+	return attributes, newNextToken, nil
+}

--- a/controlplane/internal/storage/postgres/container_instance_store.go
+++ b/controlplane/internal/storage/postgres/container_instance_store.go
@@ -1,0 +1,371 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type containerInstanceStore struct {
+	db *sql.DB
+}
+
+// Register registers a new container instance
+func (s *containerInstanceStore) Register(ctx context.Context, instance *storage.ContainerInstance) error {
+	if instance.ID == "" {
+		instance.ID = uuid.New().String()
+	}
+
+	now := time.Now()
+	if instance.RegisteredAt.IsZero() {
+		instance.RegisteredAt = now
+	}
+	instance.UpdatedAt = now
+
+	query := `
+	INSERT INTO container_instances (
+		id, arn, cluster_arn, ec2_instance_id, status, status_reason,
+		agent_connected, agent_update_status, running_tasks_count,
+		pending_tasks_count, version, version_info, registered_resources,
+		remaining_resources, attributes, attachments, tags,
+		capacity_provider_name, health_status, region, account_id,
+		registered_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+		$11, $12, $13, $14, $15, $16, $17, $18, $19,
+		$20, $21, $22, $23
+	)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		instance.ID, instance.ARN, instance.ClusterARN, instance.EC2InstanceID,
+		instance.Status, toNullString(instance.StatusReason),
+		instance.AgentConnected, toNullString(instance.AgentUpdateStatus),
+		instance.RunningTasksCount, instance.PendingTasksCount,
+		instance.Version, toNullString(instance.VersionInfo),
+		toNullString(instance.RegisteredResources), toNullString(instance.RemainingResources),
+		toNullString(instance.Attributes), toNullString(instance.Attachments),
+		toNullString(instance.Tags), toNullString(instance.CapacityProviderName),
+		toNullString(instance.HealthStatus), toNullString(instance.Region),
+		toNullString(instance.AccountID), instance.RegisteredAt, instance.UpdatedAt,
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return storage.ErrResourceAlreadyExists
+		}
+		return fmt.Errorf("failed to register container instance: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves a container instance by ARN
+func (s *containerInstanceStore) Get(ctx context.Context, arn string) (*storage.ContainerInstance, error) {
+	query := `
+	SELECT
+		id, arn, cluster_arn, ec2_instance_id, status, status_reason,
+		agent_connected, agent_update_status, running_tasks_count,
+		pending_tasks_count, version, version_info, registered_resources,
+		remaining_resources, attributes, attachments, tags,
+		capacity_provider_name, health_status, region, account_id,
+		registered_at, updated_at, deregistered_at
+	FROM container_instances
+	WHERE arn = $1`
+
+	var instance storage.ContainerInstance
+	var statusReason, agentUpdateStatus, versionInfo sql.NullString
+	var registeredResources, remainingResources, attributes, attachments sql.NullString
+	var tags, capacityProviderName, healthStatus, region, accountID sql.NullString
+	var deregisteredAt sql.NullTime
+
+	err := s.db.QueryRowContext(ctx, query, arn).Scan(
+		&instance.ID, &instance.ARN, &instance.ClusterARN, &instance.EC2InstanceID,
+		&instance.Status, &statusReason, &instance.AgentConnected, &agentUpdateStatus,
+		&instance.RunningTasksCount, &instance.PendingTasksCount,
+		&instance.Version, &versionInfo, &registeredResources, &remainingResources,
+		&attributes, &attachments, &tags, &capacityProviderName, &healthStatus,
+		&region, &accountID, &instance.RegisteredAt, &instance.UpdatedAt, &deregisteredAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get container instance: %w", err)
+	}
+
+	// Convert null values
+	instance.StatusReason = fromNullString(statusReason)
+	instance.AgentUpdateStatus = fromNullString(agentUpdateStatus)
+	instance.VersionInfo = fromNullString(versionInfo)
+	instance.RegisteredResources = fromNullString(registeredResources)
+	instance.RemainingResources = fromNullString(remainingResources)
+	instance.Attributes = fromNullString(attributes)
+	instance.Attachments = fromNullString(attachments)
+	instance.Tags = fromNullString(tags)
+	instance.CapacityProviderName = fromNullString(capacityProviderName)
+	instance.HealthStatus = fromNullString(healthStatus)
+	instance.Region = fromNullString(region)
+	instance.AccountID = fromNullString(accountID)
+	instance.DeregisteredAt = fromNullTime(deregisteredAt)
+
+	return &instance, nil
+}
+
+// ListWithPagination retrieves container instances with filtering and pagination
+func (s *containerInstanceStore) ListWithPagination(ctx context.Context, cluster string, filters storage.ContainerInstanceFilters, limit int, nextToken string) ([]*storage.ContainerInstance, string, error) {
+	// Parse the next token to get offset
+	offset := 0
+	if nextToken != "" {
+		if _, err := fmt.Sscanf(nextToken, "%d", &offset); err != nil {
+			return nil, "", fmt.Errorf("invalid next token: %w", err)
+		}
+	}
+
+	query := `
+	SELECT
+		id, arn, cluster_arn, ec2_instance_id, status, status_reason,
+		agent_connected, agent_update_status, running_tasks_count,
+		pending_tasks_count, version, version_info, registered_resources,
+		remaining_resources, attributes, attachments, tags,
+		capacity_provider_name, health_status, region, account_id,
+		registered_at, updated_at, deregistered_at
+	FROM container_instances
+	WHERE cluster_arn = $1`
+
+	args := []interface{}{cluster}
+	argNum := 2
+
+	if filters.Status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argNum)
+		args = append(args, filters.Status)
+		argNum++
+	}
+
+	// Handle filter string (could be instance ID, ARN, or attribute)
+	if filters.Filter != "" {
+		query += fmt.Sprintf(" AND (ec2_instance_id = $%d OR arn LIKE $%d OR attributes LIKE $%d)", argNum, argNum, argNum)
+		args = append(args, filters.Filter)
+		argNum++
+	}
+
+	query += " ORDER BY registered_at DESC"
+
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
+		args = append(args, limit, offset)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list container instances: %w", err)
+	}
+	defer rows.Close()
+
+	var instances []*storage.ContainerInstance
+	for rows.Next() {
+		var instance storage.ContainerInstance
+		var statusReason, agentUpdateStatus, versionInfo sql.NullString
+		var registeredResources, remainingResources, attributes, attachments sql.NullString
+		var tags, capacityProviderName, healthStatus, region, accountID sql.NullString
+		var deregisteredAt sql.NullTime
+
+		err := rows.Scan(
+			&instance.ID, &instance.ARN, &instance.ClusterARN, &instance.EC2InstanceID,
+			&instance.Status, &statusReason, &instance.AgentConnected, &agentUpdateStatus,
+			&instance.RunningTasksCount, &instance.PendingTasksCount,
+			&instance.Version, &versionInfo, &registeredResources, &remainingResources,
+			&attributes, &attachments, &tags, &capacityProviderName, &healthStatus,
+			&region, &accountID, &instance.RegisteredAt, &instance.UpdatedAt, &deregisteredAt,
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to scan container instance: %w", err)
+		}
+
+		// Convert null values
+		instance.StatusReason = fromNullString(statusReason)
+		instance.AgentUpdateStatus = fromNullString(agentUpdateStatus)
+		instance.VersionInfo = fromNullString(versionInfo)
+		instance.RegisteredResources = fromNullString(registeredResources)
+		instance.RemainingResources = fromNullString(remainingResources)
+		instance.Attributes = fromNullString(attributes)
+		instance.Attachments = fromNullString(attachments)
+		instance.Tags = fromNullString(tags)
+		instance.CapacityProviderName = fromNullString(capacityProviderName)
+		instance.HealthStatus = fromNullString(healthStatus)
+		instance.Region = fromNullString(region)
+		instance.AccountID = fromNullString(accountID)
+		instance.DeregisteredAt = fromNullTime(deregisteredAt)
+
+		instances = append(instances, &instance)
+	}
+
+	// Generate next token if there are more results
+	newNextToken := ""
+	if limit > 0 && len(instances) == limit {
+		newNextToken = fmt.Sprintf("%d", offset+limit)
+	}
+
+	return instances, newNextToken, nil
+}
+
+// Update updates a container instance
+func (s *containerInstanceStore) Update(ctx context.Context, instance *storage.ContainerInstance) error {
+	instance.UpdatedAt = time.Now()
+
+	query := `
+	UPDATE container_instances SET
+		status = $1, status_reason = $2, agent_connected = $3,
+		agent_update_status = $4, running_tasks_count = $5,
+		pending_tasks_count = $6, version = $7, version_info = $8,
+		registered_resources = $9, remaining_resources = $10,
+		attributes = $11, attachments = $12, tags = $13,
+		capacity_provider_name = $14, health_status = $15,
+		updated_at = $16
+	WHERE arn = $17`
+
+	result, err := s.db.ExecContext(ctx, query,
+		instance.Status, toNullString(instance.StatusReason),
+		instance.AgentConnected, toNullString(instance.AgentUpdateStatus),
+		instance.RunningTasksCount, instance.PendingTasksCount,
+		instance.Version, toNullString(instance.VersionInfo),
+		toNullString(instance.RegisteredResources), toNullString(instance.RemainingResources),
+		toNullString(instance.Attributes), toNullString(instance.Attachments),
+		toNullString(instance.Tags), toNullString(instance.CapacityProviderName),
+		toNullString(instance.HealthStatus), instance.UpdatedAt, instance.ARN,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to update container instance: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Deregister deregisters a container instance
+func (s *containerInstanceStore) Deregister(ctx context.Context, arn string) error {
+	now := time.Now()
+
+	query := `
+	UPDATE container_instances SET
+		status = 'INACTIVE',
+		deregistered_at = $1,
+		updated_at = $2
+	WHERE arn = $3`
+
+	result, err := s.db.ExecContext(ctx, query, now, now, arn)
+	if err != nil {
+		return fmt.Errorf("failed to deregister container instance: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// GetByARNs retrieves container instances by ARNs
+func (s *containerInstanceStore) GetByARNs(ctx context.Context, arns []string) ([]*storage.ContainerInstance, error) {
+	if len(arns) == 0 {
+		return []*storage.ContainerInstance{}, nil
+	}
+
+	query := `
+	SELECT
+		id, arn, cluster_arn, ec2_instance_id, status, status_reason,
+		agent_connected, agent_update_status, running_tasks_count,
+		pending_tasks_count, version, version_info, registered_resources,
+		remaining_resources, attributes, attachments, tags,
+		capacity_provider_name, health_status, region, account_id,
+		registered_at, updated_at, deregistered_at
+	FROM container_instances
+	WHERE arn = ANY($1)
+	ORDER BY registered_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, pq.Array(arns))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container instances by ARNs: %w", err)
+	}
+	defer rows.Close()
+
+	var instances []*storage.ContainerInstance
+	for rows.Next() {
+		var instance storage.ContainerInstance
+		var statusReason, agentUpdateStatus, versionInfo sql.NullString
+		var registeredResources, remainingResources, attributes, attachments sql.NullString
+		var tags, capacityProviderName, healthStatus, region, accountID sql.NullString
+		var deregisteredAt sql.NullTime
+
+		err := rows.Scan(
+			&instance.ID, &instance.ARN, &instance.ClusterARN, &instance.EC2InstanceID,
+			&instance.Status, &statusReason, &instance.AgentConnected, &agentUpdateStatus,
+			&instance.RunningTasksCount, &instance.PendingTasksCount,
+			&instance.Version, &versionInfo, &registeredResources, &remainingResources,
+			&attributes, &attachments, &tags, &capacityProviderName, &healthStatus,
+			&region, &accountID, &instance.RegisteredAt, &instance.UpdatedAt, &deregisteredAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan container instance: %w", err)
+		}
+
+		// Convert null values
+		instance.StatusReason = fromNullString(statusReason)
+		instance.AgentUpdateStatus = fromNullString(agentUpdateStatus)
+		instance.VersionInfo = fromNullString(versionInfo)
+		instance.RegisteredResources = fromNullString(registeredResources)
+		instance.RemainingResources = fromNullString(remainingResources)
+		instance.Attributes = fromNullString(attributes)
+		instance.Attachments = fromNullString(attachments)
+		instance.Tags = fromNullString(tags)
+		instance.CapacityProviderName = fromNullString(capacityProviderName)
+		instance.HealthStatus = fromNullString(healthStatus)
+		instance.Region = fromNullString(region)
+		instance.AccountID = fromNullString(accountID)
+		instance.DeregisteredAt = fromNullTime(deregisteredAt)
+
+		instances = append(instances, &instance)
+	}
+
+	return instances, nil
+}
+
+// DeleteStale deletes container instances that have been inactive before the specified time
+func (s *containerInstanceStore) DeleteStale(ctx context.Context, clusterARN string, before time.Time) (int, error) {
+	query := `
+	DELETE FROM container_instances
+	WHERE cluster_arn = $1
+	AND status = 'INACTIVE'
+	AND deregistered_at < $2`
+
+	result, err := s.db.ExecContext(ctx, query, clusterARN, before)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete stale container instances: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return int(rowsAffected), nil
+}

--- a/controlplane/internal/storage/postgres/elbv2_store.go
+++ b/controlplane/internal/storage/postgres/elbv2_store.go
@@ -1,0 +1,543 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type elbv2Store struct {
+	db *sql.DB
+}
+
+// Load Balancer operations
+
+// CreateLoadBalancer creates a new load balancer
+func (s *elbv2Store) CreateLoadBalancer(ctx context.Context, lb *storage.ELBv2LoadBalancer) error {
+	if lb.CreatedAt.IsZero() {
+		lb.CreatedAt = time.Now()
+	}
+	lb.UpdatedAt = time.Now()
+
+	// Convert arrays and maps to JSON
+	subnetsJSON, _ := json.Marshal(lb.Subnets)
+	azsJSON, _ := json.Marshal(lb.AvailabilityZones)
+	sgJSON, _ := json.Marshal(lb.SecurityGroups)
+	tagsJSON, _ := json.Marshal(lb.Tags)
+
+	query := `
+	INSERT INTO elbv2_load_balancers (
+		arn, name, dns_name, canonical_hosted_zone_id,
+		state, type, scheme, vpc_id, subnets,
+		availability_zones, security_groups, ip_address_type,
+		tags, region, account_id, created_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+		$11, $12, $13, $14, $15, $16, $17
+	)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		lb.ARN, lb.Name, lb.DNSName, lb.CanonicalHostedZoneID,
+		lb.State, lb.Type, lb.Scheme, lb.VpcID,
+		string(subnetsJSON), string(azsJSON), string(sgJSON),
+		lb.IpAddressType, string(tagsJSON),
+		lb.Region, lb.AccountID, lb.CreatedAt, lb.UpdatedAt,
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return storage.ErrResourceAlreadyExists
+		}
+		return fmt.Errorf("failed to create load balancer: %w", err)
+	}
+
+	return nil
+}
+
+// GetLoadBalancer retrieves a load balancer by ARN
+func (s *elbv2Store) GetLoadBalancer(ctx context.Context, arn string) (*storage.ELBv2LoadBalancer, error) {
+	query := `
+	SELECT arn, name, dns_name, canonical_hosted_zone_id,
+		state, type, scheme, vpc_id, subnets,
+		availability_zones, security_groups, ip_address_type,
+		tags, region, account_id, created_at, updated_at
+	FROM elbv2_load_balancers
+	WHERE arn = $1`
+
+	var lb storage.ELBv2LoadBalancer
+	var subnetsJSON, azsJSON, sgJSON, tagsJSON string
+
+	err := s.db.QueryRowContext(ctx, query, arn).Scan(
+		&lb.ARN, &lb.Name, &lb.DNSName, &lb.CanonicalHostedZoneID,
+		&lb.State, &lb.Type, &lb.Scheme, &lb.VpcID,
+		&subnetsJSON, &azsJSON, &sgJSON, &lb.IpAddressType,
+		&tagsJSON, &lb.Region, &lb.AccountID,
+		&lb.CreatedAt, &lb.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get load balancer: %w", err)
+	}
+
+	// Parse JSON fields
+	json.Unmarshal([]byte(subnetsJSON), &lb.Subnets)
+	json.Unmarshal([]byte(azsJSON), &lb.AvailabilityZones)
+	json.Unmarshal([]byte(sgJSON), &lb.SecurityGroups)
+	json.Unmarshal([]byte(tagsJSON), &lb.Tags)
+
+	return &lb, nil
+}
+
+// GetLoadBalancerByName retrieves a load balancer by name
+func (s *elbv2Store) GetLoadBalancerByName(ctx context.Context, name string) (*storage.ELBv2LoadBalancer, error) {
+	query := `
+	SELECT arn, name, dns_name, canonical_hosted_zone_id,
+		state, type, scheme, vpc_id, subnets,
+		availability_zones, security_groups, ip_address_type,
+		tags, region, account_id, created_at, updated_at
+	FROM elbv2_load_balancers
+	WHERE name = $1`
+
+	var lb storage.ELBv2LoadBalancer
+	var subnetsJSON, azsJSON, sgJSON, tagsJSON string
+
+	err := s.db.QueryRowContext(ctx, query, name).Scan(
+		&lb.ARN, &lb.Name, &lb.DNSName, &lb.CanonicalHostedZoneID,
+		&lb.State, &lb.Type, &lb.Scheme, &lb.VpcID,
+		&subnetsJSON, &azsJSON, &sgJSON, &lb.IpAddressType,
+		&tagsJSON, &lb.Region, &lb.AccountID,
+		&lb.CreatedAt, &lb.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get load balancer by name: %w", err)
+	}
+
+	// Parse JSON fields
+	json.Unmarshal([]byte(subnetsJSON), &lb.Subnets)
+	json.Unmarshal([]byte(azsJSON), &lb.AvailabilityZones)
+	json.Unmarshal([]byte(sgJSON), &lb.SecurityGroups)
+	json.Unmarshal([]byte(tagsJSON), &lb.Tags)
+
+	return &lb, nil
+}
+
+// ListLoadBalancers lists all load balancers in a region
+func (s *elbv2Store) ListLoadBalancers(ctx context.Context, region string) ([]*storage.ELBv2LoadBalancer, error) {
+	query := `
+	SELECT arn, name, dns_name, canonical_hosted_zone_id,
+		state, type, scheme, vpc_id, subnets,
+		availability_zones, security_groups, ip_address_type,
+		tags, region, account_id, created_at, updated_at
+	FROM elbv2_load_balancers
+	WHERE region = $1
+	ORDER BY created_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list load balancers: %w", err)
+	}
+	defer rows.Close()
+
+	var lbs []*storage.ELBv2LoadBalancer
+	for rows.Next() {
+		var lb storage.ELBv2LoadBalancer
+		var subnetsJSON, azsJSON, sgJSON, tagsJSON string
+
+		err := rows.Scan(
+			&lb.ARN, &lb.Name, &lb.DNSName, &lb.CanonicalHostedZoneID,
+			&lb.State, &lb.Type, &lb.Scheme, &lb.VpcID,
+			&subnetsJSON, &azsJSON, &sgJSON, &lb.IpAddressType,
+			&tagsJSON, &lb.Region, &lb.AccountID,
+			&lb.CreatedAt, &lb.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan load balancer: %w", err)
+		}
+
+		// Parse JSON fields
+		json.Unmarshal([]byte(subnetsJSON), &lb.Subnets)
+		json.Unmarshal([]byte(azsJSON), &lb.AvailabilityZones)
+		json.Unmarshal([]byte(sgJSON), &lb.SecurityGroups)
+		json.Unmarshal([]byte(tagsJSON), &lb.Tags)
+
+		lbs = append(lbs, &lb)
+	}
+
+	return lbs, nil
+}
+
+// UpdateLoadBalancer updates a load balancer
+func (s *elbv2Store) UpdateLoadBalancer(ctx context.Context, lb *storage.ELBv2LoadBalancer) error {
+	lb.UpdatedAt = time.Now()
+
+	// Convert arrays and maps to JSON
+	subnetsJSON, _ := json.Marshal(lb.Subnets)
+	azsJSON, _ := json.Marshal(lb.AvailabilityZones)
+	sgJSON, _ := json.Marshal(lb.SecurityGroups)
+	tagsJSON, _ := json.Marshal(lb.Tags)
+
+	query := `
+	UPDATE elbv2_load_balancers SET
+		state = $1, subnets = $2, availability_zones = $3,
+		security_groups = $4, tags = $5, updated_at = $6
+	WHERE arn = $7`
+
+	result, err := s.db.ExecContext(ctx, query,
+		lb.State, string(subnetsJSON), string(azsJSON),
+		string(sgJSON), string(tagsJSON), lb.UpdatedAt, lb.ARN,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to update load balancer: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// DeleteLoadBalancer deletes a load balancer
+func (s *elbv2Store) DeleteLoadBalancer(ctx context.Context, arn string) error {
+	query := `DELETE FROM elbv2_load_balancers WHERE arn = $1`
+
+	result, err := s.db.ExecContext(ctx, query, arn)
+	if err != nil {
+		return fmt.Errorf("failed to delete load balancer: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Target Group operations
+
+// CreateTargetGroup creates a new target group
+func (s *elbv2Store) CreateTargetGroup(ctx context.Context, tg *storage.ELBv2TargetGroup) error {
+	if tg.CreatedAt.IsZero() {
+		tg.CreatedAt = time.Now()
+	}
+	tg.UpdatedAt = time.Now()
+
+	// Convert arrays and maps to JSON
+	lbArnsJSON, _ := json.Marshal(tg.LoadBalancerArns)
+	tagsJSON, _ := json.Marshal(tg.Tags)
+
+	query := `
+	INSERT INTO elbv2_target_groups (
+		arn, name, protocol, port, vpc_id, target_type,
+		health_check_enabled, health_check_protocol, health_check_port,
+		health_check_path, health_check_interval_seconds,
+		health_check_timeout_seconds, healthy_threshold_count,
+		unhealthy_threshold_count, matcher, load_balancer_arns,
+		tags, region, account_id, created_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+		$11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
+	)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		tg.ARN, tg.Name, tg.Protocol, tg.Port, tg.VpcID, tg.TargetType,
+		tg.HealthCheckEnabled, tg.HealthCheckProtocol, tg.HealthCheckPort,
+		tg.HealthCheckPath, tg.HealthCheckIntervalSeconds,
+		tg.HealthCheckTimeoutSeconds, tg.HealthyThresholdCount,
+		tg.UnhealthyThresholdCount, tg.Matcher, string(lbArnsJSON),
+		string(tagsJSON), tg.Region, tg.AccountID,
+		tg.CreatedAt, tg.UpdatedAt,
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return storage.ErrResourceAlreadyExists
+		}
+		return fmt.Errorf("failed to create target group: %w", err)
+	}
+
+	return nil
+}
+
+// GetTargetGroup retrieves a target group by ARN
+func (s *elbv2Store) GetTargetGroup(ctx context.Context, arn string) (*storage.ELBv2TargetGroup, error) {
+	query := `
+	SELECT arn, name, protocol, port, vpc_id, target_type,
+		health_check_enabled, health_check_protocol, health_check_port,
+		health_check_path, health_check_interval_seconds,
+		health_check_timeout_seconds, healthy_threshold_count,
+		unhealthy_threshold_count, matcher, load_balancer_arns,
+		tags, region, account_id, created_at, updated_at
+	FROM elbv2_target_groups
+	WHERE arn = $1`
+
+	var tg storage.ELBv2TargetGroup
+	var lbArnsJSON, tagsJSON string
+
+	err := s.db.QueryRowContext(ctx, query, arn).Scan(
+		&tg.ARN, &tg.Name, &tg.Protocol, &tg.Port, &tg.VpcID, &tg.TargetType,
+		&tg.HealthCheckEnabled, &tg.HealthCheckProtocol, &tg.HealthCheckPort,
+		&tg.HealthCheckPath, &tg.HealthCheckIntervalSeconds,
+		&tg.HealthCheckTimeoutSeconds, &tg.HealthyThresholdCount,
+		&tg.UnhealthyThresholdCount, &tg.Matcher, &lbArnsJSON,
+		&tagsJSON, &tg.Region, &tg.AccountID,
+		&tg.CreatedAt, &tg.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get target group: %w", err)
+	}
+
+	// Parse JSON fields
+	json.Unmarshal([]byte(lbArnsJSON), &tg.LoadBalancerArns)
+	json.Unmarshal([]byte(tagsJSON), &tg.Tags)
+
+	return &tg, nil
+}
+
+// GetTargetGroupByName retrieves a target group by name
+func (s *elbv2Store) GetTargetGroupByName(ctx context.Context, name string) (*storage.ELBv2TargetGroup, error) {
+	query := `
+	SELECT arn, name, protocol, port, vpc_id, target_type,
+		health_check_enabled, health_check_protocol, health_check_port,
+		health_check_path, health_check_interval_seconds,
+		health_check_timeout_seconds, healthy_threshold_count,
+		unhealthy_threshold_count, matcher, load_balancer_arns,
+		tags, region, account_id, created_at, updated_at
+	FROM elbv2_target_groups
+	WHERE name = $1`
+
+	var tg storage.ELBv2TargetGroup
+	var lbArnsJSON, tagsJSON string
+
+	err := s.db.QueryRowContext(ctx, query, name).Scan(
+		&tg.ARN, &tg.Name, &tg.Protocol, &tg.Port, &tg.VpcID, &tg.TargetType,
+		&tg.HealthCheckEnabled, &tg.HealthCheckProtocol, &tg.HealthCheckPort,
+		&tg.HealthCheckPath, &tg.HealthCheckIntervalSeconds,
+		&tg.HealthCheckTimeoutSeconds, &tg.HealthyThresholdCount,
+		&tg.UnhealthyThresholdCount, &tg.Matcher, &lbArnsJSON,
+		&tagsJSON, &tg.Region, &tg.AccountID,
+		&tg.CreatedAt, &tg.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get target group by name: %w", err)
+	}
+
+	// Parse JSON fields
+	json.Unmarshal([]byte(lbArnsJSON), &tg.LoadBalancerArns)
+	json.Unmarshal([]byte(tagsJSON), &tg.Tags)
+
+	return &tg, nil
+}
+
+// ListTargetGroups lists all target groups in a region
+func (s *elbv2Store) ListTargetGroups(ctx context.Context, region string) ([]*storage.ELBv2TargetGroup, error) {
+	query := `
+	SELECT arn, name, protocol, port, vpc_id, target_type,
+		health_check_enabled, health_check_protocol, health_check_port,
+		health_check_path, health_check_interval_seconds,
+		health_check_timeout_seconds, healthy_threshold_count,
+		unhealthy_threshold_count, matcher, load_balancer_arns,
+		tags, region, account_id, created_at, updated_at
+	FROM elbv2_target_groups
+	WHERE region = $1
+	ORDER BY created_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list target groups: %w", err)
+	}
+	defer rows.Close()
+
+	var tgs []*storage.ELBv2TargetGroup
+	for rows.Next() {
+		var tg storage.ELBv2TargetGroup
+		var lbArnsJSON, tagsJSON string
+
+		err := rows.Scan(
+			&tg.ARN, &tg.Name, &tg.Protocol, &tg.Port, &tg.VpcID, &tg.TargetType,
+			&tg.HealthCheckEnabled, &tg.HealthCheckProtocol, &tg.HealthCheckPort,
+			&tg.HealthCheckPath, &tg.HealthCheckIntervalSeconds,
+			&tg.HealthCheckTimeoutSeconds, &tg.HealthyThresholdCount,
+			&tg.UnhealthyThresholdCount, &tg.Matcher, &lbArnsJSON,
+			&tagsJSON, &tg.Region, &tg.AccountID,
+			&tg.CreatedAt, &tg.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan target group: %w", err)
+		}
+
+		// Parse JSON fields
+		json.Unmarshal([]byte(lbArnsJSON), &tg.LoadBalancerArns)
+		json.Unmarshal([]byte(tagsJSON), &tg.Tags)
+
+		tgs = append(tgs, &tg)
+	}
+
+	return tgs, nil
+}
+
+// UpdateTargetGroup updates a target group
+func (s *elbv2Store) UpdateTargetGroup(ctx context.Context, tg *storage.ELBv2TargetGroup) error {
+	tg.UpdatedAt = time.Now()
+
+	// Convert arrays and maps to JSON
+	lbArnsJSON, _ := json.Marshal(tg.LoadBalancerArns)
+	tagsJSON, _ := json.Marshal(tg.Tags)
+
+	query := `
+	UPDATE elbv2_target_groups SET
+		health_check_enabled = $1, health_check_protocol = $2,
+		health_check_port = $3, health_check_path = $4,
+		health_check_interval_seconds = $5, health_check_timeout_seconds = $6,
+		healthy_threshold_count = $7, unhealthy_threshold_count = $8,
+		matcher = $9, load_balancer_arns = $10, tags = $11, updated_at = $12
+	WHERE arn = $13`
+
+	result, err := s.db.ExecContext(ctx, query,
+		tg.HealthCheckEnabled, tg.HealthCheckProtocol, tg.HealthCheckPort,
+		tg.HealthCheckPath, tg.HealthCheckIntervalSeconds,
+		tg.HealthCheckTimeoutSeconds, tg.HealthyThresholdCount,
+		tg.UnhealthyThresholdCount, tg.Matcher,
+		string(lbArnsJSON), string(tagsJSON), tg.UpdatedAt, tg.ARN,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to update target group: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// DeleteTargetGroup deletes a target group
+func (s *elbv2Store) DeleteTargetGroup(ctx context.Context, arn string) error {
+	query := `DELETE FROM elbv2_target_groups WHERE arn = $1`
+
+	result, err := s.db.ExecContext(ctx, query, arn)
+	if err != nil {
+		return fmt.Errorf("failed to delete target group: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Placeholder implementations for remaining methods
+// These will be fully implemented when the corresponding structs are defined
+
+// CreateListener creates a new listener
+func (s *elbv2Store) CreateListener(ctx context.Context, listener *storage.ELBv2Listener) error {
+	return fmt.Errorf("not implemented")
+}
+
+// GetListener retrieves a listener by ARN
+func (s *elbv2Store) GetListener(ctx context.Context, arn string) (*storage.ELBv2Listener, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ListListeners lists all listeners for a load balancer
+func (s *elbv2Store) ListListeners(ctx context.Context, loadBalancerArn string) ([]*storage.ELBv2Listener, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// UpdateListener updates a listener
+func (s *elbv2Store) UpdateListener(ctx context.Context, listener *storage.ELBv2Listener) error {
+	return fmt.Errorf("not implemented")
+}
+
+// DeleteListener deletes a listener
+func (s *elbv2Store) DeleteListener(ctx context.Context, arn string) error {
+	return fmt.Errorf("not implemented")
+}
+
+// RegisterTargets registers targets with a target group
+func (s *elbv2Store) RegisterTargets(ctx context.Context, targetGroupArn string, targets []*storage.ELBv2Target) error {
+	return fmt.Errorf("not implemented")
+}
+
+// DeregisterTargets deregisters targets from a target group
+func (s *elbv2Store) DeregisterTargets(ctx context.Context, targetGroupArn string, targetIDs []string) error {
+	return fmt.Errorf("not implemented")
+}
+
+// ListTargets lists all targets in a target group
+func (s *elbv2Store) ListTargets(ctx context.Context, targetGroupArn string) ([]*storage.ELBv2Target, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// UpdateTargetHealth updates the health of a target
+func (s *elbv2Store) UpdateTargetHealth(ctx context.Context, targetGroupArn, targetID string, health *storage.ELBv2TargetHealth) error {
+	return fmt.Errorf("not implemented")
+}
+
+// CreateRule creates a new rule
+func (s *elbv2Store) CreateRule(ctx context.Context, rule *storage.ELBv2Rule) error {
+	return fmt.Errorf("not implemented")
+}
+
+// GetRule retrieves a rule by ARN
+func (s *elbv2Store) GetRule(ctx context.Context, ruleArn string) (*storage.ELBv2Rule, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ListRules lists all rules for a listener
+func (s *elbv2Store) ListRules(ctx context.Context, listenerArn string) ([]*storage.ELBv2Rule, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// UpdateRule updates a rule
+func (s *elbv2Store) UpdateRule(ctx context.Context, rule *storage.ELBv2Rule) error {
+	return fmt.Errorf("not implemented")
+}
+
+// DeleteRule deletes a rule
+func (s *elbv2Store) DeleteRule(ctx context.Context, ruleArn string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/controlplane/internal/storage/postgres/postgres.go
+++ b/controlplane/internal/storage/postgres/postgres.go
@@ -12,13 +12,18 @@ import (
 
 // PostgresStorage implements the Storage interface for PostgreSQL
 type PostgresStorage struct {
-	db                  *sql.DB
-	connString          string
-	clusterStore        *clusterStore
-	serviceStore        *serviceStore
-	taskStore           *taskStore
-	taskDefinitionStore *taskDefinitionStore
-	// TODO: Add other stores once implemented
+	db                     *sql.DB
+	connString             string
+	clusterStore           *clusterStore
+	serviceStore           *serviceStore
+	taskStore              *taskStore
+	taskDefinitionStore    *taskDefinitionStore
+	accountSettingStore    *accountSettingStore
+	taskSetStore           *taskSetStore
+	containerInstanceStore *containerInstanceStore
+	attributeStore         *attributeStore
+	elbv2Store             *elbv2Store
+	taskLogStore           *taskLogStore
 }
 
 // NewPostgresStorage creates a new PostgreSQL storage instance
@@ -53,7 +58,12 @@ func (s *PostgresStorage) Initialize(ctx context.Context) error {
 	s.serviceStore = &serviceStore{db: db}
 	s.taskStore = &taskStore{db: db}
 	s.taskDefinitionStore = &taskDefinitionStore{db: db}
-	// TODO: Initialize other stores once implemented
+	s.accountSettingStore = &accountSettingStore{db: db}
+	s.taskSetStore = &taskSetStore{db: db}
+	s.containerInstanceStore = &containerInstanceStore{db: db}
+	s.attributeStore = &attributeStore{db: db}
+	s.elbv2Store = &elbv2Store{db: db}
+	s.taskLogStore = &taskLogStore{db: db}
 
 	// Create tables
 	if err := s.createTables(ctx); err != nil {
@@ -93,38 +103,32 @@ func (s *PostgresStorage) TaskStore() storage.TaskStore {
 
 // AccountSettingStore returns the account setting store
 func (s *PostgresStorage) AccountSettingStore() storage.AccountSettingStore {
-	// TODO: Implement account setting store
-	return nil
+	return s.accountSettingStore
 }
 
 // TaskSetStore returns the task set store
 func (s *PostgresStorage) TaskSetStore() storage.TaskSetStore {
-	// TODO: Implement task set store
-	return nil
+	return s.taskSetStore
 }
 
 // ContainerInstanceStore returns the container instance store
 func (s *PostgresStorage) ContainerInstanceStore() storage.ContainerInstanceStore {
-	// TODO: Implement container instance store
-	return nil
+	return s.containerInstanceStore
 }
 
 // AttributeStore returns the attribute store
 func (s *PostgresStorage) AttributeStore() storage.AttributeStore {
-	// TODO: Implement attribute store
-	return nil
+	return s.attributeStore
 }
 
 // ELBv2Store returns the ELBv2 store
 func (s *PostgresStorage) ELBv2Store() storage.ELBv2Store {
-	// TODO: Implement ELBv2 store
-	return nil
+	return s.elbv2Store
 }
 
 // TaskLogStore returns the task log store
 func (s *PostgresStorage) TaskLogStore() storage.TaskLogStore {
-	// TODO: Implement task log store
-	return nil
+	return s.taskLogStore
 }
 
 // BeginTx starts a new transaction
@@ -420,42 +424,293 @@ func (s *PostgresStorage) createTasksTable(ctx context.Context) error {
 
 // createAccountSettingsTable creates the account_settings table
 func (s *PostgresStorage) createAccountSettingsTable(ctx context.Context) error {
-	// Implementation will follow DuckDB schema
-	// TODO: Implement
+	query := `
+	CREATE TABLE IF NOT EXISTS account_settings (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		value TEXT NOT NULL,
+		principal_arn TEXT NOT NULL,
+		is_default BOOLEAN DEFAULT FALSE,
+		region TEXT,
+		account_id TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(principal_arn, name)
+	)`
+
+	_, err := s.db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create account_settings table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_account_settings_name ON account_settings(name)",
+		"CREATE INDEX IF NOT EXISTS idx_account_settings_principal_arn ON account_settings(principal_arn)",
+		"CREATE INDEX IF NOT EXISTS idx_account_settings_is_default ON account_settings(is_default)",
+	}
+
+	for _, idx := range indexes {
+		if _, err := s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // createTaskSetsTable creates the task_sets table
 func (s *PostgresStorage) createTaskSetsTable(ctx context.Context) error {
-	// Implementation will follow DuckDB schema
-	// TODO: Implement
+	query := `
+	CREATE TABLE IF NOT EXISTS task_sets (
+		id TEXT PRIMARY KEY,
+		arn TEXT NOT NULL UNIQUE,
+		service_arn TEXT NOT NULL,
+		cluster_arn TEXT NOT NULL,
+		external_id TEXT,
+		task_definition TEXT NOT NULL,
+		launch_type TEXT,
+		platform_version TEXT,
+		platform_family TEXT,
+		network_configuration TEXT,
+		load_balancers TEXT,
+		service_registries TEXT,
+		capacity_provider_strategy TEXT,
+		scale TEXT,
+		computed_desired_count INTEGER DEFAULT 0,
+		pending_count INTEGER DEFAULT 0,
+		running_count INTEGER DEFAULT 0,
+		status TEXT NOT NULL,
+		stability_status TEXT,
+		stability_status_at TIMESTAMP,
+		started_by TEXT,
+		tags TEXT,
+		fargate_ephemeral_storage TEXT,
+		region TEXT,
+		account_id TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(service_arn, id)
+	)`
+
+	_, err := s.db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create task_sets table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_task_sets_service_arn ON task_sets(service_arn)",
+		"CREATE INDEX IF NOT EXISTS idx_task_sets_cluster_arn ON task_sets(cluster_arn)",
+		"CREATE INDEX IF NOT EXISTS idx_task_sets_status ON task_sets(status)",
+		"CREATE INDEX IF NOT EXISTS idx_task_sets_created_at ON task_sets(created_at)",
+	}
+
+	for _, idx := range indexes {
+		if _, err := s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // createContainerInstancesTable creates the container_instances table
 func (s *PostgresStorage) createContainerInstancesTable(ctx context.Context) error {
-	// Implementation will follow DuckDB schema
-	// TODO: Implement
+	query := `
+	CREATE TABLE IF NOT EXISTS container_instances (
+		id TEXT PRIMARY KEY,
+		arn TEXT NOT NULL UNIQUE,
+		cluster_arn TEXT NOT NULL,
+		ec2_instance_id TEXT,
+		status TEXT NOT NULL,
+		status_reason TEXT,
+		agent_connected BOOLEAN DEFAULT FALSE,
+		agent_update_status TEXT,
+		running_tasks_count INTEGER DEFAULT 0,
+		pending_tasks_count INTEGER DEFAULT 0,
+		version BIGINT DEFAULT 0,
+		version_info TEXT,
+		registered_resources TEXT,
+		remaining_resources TEXT,
+		attributes TEXT,
+		attachments TEXT,
+		tags TEXT,
+		capacity_provider_name TEXT,
+		health_status TEXT,
+		region TEXT,
+		account_id TEXT,
+		registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		deregistered_at TIMESTAMP
+	)`
+
+	_, err := s.db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create container_instances table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_container_instances_cluster_arn ON container_instances(cluster_arn)",
+		"CREATE INDEX IF NOT EXISTS idx_container_instances_status ON container_instances(status)",
+		"CREATE INDEX IF NOT EXISTS idx_container_instances_ec2_instance_id ON container_instances(ec2_instance_id)",
+		"CREATE INDEX IF NOT EXISTS idx_container_instances_registered_at ON container_instances(registered_at)",
+	}
+
+	for _, idx := range indexes {
+		if _, err := s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // createAttributesTable creates the attributes table
 func (s *PostgresStorage) createAttributesTable(ctx context.Context) error {
-	// Implementation will follow DuckDB schema
-	// TODO: Implement
+	query := `
+	CREATE TABLE IF NOT EXISTS attributes (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		value TEXT,
+		target_type TEXT NOT NULL,
+		target_id TEXT NOT NULL,
+		cluster TEXT NOT NULL,
+		region TEXT,
+		account_id TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(name, target_type, target_id, cluster)
+	)`
+
+	_, err := s.db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create attributes table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_attributes_cluster ON attributes(cluster)",
+		"CREATE INDEX IF NOT EXISTS idx_attributes_target_type ON attributes(target_type)",
+		"CREATE INDEX IF NOT EXISTS idx_attributes_target_id ON attributes(target_id)",
+	}
+
+	for _, idx := range indexes {
+		if _, err := s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // createELBv2Tables creates the ELBv2 related tables
 func (s *PostgresStorage) createELBv2Tables(ctx context.Context) error {
-	// Implementation will follow DuckDB schema
-	// TODO: Implement
+	// Create load balancers table
+	lbQuery := `
+	CREATE TABLE IF NOT EXISTS elbv2_load_balancers (
+		arn TEXT PRIMARY KEY,
+		name TEXT NOT NULL UNIQUE,
+		dns_name TEXT,
+		canonical_hosted_zone_id TEXT,
+		state TEXT,
+		type TEXT,
+		scheme TEXT,
+		vpc_id TEXT,
+		subnets TEXT,
+		availability_zones TEXT,
+		security_groups TEXT,
+		ip_address_type TEXT,
+		tags TEXT,
+		region TEXT,
+		account_id TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`
+
+	if _, err := s.db.ExecContext(ctx, lbQuery); err != nil {
+		return fmt.Errorf("failed to create elbv2_load_balancers table: %w", err)
+	}
+
+	// Create target groups table
+	tgQuery := `
+	CREATE TABLE IF NOT EXISTS elbv2_target_groups (
+		arn TEXT PRIMARY KEY,
+		name TEXT NOT NULL UNIQUE,
+		protocol TEXT,
+		port INTEGER,
+		vpc_id TEXT,
+		target_type TEXT,
+		health_check_enabled BOOLEAN DEFAULT TRUE,
+		health_check_protocol TEXT,
+		health_check_port TEXT,
+		health_check_path TEXT,
+		health_check_interval_seconds INTEGER,
+		health_check_timeout_seconds INTEGER,
+		healthy_threshold_count INTEGER,
+		unhealthy_threshold_count INTEGER,
+		matcher TEXT,
+		load_balancer_arns TEXT,
+		tags TEXT,
+		region TEXT,
+		account_id TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`
+
+	if _, err := s.db.ExecContext(ctx, tgQuery); err != nil {
+		return fmt.Errorf("failed to create elbv2_target_groups table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_elbv2_load_balancers_region ON elbv2_load_balancers(region)",
+		"CREATE INDEX IF NOT EXISTS idx_elbv2_load_balancers_vpc_id ON elbv2_load_balancers(vpc_id)",
+		"CREATE INDEX IF NOT EXISTS idx_elbv2_target_groups_region ON elbv2_target_groups(region)",
+		"CREATE INDEX IF NOT EXISTS idx_elbv2_target_groups_vpc_id ON elbv2_target_groups(vpc_id)",
+	}
+
+	for _, idx := range indexes {
+		if _, err := s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // createTaskLogsTable creates the task_logs table
 func (s *PostgresStorage) createTaskLogsTable(ctx context.Context) error {
-	// Implementation will follow DuckDB schema
-	// TODO: Implement
+	query := `
+	CREATE TABLE IF NOT EXISTS task_logs (
+		id TEXT PRIMARY KEY,
+		task_arn TEXT NOT NULL,
+		container_name TEXT NOT NULL,
+		timestamp TIMESTAMP NOT NULL,
+		log_line TEXT NOT NULL,
+		log_level TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`
+
+	_, err := s.db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create task_logs table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_task_logs_task_arn ON task_logs(task_arn)",
+		"CREATE INDEX IF NOT EXISTS idx_task_logs_container_name ON task_logs(container_name)",
+		"CREATE INDEX IF NOT EXISTS idx_task_logs_timestamp ON task_logs(timestamp)",
+		"CREATE INDEX IF NOT EXISTS idx_task_logs_created_at ON task_logs(created_at)",
+	}
+
+	for _, idx := range indexes {
+		if _, err := s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/controlplane/internal/storage/postgres/task_definition_store.go
+++ b/controlplane/internal/storage/postgres/task_definition_store.go
@@ -1,0 +1,438 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type taskDefinitionStore struct {
+	db *sql.DB
+}
+
+// Register registers a new task definition (creates a new revision)
+func (s *taskDefinitionStore) Register(ctx context.Context, td *storage.TaskDefinition) (*storage.TaskDefinition, error) {
+	if td.ID == "" {
+		td.ID = uuid.New().String()
+	}
+
+	if td.RegisteredAt.IsZero() {
+		td.RegisteredAt = time.Now()
+	}
+
+	query := `
+	INSERT INTO task_definitions (
+		id, arn, family, revision, task_role_arn, execution_role_arn,
+		network_mode, container_definitions, volumes, placement_constraints,
+		requires_compatibilities, cpu, memory, tags, pid_mode, ipc_mode,
+		proxy_configuration, inference_accelerators, runtime_platform,
+		status, region, account_id, registered_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+		$11, $12, $13, $14, $15, $16, $17, $18, $19,
+		$20, $21, $22, $23
+	)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		td.ID, td.ARN, td.Family, td.Revision,
+		toNullString(td.TaskRoleARN), toNullString(td.ExecutionRoleARN),
+		td.NetworkMode, td.ContainerDefinitions,
+		toNullString(td.Volumes), toNullString(td.PlacementConstraints),
+		toNullString(td.RequiresCompatibilities), toNullString(td.CPU),
+		toNullString(td.Memory), toNullString(td.Tags),
+		toNullString(td.PidMode), toNullString(td.IpcMode),
+		toNullString(td.ProxyConfiguration), toNullString(td.InferenceAccelerators),
+		toNullString(td.RuntimePlatform),
+		td.Status, td.Region, td.AccountID, td.RegisteredAt,
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return nil, storage.ErrResourceAlreadyExists
+		}
+		return nil, fmt.Errorf("failed to create task definition: %w", err)
+	}
+
+	return td, nil
+}
+
+// GetByARN retrieves a task definition by ARN
+func (s *taskDefinitionStore) GetByARN(ctx context.Context, taskDefArn string) (*storage.TaskDefinition, error) {
+	query := `
+	SELECT
+		id, arn, family, revision, task_role_arn, execution_role_arn,
+		network_mode, container_definitions, volumes, placement_constraints,
+		requires_compatibilities, cpu, memory, tags, pid_mode, ipc_mode,
+		proxy_configuration, inference_accelerators, runtime_platform,
+		status, region, account_id, registered_at, deregistered_at
+	FROM task_definitions
+	WHERE arn = $1`
+
+	var td storage.TaskDefinition
+	var taskRoleARN, executionRoleARN, volumes, placementConstraints sql.NullString
+	var requiresCompatibilities, cpu, memory, tags sql.NullString
+	var pidMode, ipcMode, proxyConfiguration, inferenceAccelerators sql.NullString
+	var runtimePlatform sql.NullString
+	var deregisteredAt sql.NullTime
+
+	err := s.db.QueryRowContext(ctx, query, taskDefArn).Scan(
+		&td.ID, &td.ARN, &td.Family, &td.Revision,
+		&taskRoleARN, &executionRoleARN,
+		&td.NetworkMode, &td.ContainerDefinitions,
+		&volumes, &placementConstraints,
+		&requiresCompatibilities, &cpu, &memory, &tags,
+		&pidMode, &ipcMode, &proxyConfiguration,
+		&inferenceAccelerators, &runtimePlatform,
+		&td.Status, &td.Region, &td.AccountID,
+		&td.RegisteredAt, &deregisteredAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get task definition: %w", err)
+	}
+
+	// Convert null values
+	td.TaskRoleARN = fromNullString(taskRoleARN)
+	td.ExecutionRoleARN = fromNullString(executionRoleARN)
+	td.Volumes = fromNullString(volumes)
+	td.PlacementConstraints = fromNullString(placementConstraints)
+	td.RequiresCompatibilities = fromNullString(requiresCompatibilities)
+	td.CPU = fromNullString(cpu)
+	td.Memory = fromNullString(memory)
+	td.Tags = fromNullString(tags)
+	td.PidMode = fromNullString(pidMode)
+	td.IpcMode = fromNullString(ipcMode)
+	td.ProxyConfiguration = fromNullString(proxyConfiguration)
+	td.InferenceAccelerators = fromNullString(inferenceAccelerators)
+	td.RuntimePlatform = fromNullString(runtimePlatform)
+	td.DeregisteredAt = fromNullTime(deregisteredAt)
+
+	return &td, nil
+}
+
+// GetLatest retrieves the latest revision of a task definition family
+func (s *taskDefinitionStore) GetLatest(ctx context.Context, family string) (*storage.TaskDefinition, error) {
+	query := `
+	SELECT
+		id, arn, family, revision, task_role_arn, execution_role_arn,
+		network_mode, container_definitions, volumes, placement_constraints,
+		requires_compatibilities, cpu, memory, tags, pid_mode, ipc_mode,
+		proxy_configuration, inference_accelerators, runtime_platform,
+		status, region, account_id, registered_at, deregistered_at
+	FROM task_definitions
+	WHERE family = $1 AND status = 'ACTIVE'
+	ORDER BY revision DESC
+	LIMIT 1`
+
+	var td storage.TaskDefinition
+	var taskRoleARN, executionRoleARN, volumes, placementConstraints sql.NullString
+	var requiresCompatibilities, cpu, memory, tags sql.NullString
+	var pidMode, ipcMode, proxyConfiguration, inferenceAccelerators sql.NullString
+	var runtimePlatform sql.NullString
+	var deregisteredAt sql.NullTime
+
+	err := s.db.QueryRowContext(ctx, query, family).Scan(
+		&td.ID, &td.ARN, &td.Family, &td.Revision,
+		&taskRoleARN, &executionRoleARN,
+		&td.NetworkMode, &td.ContainerDefinitions,
+		&volumes, &placementConstraints,
+		&requiresCompatibilities, &cpu, &memory, &tags,
+		&pidMode, &ipcMode, &proxyConfiguration,
+		&inferenceAccelerators, &runtimePlatform,
+		&td.Status, &td.Region, &td.AccountID,
+		&td.RegisteredAt, &deregisteredAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get latest task definition: %w", err)
+	}
+
+	// Convert null values
+	td.TaskRoleARN = fromNullString(taskRoleARN)
+	td.ExecutionRoleARN = fromNullString(executionRoleARN)
+	td.Volumes = fromNullString(volumes)
+	td.PlacementConstraints = fromNullString(placementConstraints)
+	td.RequiresCompatibilities = fromNullString(requiresCompatibilities)
+	td.CPU = fromNullString(cpu)
+	td.Memory = fromNullString(memory)
+	td.Tags = fromNullString(tags)
+	td.PidMode = fromNullString(pidMode)
+	td.IpcMode = fromNullString(ipcMode)
+	td.ProxyConfiguration = fromNullString(proxyConfiguration)
+	td.InferenceAccelerators = fromNullString(inferenceAccelerators)
+	td.RuntimePlatform = fromNullString(runtimePlatform)
+	td.DeregisteredAt = fromNullTime(deregisteredAt)
+
+	return &td, nil
+}
+
+// Get retrieves a specific task definition revision
+func (s *taskDefinitionStore) Get(ctx context.Context, family string, revision int) (*storage.TaskDefinition, error) {
+	query := `
+	SELECT
+		id, arn, family, revision, task_role_arn, execution_role_arn,
+		network_mode, container_definitions, volumes, placement_constraints,
+		requires_compatibilities, cpu, memory, tags, pid_mode, ipc_mode,
+		proxy_configuration, inference_accelerators, runtime_platform,
+		status, region, account_id, registered_at, deregistered_at
+	FROM task_definitions
+	WHERE family = $1 AND revision = $2`
+
+	var td storage.TaskDefinition
+	var taskRoleARN, executionRoleARN, volumes, placementConstraints sql.NullString
+	var requiresCompatibilities, cpu, memory, tags sql.NullString
+	var pidMode, ipcMode, proxyConfiguration, inferenceAccelerators sql.NullString
+	var runtimePlatform sql.NullString
+	var deregisteredAt sql.NullTime
+
+	err := s.db.QueryRowContext(ctx, query, family, revision).Scan(
+		&td.ID, &td.ARN, &td.Family, &td.Revision,
+		&taskRoleARN, &executionRoleARN,
+		&td.NetworkMode, &td.ContainerDefinitions,
+		&volumes, &placementConstraints,
+		&requiresCompatibilities, &cpu, &memory, &tags,
+		&pidMode, &ipcMode, &proxyConfiguration,
+		&inferenceAccelerators, &runtimePlatform,
+		&td.Status, &td.Region, &td.AccountID,
+		&td.RegisteredAt, &deregisteredAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get task definition by family and revision: %w", err)
+	}
+
+	// Convert null values
+	td.TaskRoleARN = fromNullString(taskRoleARN)
+	td.ExecutionRoleARN = fromNullString(executionRoleARN)
+	td.Volumes = fromNullString(volumes)
+	td.PlacementConstraints = fromNullString(placementConstraints)
+	td.RequiresCompatibilities = fromNullString(requiresCompatibilities)
+	td.CPU = fromNullString(cpu)
+	td.Memory = fromNullString(memory)
+	td.Tags = fromNullString(tags)
+	td.PidMode = fromNullString(pidMode)
+	td.IpcMode = fromNullString(ipcMode)
+	td.ProxyConfiguration = fromNullString(proxyConfiguration)
+	td.InferenceAccelerators = fromNullString(inferenceAccelerators)
+	td.RuntimePlatform = fromNullString(runtimePlatform)
+	td.DeregisteredAt = fromNullTime(deregisteredAt)
+
+	return &td, nil
+}
+
+// ListRevisions lists revisions of a specific task definition family
+func (s *taskDefinitionStore) ListRevisions(ctx context.Context, family string, status string, limit int, nextToken string) ([]*storage.TaskDefinitionRevision, string, error) {
+	// Parse the next token to get offset
+	offset := 0
+	if nextToken != "" {
+		if _, err := fmt.Sscanf(nextToken, "%d", &offset); err != nil {
+			return nil, "", fmt.Errorf("invalid next token: %w", err)
+		}
+	}
+
+	query := `
+	SELECT revision, arn, status, registered_at, deregistered_at
+	FROM task_definitions
+	WHERE family = $1`
+
+	args := []interface{}{family}
+	argNum := 2
+
+	if status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argNum)
+		args = append(args, status)
+		argNum++
+	}
+
+	query += " ORDER BY revision DESC"
+
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
+		args = append(args, limit, offset)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list task definition revisions: %w", err)
+	}
+	defer rows.Close()
+
+	var revisions []*storage.TaskDefinitionRevision
+	for rows.Next() {
+		var rev storage.TaskDefinitionRevision
+		var deregisteredAt sql.NullTime
+
+		err := rows.Scan(
+			&rev.Revision, &rev.ARN, &rev.Status,
+			&rev.RegisteredAt, &deregisteredAt,
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to scan revision row: %w", err)
+		}
+
+		// Note: deregisteredAt is not part of TaskDefinitionRevision struct
+		// but we query it for completeness
+		revisions = append(revisions, &rev)
+	}
+
+	// Generate next token if there are more results
+	newNextToken := ""
+	if limit > 0 && len(revisions) == limit {
+		newNextToken = fmt.Sprintf("%d", offset+limit)
+	}
+
+	return revisions, newNextToken, nil
+}
+
+// ListFamilies lists task definition families with pagination
+func (s *taskDefinitionStore) ListFamilies(ctx context.Context, familyPrefix string, status string, limit int, nextToken string) ([]*storage.TaskDefinitionFamily, string, error) {
+	// Parse the next token to get offset
+	offset := 0
+	if nextToken != "" {
+		if _, err := fmt.Sscanf(nextToken, "%d", &offset); err != nil {
+			return nil, "", fmt.Errorf("invalid next token: %w", err)
+		}
+	}
+
+	query := `
+	SELECT DISTINCT family
+	FROM task_definitions
+	WHERE 1=1`
+
+	args := []interface{}{}
+	argNum := 1
+
+	if familyPrefix != "" {
+		query += fmt.Sprintf(" AND family LIKE $%d", argNum)
+		args = append(args, familyPrefix+"%")
+		argNum++
+	}
+
+	if status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argNum)
+		args = append(args, status)
+		argNum++
+	}
+
+	query += " ORDER BY family"
+
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
+		args = append(args, limit, offset)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list task definition families: %w", err)
+	}
+	defer rows.Close()
+
+	var families []*storage.TaskDefinitionFamily
+	for rows.Next() {
+		var family storage.TaskDefinitionFamily
+		err := rows.Scan(&family.Family)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to scan family row: %w", err)
+		}
+		families = append(families, &family)
+	}
+
+	// Generate next token if there are more results
+	newNextToken := ""
+	if limit > 0 && len(families) == limit {
+		newNextToken = fmt.Sprintf("%d", offset+limit)
+	}
+
+	return families, newNextToken, nil
+}
+
+// Update updates a task definition
+func (s *taskDefinitionStore) Update(ctx context.Context, td *storage.TaskDefinition) error {
+	query := `
+	UPDATE task_definitions SET
+		status = $1, tags = $2
+	WHERE arn = $3`
+
+	result, err := s.db.ExecContext(ctx, query,
+		td.Status, toNullString(td.Tags), td.ARN,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to update task definition: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Delete deletes a task definition (logical delete)
+func (s *taskDefinitionStore) Delete(ctx context.Context, taskDefArn string) error {
+	query := `
+	UPDATE task_definitions SET
+		status = 'INACTIVE',
+		deregistered_at = $1
+	WHERE arn = $2`
+
+	result, err := s.db.ExecContext(ctx, query, time.Now(), taskDefArn)
+	if err != nil {
+		return fmt.Errorf("failed to delete task definition: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Deregister marks a task definition as INACTIVE
+func (s *taskDefinitionStore) Deregister(ctx context.Context, family string, revision int) error {
+	query := `
+	UPDATE task_definitions SET
+		status = 'INACTIVE',
+		deregistered_at = $1
+	WHERE family = $2 AND revision = $3`
+
+	result, err := s.db.ExecContext(ctx, query, time.Now(), family, revision)
+	if err != nil {
+		return fmt.Errorf("failed to deregister task definition: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}

--- a/controlplane/internal/storage/postgres/task_log_store.go
+++ b/controlplane/internal/storage/postgres/task_log_store.go
@@ -1,0 +1,290 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type taskLogStore struct {
+	db *sql.DB
+}
+
+// SaveLogs saves multiple log entries for a task container
+func (s *taskLogStore) SaveLogs(ctx context.Context, logs []storage.TaskLog) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	// Use a transaction for batch insert
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	query := `
+	INSERT INTO task_logs (
+		id, task_arn, container_name, timestamp, log_line,
+		log_level, created_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7
+	)`
+
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	now := time.Now()
+	for _, log := range logs {
+		if log.ID == "" {
+			log.ID = uuid.New().String()
+		}
+		if log.CreatedAt.IsZero() {
+			log.CreatedAt = now
+		}
+
+		_, err = stmt.ExecContext(ctx,
+			log.ID, log.TaskArn, log.ContainerName,
+			log.Timestamp, log.LogLine,
+			toNullString(log.LogLevel), log.CreatedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to save log: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// GetLogs retrieves logs based on filter criteria
+func (s *taskLogStore) GetLogs(ctx context.Context, filter storage.TaskLogFilter) ([]storage.TaskLog, error) {
+	query := `
+	SELECT id, task_arn, container_name, timestamp, log_line,
+		log_level, created_at
+	FROM task_logs
+	WHERE 1=1`
+
+	args := []interface{}{}
+	argNum := 1
+
+	// Build dynamic query based on filter
+	if filter.TaskArn != "" {
+		query += fmt.Sprintf(" AND task_arn = $%d", argNum)
+		args = append(args, filter.TaskArn)
+		argNum++
+	}
+
+	if filter.ContainerName != "" {
+		query += fmt.Sprintf(" AND container_name = $%d", argNum)
+		args = append(args, filter.ContainerName)
+		argNum++
+	}
+
+	if filter.From != nil {
+		query += fmt.Sprintf(" AND timestamp >= $%d", argNum)
+		args = append(args, *filter.From)
+		argNum++
+	}
+
+	if filter.To != nil {
+		query += fmt.Sprintf(" AND timestamp <= $%d", argNum)
+		args = append(args, *filter.To)
+		argNum++
+	}
+
+	if filter.LogLevel != "" {
+		query += fmt.Sprintf(" AND log_level = $%d", argNum)
+		args = append(args, filter.LogLevel)
+		argNum++
+	}
+
+	if filter.SearchText != "" {
+		query += fmt.Sprintf(" AND log_line ILIKE $%d", argNum)
+		args = append(args, "%"+filter.SearchText+"%")
+		argNum++
+	}
+
+	query += " ORDER BY timestamp DESC"
+
+	if filter.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d", argNum)
+		args = append(args, filter.Limit)
+		argNum++
+	}
+
+	if filter.Offset > 0 {
+		query += fmt.Sprintf(" OFFSET $%d", argNum)
+		args = append(args, filter.Offset)
+		argNum++
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get logs: %w", err)
+	}
+	defer rows.Close()
+
+	var logs []storage.TaskLog
+	for rows.Next() {
+		var log storage.TaskLog
+		var logLevel sql.NullString
+
+		err := rows.Scan(
+			&log.ID, &log.TaskArn, &log.ContainerName,
+			&log.Timestamp, &log.LogLine,
+			&logLevel, &log.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan log: %w", err)
+		}
+
+		log.LogLevel = fromNullString(logLevel)
+		logs = append(logs, log)
+	}
+
+	return logs, nil
+}
+
+// GetLogCount returns the count of logs matching the filter
+func (s *taskLogStore) GetLogCount(ctx context.Context, filter storage.TaskLogFilter) (int64, error) {
+	query := `
+	SELECT COUNT(*)
+	FROM task_logs
+	WHERE 1=1`
+
+	args := []interface{}{}
+	argNum := 1
+
+	// Build dynamic query based on filter (same as GetLogs but without ORDER BY and LIMIT)
+	if filter.TaskArn != "" {
+		query += fmt.Sprintf(" AND task_arn = $%d", argNum)
+		args = append(args, filter.TaskArn)
+		argNum++
+	}
+
+	if filter.ContainerName != "" {
+		query += fmt.Sprintf(" AND container_name = $%d", argNum)
+		args = append(args, filter.ContainerName)
+		argNum++
+	}
+
+	if filter.From != nil {
+		query += fmt.Sprintf(" AND timestamp >= $%d", argNum)
+		args = append(args, *filter.From)
+		argNum++
+	}
+
+	if filter.To != nil {
+		query += fmt.Sprintf(" AND timestamp <= $%d", argNum)
+		args = append(args, *filter.To)
+		argNum++
+	}
+
+	if filter.LogLevel != "" {
+		query += fmt.Sprintf(" AND log_level = $%d", argNum)
+		args = append(args, filter.LogLevel)
+		argNum++
+	}
+
+	if filter.SearchText != "" {
+		query += fmt.Sprintf(" AND log_line ILIKE $%d", argNum)
+		args = append(args, "%"+filter.SearchText+"%")
+		argNum++
+	}
+
+	var count int64
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get log count: %w", err)
+	}
+
+	return count, nil
+}
+
+// DeleteOldLogs removes logs older than the specified retention period
+func (s *taskLogStore) DeleteOldLogs(ctx context.Context, olderThan time.Time) (int64, error) {
+	query := `
+	DELETE FROM task_logs
+	WHERE created_at < $1`
+
+	result, err := s.db.ExecContext(ctx, query, olderThan)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete old logs: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return rowsAffected, nil
+}
+
+// DeleteTaskLogs removes all logs for a specific task
+func (s *taskLogStore) DeleteTaskLogs(ctx context.Context, taskArn string) error {
+	query := `
+	DELETE FROM task_logs
+	WHERE task_arn = $1`
+
+	_, err := s.db.ExecContext(ctx, query, taskArn)
+	if err != nil {
+		return fmt.Errorf("failed to delete task logs: %w", err)
+	}
+
+	return nil
+}
+
+// Helper function to build WHERE clause from filter
+func buildWhereClause(filter storage.TaskLogFilter) (string, []interface{}) {
+	conditions := []string{}
+	args := []interface{}{}
+
+	if filter.TaskArn != "" {
+		conditions = append(conditions, fmt.Sprintf("task_arn = $%d", len(args)+1))
+		args = append(args, filter.TaskArn)
+	}
+
+	if filter.ContainerName != "" {
+		conditions = append(conditions, fmt.Sprintf("container_name = $%d", len(args)+1))
+		args = append(args, filter.ContainerName)
+	}
+
+	if filter.From != nil {
+		conditions = append(conditions, fmt.Sprintf("timestamp >= $%d", len(args)+1))
+		args = append(args, *filter.From)
+	}
+
+	if filter.To != nil {
+		conditions = append(conditions, fmt.Sprintf("timestamp <= $%d", len(args)+1))
+		args = append(args, *filter.To)
+	}
+
+	if filter.LogLevel != "" {
+		conditions = append(conditions, fmt.Sprintf("log_level = $%d", len(args)+1))
+		args = append(args, filter.LogLevel)
+	}
+
+	if filter.SearchText != "" {
+		conditions = append(conditions, fmt.Sprintf("log_line ILIKE $%d", len(args)+1))
+		args = append(args, "%"+filter.SearchText+"%")
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	return whereClause, args
+}

--- a/controlplane/internal/storage/postgres/task_set_store.go
+++ b/controlplane/internal/storage/postgres/task_set_store.go
@@ -1,0 +1,370 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type taskSetStore struct {
+	db *sql.DB
+}
+
+// Create creates a new task set
+func (s *taskSetStore) Create(ctx context.Context, taskSet *storage.TaskSet) error {
+	if taskSet.ID == "" {
+		taskSet.ID = uuid.New().String()
+	}
+
+	now := time.Now()
+	if taskSet.CreatedAt.IsZero() {
+		taskSet.CreatedAt = now
+	}
+	taskSet.UpdatedAt = now
+
+	query := `
+	INSERT INTO task_sets (
+		id, arn, service_arn, cluster_arn, external_id,
+		task_definition, launch_type, platform_version, platform_family,
+		network_configuration, load_balancers, service_registries,
+		capacity_provider_strategy, scale, computed_desired_count,
+		pending_count, running_count, status, stability_status,
+		stability_status_at, started_by, tags, fargate_ephemeral_storage,
+		region, account_id, created_at, updated_at
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+		$11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+		$21, $22, $23, $24, $25, $26, $27
+	)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		taskSet.ID, taskSet.ARN, taskSet.ServiceARN, taskSet.ClusterARN,
+		toNullString(taskSet.ExternalID), taskSet.TaskDefinition,
+		toNullString(taskSet.LaunchType), toNullString(taskSet.PlatformVersion),
+		toNullString(taskSet.PlatformFamily), toNullString(taskSet.NetworkConfiguration),
+		toNullString(taskSet.LoadBalancers), toNullString(taskSet.ServiceRegistries),
+		toNullString(taskSet.CapacityProviderStrategy), toNullString(taskSet.Scale),
+		taskSet.ComputedDesiredCount, taskSet.PendingCount, taskSet.RunningCount,
+		taskSet.Status, taskSet.StabilityStatus, toNullTime(taskSet.StabilityStatusAt),
+		toNullString(taskSet.StartedBy), toNullString(taskSet.Tags),
+		toNullString(taskSet.FargateEphemeralStorage),
+		toNullString(taskSet.Region), toNullString(taskSet.AccountID),
+		taskSet.CreatedAt, taskSet.UpdatedAt,
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return storage.ErrResourceAlreadyExists
+		}
+		return fmt.Errorf("failed to create task set: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves a task set by service ARN and task set ID
+func (s *taskSetStore) Get(ctx context.Context, serviceARN, taskSetID string) (*storage.TaskSet, error) {
+	query := `
+	SELECT
+		id, arn, service_arn, cluster_arn, external_id,
+		task_definition, launch_type, platform_version, platform_family,
+		network_configuration, load_balancers, service_registries,
+		capacity_provider_strategy, scale, computed_desired_count,
+		pending_count, running_count, status, stability_status,
+		stability_status_at, started_by, tags, fargate_ephemeral_storage,
+		region, account_id, created_at, updated_at
+	FROM task_sets
+	WHERE service_arn = $1 AND id = $2`
+
+	return s.scanTaskSet(ctx, query, serviceARN, taskSetID)
+}
+
+// GetByARN retrieves a task set by ARN
+func (s *taskSetStore) GetByARN(ctx context.Context, arn string) (*storage.TaskSet, error) {
+	query := `
+	SELECT
+		id, arn, service_arn, cluster_arn, external_id,
+		task_definition, launch_type, platform_version, platform_family,
+		network_configuration, load_balancers, service_registries,
+		capacity_provider_strategy, scale, computed_desired_count,
+		pending_count, running_count, status, stability_status,
+		stability_status_at, started_by, tags, fargate_ephemeral_storage,
+		region, account_id, created_at, updated_at
+	FROM task_sets
+	WHERE arn = $1`
+
+	return s.scanTaskSet(ctx, query, arn)
+}
+
+// List retrieves task sets for a service
+func (s *taskSetStore) List(ctx context.Context, serviceARN string, taskSetIDs []string) ([]*storage.TaskSet, error) {
+	query := `
+	SELECT
+		id, arn, service_arn, cluster_arn, external_id,
+		task_definition, launch_type, platform_version, platform_family,
+		network_configuration, load_balancers, service_registries,
+		capacity_provider_strategy, scale, computed_desired_count,
+		pending_count, running_count, status, stability_status,
+		stability_status_at, started_by, tags, fargate_ephemeral_storage,
+		region, account_id, created_at, updated_at
+	FROM task_sets
+	WHERE service_arn = $1`
+
+	args := []interface{}{serviceARN}
+
+	if len(taskSetIDs) > 0 {
+		query += " AND id = ANY($2)"
+		args = append(args, pq.Array(taskSetIDs))
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list task sets: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanTaskSets(rows)
+}
+
+// Update updates a task set
+func (s *taskSetStore) Update(ctx context.Context, taskSet *storage.TaskSet) error {
+	taskSet.UpdatedAt = time.Now()
+
+	query := `
+	UPDATE task_sets SET
+		external_id = $1, task_definition = $2, launch_type = $3,
+		platform_version = $4, platform_family = $5,
+		network_configuration = $6, load_balancers = $7,
+		service_registries = $8, capacity_provider_strategy = $9,
+		scale = $10, computed_desired_count = $11,
+		pending_count = $12, running_count = $13, status = $14,
+		stability_status = $15, stability_status_at = $16,
+		started_by = $17, tags = $18, fargate_ephemeral_storage = $19,
+		updated_at = $20
+	WHERE service_arn = $21 AND id = $22`
+
+	result, err := s.db.ExecContext(ctx, query,
+		toNullString(taskSet.ExternalID), taskSet.TaskDefinition,
+		toNullString(taskSet.LaunchType), toNullString(taskSet.PlatformVersion),
+		toNullString(taskSet.PlatformFamily), toNullString(taskSet.NetworkConfiguration),
+		toNullString(taskSet.LoadBalancers), toNullString(taskSet.ServiceRegistries),
+		toNullString(taskSet.CapacityProviderStrategy), toNullString(taskSet.Scale),
+		taskSet.ComputedDesiredCount, taskSet.PendingCount, taskSet.RunningCount,
+		taskSet.Status, taskSet.StabilityStatus, toNullTime(taskSet.StabilityStatusAt),
+		toNullString(taskSet.StartedBy), toNullString(taskSet.Tags),
+		toNullString(taskSet.FargateEphemeralStorage),
+		taskSet.UpdatedAt, taskSet.ServiceARN, taskSet.ID,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to update task set: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Delete deletes a task set
+func (s *taskSetStore) Delete(ctx context.Context, serviceARN, taskSetID string) error {
+	query := `
+	DELETE FROM task_sets
+	WHERE service_arn = $1 AND id = $2`
+
+	result, err := s.db.ExecContext(ctx, query, serviceARN, taskSetID)
+	if err != nil {
+		return fmt.Errorf("failed to delete task set: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// UpdatePrimary updates the primary task set for a service
+func (s *taskSetStore) UpdatePrimary(ctx context.Context, serviceARN, taskSetID string) error {
+	// First, unset all task sets for this service as non-primary
+	// This would typically involve updating a 'is_primary' field, but since
+	// it's not defined in the TaskSet struct, we'll handle it through status
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Update all task sets for the service to non-primary status
+	updateAllQuery := `
+	UPDATE task_sets
+	SET status = CASE
+		WHEN status = 'PRIMARY' THEN 'ACTIVE'
+		ELSE status
+	END
+	WHERE service_arn = $1`
+
+	if _, err := tx.ExecContext(ctx, updateAllQuery, serviceARN); err != nil {
+		return fmt.Errorf("failed to update task sets: %w", err)
+	}
+
+	// Set the specified task set as primary
+	setPrimaryQuery := `
+	UPDATE task_sets
+	SET status = 'PRIMARY', updated_at = $1
+	WHERE service_arn = $2 AND id = $3`
+
+	result, err := tx.ExecContext(ctx, setPrimaryQuery, time.Now(), serviceARN, taskSetID)
+	if err != nil {
+		return fmt.Errorf("failed to set primary task set: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteOrphaned deletes task sets that no longer have an associated service
+func (s *taskSetStore) DeleteOrphaned(ctx context.Context, clusterARN string) (int, error) {
+	query := `
+	DELETE FROM task_sets
+	WHERE cluster_arn = $1
+	AND service_arn NOT IN (
+		SELECT arn FROM services WHERE cluster_arn = $1
+	)`
+
+	result, err := s.db.ExecContext(ctx, query, clusterARN)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete orphaned task sets: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return int(rowsAffected), nil
+}
+
+// Helper function to scan a single task set
+func (s *taskSetStore) scanTaskSet(ctx context.Context, query string, args ...interface{}) (*storage.TaskSet, error) {
+	var ts storage.TaskSet
+	var externalID, launchType, platformVersion, platformFamily sql.NullString
+	var networkConfig, loadBalancers, serviceRegistries sql.NullString
+	var capacityProviderStrategy, scale, startedBy, tags sql.NullString
+	var fargateEphemeralStorage, region, accountID sql.NullString
+	var stabilityStatusAt sql.NullTime
+
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&ts.ID, &ts.ARN, &ts.ServiceARN, &ts.ClusterARN, &externalID,
+		&ts.TaskDefinition, &launchType, &platformVersion, &platformFamily,
+		&networkConfig, &loadBalancers, &serviceRegistries,
+		&capacityProviderStrategy, &scale, &ts.ComputedDesiredCount,
+		&ts.PendingCount, &ts.RunningCount, &ts.Status, &ts.StabilityStatus,
+		&stabilityStatusAt, &startedBy, &tags, &fargateEphemeralStorage,
+		&region, &accountID, &ts.CreatedAt, &ts.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to scan task set: %w", err)
+	}
+
+	// Convert null values
+	ts.ExternalID = fromNullString(externalID)
+	ts.LaunchType = fromNullString(launchType)
+	ts.PlatformVersion = fromNullString(platformVersion)
+	ts.PlatformFamily = fromNullString(platformFamily)
+	ts.NetworkConfiguration = fromNullString(networkConfig)
+	ts.LoadBalancers = fromNullString(loadBalancers)
+	ts.ServiceRegistries = fromNullString(serviceRegistries)
+	ts.CapacityProviderStrategy = fromNullString(capacityProviderStrategy)
+	ts.Scale = fromNullString(scale)
+	ts.StartedBy = fromNullString(startedBy)
+	ts.Tags = fromNullString(tags)
+	ts.FargateEphemeralStorage = fromNullString(fargateEphemeralStorage)
+	ts.Region = fromNullString(region)
+	ts.AccountID = fromNullString(accountID)
+	ts.StabilityStatusAt = fromNullTime(stabilityStatusAt)
+
+	return &ts, nil
+}
+
+// Helper function to scan multiple task sets
+func (s *taskSetStore) scanTaskSets(rows *sql.Rows) ([]*storage.TaskSet, error) {
+	var taskSets []*storage.TaskSet
+
+	for rows.Next() {
+		var ts storage.TaskSet
+		var externalID, launchType, platformVersion, platformFamily sql.NullString
+		var networkConfig, loadBalancers, serviceRegistries sql.NullString
+		var capacityProviderStrategy, scale, startedBy, tags sql.NullString
+		var fargateEphemeralStorage, region, accountID sql.NullString
+		var stabilityStatusAt sql.NullTime
+
+		err := rows.Scan(
+			&ts.ID, &ts.ARN, &ts.ServiceARN, &ts.ClusterARN, &externalID,
+			&ts.TaskDefinition, &launchType, &platformVersion, &platformFamily,
+			&networkConfig, &loadBalancers, &serviceRegistries,
+			&capacityProviderStrategy, &scale, &ts.ComputedDesiredCount,
+			&ts.PendingCount, &ts.RunningCount, &ts.Status, &ts.StabilityStatus,
+			&stabilityStatusAt, &startedBy, &tags, &fargateEphemeralStorage,
+			&region, &accountID, &ts.CreatedAt, &ts.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan task set row: %w", err)
+		}
+
+		// Convert null values
+		ts.ExternalID = fromNullString(externalID)
+		ts.LaunchType = fromNullString(launchType)
+		ts.PlatformVersion = fromNullString(platformVersion)
+		ts.PlatformFamily = fromNullString(platformFamily)
+		ts.NetworkConfiguration = fromNullString(networkConfig)
+		ts.LoadBalancers = fromNullString(loadBalancers)
+		ts.ServiceRegistries = fromNullString(serviceRegistries)
+		ts.CapacityProviderStrategy = fromNullString(capacityProviderStrategy)
+		ts.Scale = fromNullString(scale)
+		ts.StartedBy = fromNullString(startedBy)
+		ts.Tags = fromNullString(tags)
+		ts.FargateEphemeralStorage = fromNullString(fargateEphemeralStorage)
+		ts.Region = fromNullString(region)
+		ts.AccountID = fromNullString(accountID)
+		ts.StabilityStatusAt = fromNullTime(stabilityStatusAt)
+
+		taskSets = append(taskSets, &ts)
+	}
+
+	return taskSets, nil
+}

--- a/controlplane/internal/storage/postgres/task_store.go
+++ b/controlplane/internal/storage/postgres/task_store.go
@@ -1,0 +1,444 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
+)
+
+type taskStore struct {
+	db *sql.DB
+}
+
+// Create creates a new task
+func (s *taskStore) Create(ctx context.Context, task *storage.Task) error {
+	if task.ID == "" {
+		task.ID = uuid.New().String()
+	}
+
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = time.Now()
+	}
+
+	query := `
+	INSERT INTO tasks (
+		id, arn, cluster_arn, task_definition_arn, container_instance_arn,
+		overrides, last_status, desired_status, cpu, memory,
+		containers, started_by, version, stop_code, stopped_reason,
+		stopping_at, stopped_at, connectivity, connectivity_at,
+		pull_started_at, pull_stopped_at, execution_stopped_at,
+		created_at, started_at, launch_type, platform_version,
+		platform_family, task_group, attachments, health_status,
+		tags, attributes, enable_execute_command, capacity_provider_name,
+		ephemeral_storage, region, account_id, pod_name, namespace,
+		service_registries
+	) VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+		$11, $12, $13, $14, $15, $16, $17, $18, $19,
+		$20, $21, $22, $23, $24, $25, $26, $27, $28,
+		$29, $30, $31, $32, $33, $34, $35, $36, $37,
+		$38, $39, $40
+	)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		task.ID, task.ARN, task.ClusterARN, task.TaskDefinitionARN,
+		toNullString(task.ContainerInstanceARN),
+		toNullString(task.Overrides), task.LastStatus, task.DesiredStatus,
+		toNullString(task.CPU), toNullString(task.Memory),
+		task.Containers, toNullString(task.StartedBy), task.Version,
+		toNullString(task.StopCode), toNullString(task.StoppedReason),
+		toNullTime(task.StoppingAt), toNullTime(task.StoppedAt),
+		toNullString(task.Connectivity), toNullTime(task.ConnectivityAt),
+		toNullTime(task.PullStartedAt), toNullTime(task.PullStoppedAt),
+		toNullTime(task.ExecutionStoppedAt),
+		task.CreatedAt, toNullTime(task.StartedAt),
+		task.LaunchType, toNullString(task.PlatformVersion),
+		toNullString(task.PlatformFamily), toNullString(task.Group),
+		toNullString(task.Attachments), toNullString(task.HealthStatus),
+		toNullString(task.Tags), toNullString(task.Attributes),
+		task.EnableExecuteCommand, toNullString(task.CapacityProviderName),
+		toNullString(task.EphemeralStorage), task.Region, task.AccountID,
+		toNullString(task.PodName), toNullString(task.Namespace),
+		toNullString(task.ServiceRegistries),
+	)
+
+	if err != nil {
+		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
+			return storage.ErrResourceAlreadyExists
+		}
+		return fmt.Errorf("failed to create task: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves a task by cluster and task ID/ARN
+func (s *taskStore) Get(ctx context.Context, clusterARN, taskID string) (*storage.Task, error) {
+	query := `
+	SELECT
+		id, arn, cluster_arn, task_definition_arn, container_instance_arn,
+		overrides, last_status, desired_status, cpu, memory,
+		containers, started_by, version, stop_code, stopped_reason,
+		stopping_at, stopped_at, connectivity, connectivity_at,
+		pull_started_at, pull_stopped_at, execution_stopped_at,
+		created_at, started_at, launch_type, platform_version,
+		platform_family, task_group, attachments, health_status,
+		tags, attributes, enable_execute_command, capacity_provider_name,
+		ephemeral_storage, region, account_id, pod_name, namespace,
+		service_registries
+	FROM tasks
+	WHERE cluster_arn = $1 AND (arn = $2 OR id = $2)`
+
+	return scanTask(s.db.QueryRowContext(ctx, query, clusterARN, taskID))
+}
+
+// List lists tasks with filtering
+func (s *taskStore) List(ctx context.Context, clusterARN string, filters storage.TaskFilters) ([]*storage.Task, error) {
+	query := `
+	SELECT
+		id, arn, cluster_arn, task_definition_arn, container_instance_arn,
+		overrides, last_status, desired_status, cpu, memory,
+		containers, started_by, version, stop_code, stopped_reason,
+		stopping_at, stopped_at, connectivity, connectivity_at,
+		pull_started_at, pull_stopped_at, execution_stopped_at,
+		created_at, started_at, launch_type, platform_version,
+		platform_family, task_group, attachments, health_status,
+		tags, attributes, enable_execute_command, capacity_provider_name,
+		ephemeral_storage, region, account_id, pod_name, namespace,
+		service_registries
+	FROM tasks
+	WHERE cluster_arn = $1`
+
+	args := []interface{}{clusterARN}
+	argNum := 2
+
+	if filters.ServiceName != "" {
+		query += fmt.Sprintf(" AND started_by = $%d", argNum)
+		args = append(args, filters.ServiceName)
+		argNum++
+	}
+	if filters.DesiredStatus != "" {
+		query += fmt.Sprintf(" AND desired_status = $%d", argNum)
+		args = append(args, filters.DesiredStatus)
+		argNum++
+	}
+	if filters.LaunchType != "" {
+		query += fmt.Sprintf(" AND launch_type = $%d", argNum)
+		args = append(args, filters.LaunchType)
+		argNum++
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tasks: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []*storage.Task
+	for rows.Next() {
+		task, err := scanTaskFromRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+
+	return tasks, nil
+}
+
+// Update updates a task
+func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
+	query := `
+	UPDATE tasks SET
+		last_status = $1, desired_status = $2, containers = $3,
+		version = $4, stop_code = $5, stopped_reason = $6,
+		stopping_at = $7, stopped_at = $8, connectivity = $9,
+		connectivity_at = $10, pull_started_at = $11, pull_stopped_at = $12,
+		execution_stopped_at = $13, started_at = $14, health_status = $15,
+		attachments = $16, pod_name = $17, namespace = $18
+	WHERE arn = $19`
+
+	result, err := s.db.ExecContext(ctx, query,
+		task.LastStatus, task.DesiredStatus, task.Containers,
+		task.Version, toNullString(task.StopCode), toNullString(task.StoppedReason),
+		toNullTime(task.StoppingAt), toNullTime(task.StoppedAt),
+		toNullString(task.Connectivity), toNullTime(task.ConnectivityAt),
+		toNullTime(task.PullStartedAt), toNullTime(task.PullStoppedAt),
+		toNullTime(task.ExecutionStoppedAt), toNullTime(task.StartedAt),
+		toNullString(task.HealthStatus), toNullString(task.Attachments),
+		toNullString(task.PodName), toNullString(task.Namespace),
+		task.ARN,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to update task: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// Delete deletes a task
+func (s *taskStore) Delete(ctx context.Context, clusterARN, taskID string) error {
+	query := `DELETE FROM tasks WHERE cluster_arn = $1 AND (arn = $2 OR id = $2)`
+
+	result, err := s.db.ExecContext(ctx, query, clusterARN, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to delete task: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return storage.ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// GetByARNs retrieves tasks by ARNs
+func (s *taskStore) GetByARNs(ctx context.Context, arns []string) ([]*storage.Task, error) {
+	if len(arns) == 0 {
+		return []*storage.Task{}, nil
+	}
+
+	// Build placeholders for IN clause
+	placeholders := make([]string, len(arns))
+	args := make([]interface{}, len(arns))
+	for i, arn := range arns {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = arn
+	}
+
+	query := fmt.Sprintf(`
+	SELECT
+		id, arn, cluster_arn, task_definition_arn, container_instance_arn,
+		overrides, last_status, desired_status, cpu, memory,
+		containers, started_by, version, stop_code, stopped_reason,
+		stopping_at, stopped_at, connectivity, connectivity_at,
+		pull_started_at, pull_stopped_at, execution_stopped_at,
+		created_at, started_at, launch_type, platform_version,
+		platform_family, task_group, attachments, health_status,
+		tags, attributes, enable_execute_command, capacity_provider_name,
+		ephemeral_storage, region, account_id, pod_name, namespace,
+		service_registries
+	FROM tasks
+	WHERE arn IN (%s)`, strings.Join(placeholders, ","))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tasks by ARNs: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []*storage.Task
+	for rows.Next() {
+		task, err := scanTaskFromRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+
+	return tasks, nil
+}
+
+// CreateOrUpdate creates a new task or updates if it already exists
+func (s *taskStore) CreateOrUpdate(ctx context.Context, task *storage.Task) error {
+	// Try to create first
+	err := s.Create(ctx, task)
+	if err == nil {
+		return nil
+	}
+
+	// If already exists, update
+	if err == storage.ErrResourceAlreadyExists {
+		return s.Update(ctx, task)
+	}
+
+	return err
+}
+
+// DeleteOlderThan deletes tasks older than the specified time with the given status
+func (s *taskStore) DeleteOlderThan(ctx context.Context, clusterARN string, before time.Time, status string) (int, error) {
+	query := `DELETE FROM tasks WHERE cluster_arn = $1 AND created_at < $2`
+	args := []interface{}{clusterARN, before}
+
+	if status != "" {
+		query += " AND last_status = $3"
+		args = append(args, status)
+	}
+
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete old tasks: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return int(rowsAffected), nil
+}
+
+// scanTask scans a task from a row
+func scanTask(row *sql.Row) (*storage.Task, error) {
+	var task storage.Task
+	var containerInstanceARN, overrides, cpu, memory, startedBy sql.NullString
+	var stopCode, stoppedReason, connectivity, platformVersion sql.NullString
+	var platformFamily, group, attachments, healthStatus sql.NullString
+	var tags, attributes, capacityProviderName, ephemeralStorage sql.NullString
+	var podName, namespace, serviceRegistries sql.NullString
+	var stoppingAt, stoppedAt, connectivityAt, pullStartedAt sql.NullTime
+	var pullStoppedAt, executionStoppedAt, startedAt sql.NullTime
+
+	err := row.Scan(
+		&task.ID, &task.ARN, &task.ClusterARN, &task.TaskDefinitionARN,
+		&containerInstanceARN, &overrides, &task.LastStatus, &task.DesiredStatus,
+		&cpu, &memory, &task.Containers, &startedBy, &task.Version,
+		&stopCode, &stoppedReason, &stoppingAt, &stoppedAt,
+		&connectivity, &connectivityAt, &pullStartedAt, &pullStoppedAt,
+		&executionStoppedAt, &task.CreatedAt, &startedAt,
+		&task.LaunchType, &platformVersion, &platformFamily,
+		&group, &attachments, &healthStatus, &tags, &attributes,
+		&task.EnableExecuteCommand, &capacityProviderName,
+		&ephemeralStorage, &task.Region, &task.AccountID,
+		&podName, &namespace, &serviceRegistries,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to scan task: %w", err)
+	}
+
+	// Convert null values
+	task.ContainerInstanceARN = fromNullString(containerInstanceARN)
+	task.Overrides = fromNullString(overrides)
+	task.CPU = fromNullString(cpu)
+	task.Memory = fromNullString(memory)
+	task.StartedBy = fromNullString(startedBy)
+	task.StopCode = fromNullString(stopCode)
+	task.StoppedReason = fromNullString(stoppedReason)
+	task.Connectivity = fromNullString(connectivity)
+	task.PlatformVersion = fromNullString(platformVersion)
+	task.PlatformFamily = fromNullString(platformFamily)
+	task.Group = fromNullString(group)
+	task.Attachments = fromNullString(attachments)
+	task.HealthStatus = fromNullString(healthStatus)
+	task.Tags = fromNullString(tags)
+	task.Attributes = fromNullString(attributes)
+	task.CapacityProviderName = fromNullString(capacityProviderName)
+	task.EphemeralStorage = fromNullString(ephemeralStorage)
+	task.PodName = fromNullString(podName)
+	task.Namespace = fromNullString(namespace)
+	task.ServiceRegistries = fromNullString(serviceRegistries)
+
+	task.StoppingAt = fromNullTime(stoppingAt)
+	task.StoppedAt = fromNullTime(stoppedAt)
+	task.ConnectivityAt = fromNullTime(connectivityAt)
+	task.PullStartedAt = fromNullTime(pullStartedAt)
+	task.PullStoppedAt = fromNullTime(pullStoppedAt)
+	task.ExecutionStoppedAt = fromNullTime(executionStoppedAt)
+	task.StartedAt = fromNullTime(startedAt)
+
+	return &task, nil
+}
+
+// scanTaskFromRows scans a task from rows
+func scanTaskFromRows(rows *sql.Rows) (*storage.Task, error) {
+	var task storage.Task
+	var containerInstanceARN, overrides, cpu, memory, startedBy sql.NullString
+	var stopCode, stoppedReason, connectivity, platformVersion sql.NullString
+	var platformFamily, group, attachments, healthStatus sql.NullString
+	var tags, attributes, capacityProviderName, ephemeralStorage sql.NullString
+	var podName, namespace, serviceRegistries sql.NullString
+	var stoppingAt, stoppedAt, connectivityAt, pullStartedAt sql.NullTime
+	var pullStoppedAt, executionStoppedAt, startedAt sql.NullTime
+
+	err := rows.Scan(
+		&task.ID, &task.ARN, &task.ClusterARN, &task.TaskDefinitionARN,
+		&containerInstanceARN, &overrides, &task.LastStatus, &task.DesiredStatus,
+		&cpu, &memory, &task.Containers, &startedBy, &task.Version,
+		&stopCode, &stoppedReason, &stoppingAt, &stoppedAt,
+		&connectivity, &connectivityAt, &pullStartedAt, &pullStoppedAt,
+		&executionStoppedAt, &task.CreatedAt, &startedAt,
+		&task.LaunchType, &platformVersion, &platformFamily,
+		&group, &attachments, &healthStatus, &tags, &attributes,
+		&task.EnableExecuteCommand, &capacityProviderName,
+		&ephemeralStorage, &task.Region, &task.AccountID,
+		&podName, &namespace, &serviceRegistries,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan task row: %w", err)
+	}
+
+	// Convert null values
+	task.ContainerInstanceARN = fromNullString(containerInstanceARN)
+	task.Overrides = fromNullString(overrides)
+	task.CPU = fromNullString(cpu)
+	task.Memory = fromNullString(memory)
+	task.StartedBy = fromNullString(startedBy)
+	task.StopCode = fromNullString(stopCode)
+	task.StoppedReason = fromNullString(stoppedReason)
+	task.Connectivity = fromNullString(connectivity)
+	task.PlatformVersion = fromNullString(platformVersion)
+	task.PlatformFamily = fromNullString(platformFamily)
+	task.Group = fromNullString(group)
+	task.Attachments = fromNullString(attachments)
+	task.HealthStatus = fromNullString(healthStatus)
+	task.Tags = fromNullString(tags)
+	task.Attributes = fromNullString(attributes)
+	task.CapacityProviderName = fromNullString(capacityProviderName)
+	task.EphemeralStorage = fromNullString(ephemeralStorage)
+	task.PodName = fromNullString(podName)
+	task.Namespace = fromNullString(namespace)
+	task.ServiceRegistries = fromNullString(serviceRegistries)
+
+	task.StoppingAt = fromNullTime(stoppingAt)
+	task.StoppedAt = fromNullTime(stoppedAt)
+	task.ConnectivityAt = fromNullTime(connectivityAt)
+	task.PullStartedAt = fromNullTime(pullStartedAt)
+	task.PullStoppedAt = fromNullTime(pullStoppedAt)
+	task.ExecutionStoppedAt = fromNullTime(executionStoppedAt)
+	task.StartedAt = fromNullTime(startedAt)
+
+	return &task, nil
+}
+
+// Helper functions for handling NULL values
+func toNullTime(t *time.Time) sql.NullTime {
+	if t == nil {
+		return sql.NullTime{Valid: false}
+	}
+	return sql.NullTime{Time: *t, Valid: true}
+}
+
+func fromNullTime(nt sql.NullTime) *time.Time {
+	if !nt.Valid {
+		return nil
+	}
+	return &nt.Time
+}


### PR DESCRIPTION
## Summary
Complete implementation of all remaining PostgreSQL storage stores for the KECS storage layer migration.

## Changes
- ✅ **account_setting_store.go** - Full CRUD operations for ECS account settings
- ✅ **task_set_store.go** - Task set management with primary task set support
- ✅ **container_instance_store.go** - Container instance registration and management
- ✅ **attribute_store.go** - ECS attributes with batch operations
- ✅ **elbv2_store.go** - Load balancer and target group operations (partial implementation)
- ✅ **task_log_store.go** - Task log storage with filtering and retention management
- ✅ **postgres.go** - Integration of all new stores with table creation

## Implementation Details
All stores follow the established patterns:
- Proper transaction handling for batch operations
- NULL value handling with helper functions
- Pagination support with nextToken
- Error mapping to storage package errors
- Appropriate indexes for query optimization

## Related PRs
- Builds on #705 (PostgreSQL storage layer foundation)

## Testing
- [x] All code compiles successfully
- [x] Unit tests pass
- [ ] Integration tests (to be added in follow-up PR)

## Next Steps
1. Add PostgreSQL store tests
2. Update storage factory to support PostgreSQL
3. Add PostgreSQL connection configuration to CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)