### PR TITLE
feat: Add Storage Factory for backend selection

### DIFF
--- a/controlplane/internal/controlplane/cmd/server.go
+++ b/controlplane/internal/controlplane/cmd/server.go
@@ -5,11 +5,13 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	storageTypes "github.com/nandemo-ya/kecs/controlplane/internal/storage"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage/cache"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage/duckdb"
+	"github.com/nandemo-ya/kecs/controlplane/internal/storage/postgres"
 	"github.com/nandemo-ya/kecs/controlplane/internal/webhook"
 )
 
@@ -121,36 +124,97 @@ func runServer(cmd *cobra.Command) {
 		logging.Info("Using in-cluster configuration or default kubeconfig")
 	}
 
-	// Initialize storage
-	dbPath := filepath.Join(cfg.Server.DataDir, "kecs.db")
-	logging.Info("Using database",
-		"path", dbPath)
-
-	// Create data directory if it doesn't exist
-	if err := os.MkdirAll(cfg.Server.DataDir, 0o755); err != nil {
-		log.Fatalf("Failed to create data directory: %v", err)
-	}
-
-	// Initialize DuckDB storage
-	dbStorage, err := duckdb.NewDuckDBStorage(dbPath)
-	if err != nil {
-		log.Fatalf("Failed to initialize storage: %v", err)
-	}
-
-	// Initialize storage tables
+	// Initialize storage backend based on environment configuration
+	var dbStorage storageTypes.Storage
 	ctx := context.Background()
-	if err := dbStorage.Initialize(ctx); err != nil {
-		log.Fatalf("Failed to initialize storage tables: %v", err)
+
+	storageType := os.Getenv("KECS_STORAGE_TYPE")
+	if storageType == "" {
+		storageType = "duckdb" // Default to DuckDB
+	}
+
+	switch strings.ToLower(storageType) {
+	case "postgresql", "postgres", "pg":
+		// PostgreSQL storage
+		databaseURL := os.Getenv("KECS_DATABASE_URL")
+		if databaseURL == "" {
+			// Build database URL from individual environment variables
+			host := os.Getenv("KECS_POSTGRES_HOST")
+			if host == "" {
+				host = "localhost"
+			}
+			port := os.Getenv("KECS_POSTGRES_PORT")
+			if port == "" {
+				port = "5432"
+			}
+			user := os.Getenv("KECS_POSTGRES_USER")
+			if user == "" {
+				user = "kecs"
+			}
+			password := os.Getenv("KECS_POSTGRES_PASSWORD")
+			if password == "" {
+				password = "kecs"
+			}
+			database := os.Getenv("KECS_POSTGRES_DATABASE")
+			if database == "" {
+				database = "kecs"
+			}
+			sslMode := os.Getenv("KECS_POSTGRES_SSLMODE")
+			if sslMode == "" {
+				sslMode = "disable"
+			}
+			databaseURL = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+				user, password, host, port, database, sslMode)
+		}
+
+		// Mask password in logs
+		maskedURL := databaseURL
+		if idx := strings.Index(databaseURL, "://"); idx != -1 {
+			if atIdx := strings.Index(databaseURL[idx+3:], "@"); atIdx != -1 {
+				userPassSection := databaseURL[idx+3 : idx+3+atIdx]
+				if colonIdx := strings.Index(userPassSection, ":"); colonIdx != -1 {
+					maskedURL = databaseURL[:idx+3+colonIdx+1] + "***" + databaseURL[idx+3+atIdx:]
+				}
+			}
+		}
+		logging.Info("Using PostgreSQL storage", "url", maskedURL)
+
+		dbStorage = postgres.NewPostgreSQLStorage(databaseURL)
+		if err := dbStorage.Initialize(ctx); err != nil {
+			log.Fatalf("Failed to initialize PostgreSQL storage: %v", err)
+		}
+
+	default:
+		// DuckDB storage (default)
+		dbPath := filepath.Join(cfg.Server.DataDir, "kecs.db")
+		logging.Info("Using DuckDB storage",
+			"path", dbPath)
+
+		// Create data directory if it doesn't exist
+		if err := os.MkdirAll(cfg.Server.DataDir, 0o755); err != nil {
+			log.Fatalf("Failed to create data directory: %v", err)
+		}
+
+		duckdbStorage, err := duckdb.NewDuckDBStorage(dbPath)
+		if err != nil {
+			log.Fatalf("Failed to initialize DuckDB storage: %v", err)
+		}
+
+		if err := duckdbStorage.Initialize(ctx); err != nil {
+			log.Fatalf("Failed to initialize DuckDB storage tables: %v", err)
+		}
+
+		dbStorage = duckdbStorage
 	}
 
 	// Wrap storage with cache layer
 	// Default cache settings: 5 minute TTL, 10000 max items
 	cacheTTL := 5 * time.Minute
 	cacheSize := 10000
-	storage := cache.NewCachedStorage(dbStorage, cacheSize, cacheTTL)
+	cachedStorage := cache.NewCachedStorage(dbStorage, cacheSize, cacheTTL)
 
 	defer func() {
-		if err := storage.Close(); err != nil {
+		if err := cachedStorage.Close(); err != nil {
 			logging.Error("Error closing storage",
 				"error", err)
 		}
@@ -167,11 +231,11 @@ func runServer(cmd *cobra.Command) {
 		localstackConfig = &cfg.LocalStack
 	}
 
-	apiServer, err := api.NewServer(cfg.Server.Port, kubeconfig, storage, localstackConfig)
+	apiServer, err := api.NewServer(cfg.Server.Port, kubeconfig, cachedStorage, localstackConfig)
 	if err != nil {
 		log.Fatalf("Failed to initialize API server: %v", err)
 	}
-	adminServer := admin.NewServer(cfg.Server.AdminPort, storage)
+	adminServer := admin.NewServer(cfg.Server.AdminPort, cachedStorage)
 
 	// Set Kubernetes client for admin server if available
 	if apiServer != nil && apiServer.GetKubeClient() != nil {
@@ -192,7 +256,7 @@ func runServer(cmd *cobra.Command) {
 		// Create webhook configuration
 		webhookConfig := webhook.Config{
 			Port:      9443, // Standard webhook port
-			Storage:   storage,
+			Storage:   cachedStorage,
 			Region:    cfg.AWS.DefaultRegion,
 			AccountID: cfg.AWS.AccountID,
 		}
@@ -284,7 +348,7 @@ func runServer(cmd *cobra.Command) {
 
 		// Create restoration service
 		restorationService := restoration.NewService(
-			storage,
+			cachedStorage,
 			apiServer.GetTaskManager(),
 			apiServer.GetServiceManager(),
 			apiServer.GetLocalStackManager(),
@@ -395,18 +459,18 @@ func runServer(cmd *cobra.Command) {
 		defer shutdownCancel()
 
 		// Persist state before shutdown
-		if storage != nil {
+		if cachedStorage != nil {
 			logging.Info("Persisting state before shutdown...")
 
 			// Mark all running/pending tasks as stopped before shutdown
 			logging.Info("Marking running tasks as stopped...")
-			clusters, err := storage.ClusterStore().List(shutdownCtx)
+			clusters, err := cachedStorage.ClusterStore().List(shutdownCtx)
 			if err != nil {
 				logging.Warn("Failed to list clusters for shutdown cleanup", "error", err)
 			} else if len(clusters) > 0 {
 				for _, cluster := range clusters {
 					// Get all running or pending tasks
-					tasks, err := storage.TaskStore().List(shutdownCtx, cluster.ARN, storageTypes.TaskFilters{
+					tasks, err := cachedStorage.TaskStore().List(shutdownCtx, cluster.ARN, storageTypes.TaskFilters{
 						MaxResults: 1000,
 					})
 					if err != nil {
@@ -426,7 +490,7 @@ func runServer(cmd *cobra.Command) {
 							task.StoppedReason = "KECS instance shutdown"
 							task.Version++
 
-							if err := storage.TaskStore().Update(shutdownCtx, task); err != nil {
+							if err := cachedStorage.TaskStore().Update(shutdownCtx, task); err != nil {
 								logging.Warn("Failed to update task status to STOPPED",
 									"task", task.ARN, "error", err)
 							} else {

--- a/controlplane/internal/storage/postgres/postgres.go
+++ b/controlplane/internal/storage/postgres/postgres.go
@@ -33,6 +33,11 @@ func NewPostgresStorage(connString string) *PostgresStorage {
 	}
 }
 
+// NewPostgreSQLStorage is an alias for NewPostgresStorage for consistency
+func NewPostgreSQLStorage(connString string) storage.Storage {
+	return NewPostgresStorage(connString)
+}
+
 // Initialize initializes the PostgreSQL connection and creates tables
 func (s *PostgresStorage) Initialize(ctx context.Context) error {
 	// Open database connection

--- a/docs/postgresql-storage.md
+++ b/docs/postgresql-storage.md
@@ -1,0 +1,185 @@
+# PostgreSQL Storage Backend
+
+KECS supports PostgreSQL as an alternative storage backend to the default DuckDB. This enables better scalability and integration with existing PostgreSQL infrastructure.
+
+## Configuration
+
+### Environment Variables
+
+The storage backend is selected using the `KECS_STORAGE_TYPE` environment variable:
+
+```bash
+# Use PostgreSQL backend
+export KECS_STORAGE_TYPE=postgresql
+
+# Use DuckDB backend (default)
+export KECS_STORAGE_TYPE=duckdb
+```
+
+### PostgreSQL Connection
+
+There are two ways to configure the PostgreSQL connection:
+
+#### Method 1: Database URL
+
+Set the complete connection URL using `KECS_DATABASE_URL`:
+
+```bash
+export KECS_DATABASE_URL="postgres://username:password@host:port/database?sslmode=disable"
+```
+
+Example:
+```bash
+export KECS_DATABASE_URL="postgres://kecs:secret@localhost:5432/kecs?sslmode=disable"
+```
+
+#### Method 2: Individual Environment Variables
+
+Configure the connection using separate environment variables:
+
+```bash
+export KECS_POSTGRES_HOST=localhost      # Default: localhost
+export KECS_POSTGRES_PORT=5432          # Default: 5432
+export KECS_POSTGRES_USER=kecs          # Default: kecs
+export KECS_POSTGRES_PASSWORD=secret    # Default: kecs
+export KECS_POSTGRES_DATABASE=kecs      # Default: kecs
+export KECS_POSTGRES_SSLMODE=disable    # Default: disable
+```
+
+If `KECS_DATABASE_URL` is not set, KECS will automatically build the connection URL from these individual variables.
+
+## Running KECS with PostgreSQL
+
+### Prerequisites
+
+1. PostgreSQL server (version 12 or later recommended)
+2. Database and user with appropriate permissions
+
+### Setup PostgreSQL
+
+```sql
+-- Create database
+CREATE DATABASE kecs;
+
+-- Create user
+CREATE USER kecs WITH PASSWORD 'your_secure_password';
+
+-- Grant permissions
+GRANT ALL PRIVILEGES ON DATABASE kecs TO kecs;
+```
+
+### Start KECS with PostgreSQL
+
+```bash
+# Using database URL
+export KECS_STORAGE_TYPE=postgresql
+export KECS_DATABASE_URL="postgres://kecs:your_secure_password@localhost:5432/kecs?sslmode=disable"
+./bin/kecs start
+
+# Using individual variables
+export KECS_STORAGE_TYPE=postgresql
+export KECS_POSTGRES_HOST=localhost
+export KECS_POSTGRES_USER=kecs
+export KECS_POSTGRES_PASSWORD=your_secure_password
+export KECS_POSTGRES_DATABASE=kecs
+./bin/kecs start
+```
+
+### Using with Docker
+
+When running KECS in Docker with PostgreSQL:
+
+```bash
+docker run -d \
+  -e KECS_STORAGE_TYPE=postgresql \
+  -e KECS_DATABASE_URL="postgres://kecs:password@postgres:5432/kecs" \
+  -p 8080:8080 \
+  kecs:latest
+```
+
+Or with docker-compose:
+
+```yaml
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: kecs
+      POSTGRES_USER: kecs
+      POSTGRES_PASSWORD: kecs_password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  kecs:
+    image: kecs:latest
+    environment:
+      KECS_STORAGE_TYPE: postgresql
+      KECS_DATABASE_URL: postgres://kecs:kecs_password@postgres:5432/kecs?sslmode=disable
+    ports:
+      - "8080:8080"
+      - "5374:5374"
+    depends_on:
+      - postgres
+
+volumes:
+  postgres_data:
+```
+
+## Migration from DuckDB
+
+To migrate existing data from DuckDB to PostgreSQL:
+
+1. Export data from DuckDB (future feature - not yet implemented)
+2. Import data to PostgreSQL (future feature - not yet implemented)
+
+Currently, migration between storage backends requires recreating all ECS resources.
+
+## Performance Considerations
+
+- **DuckDB**: Better for single-instance deployments, embedded database, no external dependencies
+- **PostgreSQL**: Better for multi-instance deployments, centralized storage, existing PostgreSQL infrastructure
+
+## Troubleshooting
+
+### Connection Issues
+
+If you see connection errors:
+
+1. Verify PostgreSQL is running: `pg_isready -h localhost -p 5432`
+2. Check credentials: `psql -h localhost -U kecs -d kecs -c "SELECT 1"`
+3. Verify network connectivity
+4. Check PostgreSQL logs
+
+### SSL/TLS Configuration
+
+For production environments, use SSL:
+
+```bash
+export KECS_POSTGRES_SSLMODE=require  # or 'verify-ca', 'verify-full'
+```
+
+### Password Security
+
+The password is masked in logs for security. You'll see output like:
+```
+Using PostgreSQL storage url=postgres://kecs:***@localhost:5432/kecs
+```
+
+## Features
+
+Both DuckDB and PostgreSQL backends support the full KECS feature set:
+
+- Clusters management
+- Task definitions
+- Services
+- Tasks
+- Container instances
+- Account settings
+- Task sets
+- ELBv2 integration
+- Attributes
+- Task logs
+
+The storage backend is abstracted through a common interface, ensuring consistent behavior regardless of the chosen backend.


### PR DESCRIPTION
## Summary
- Implement dynamic storage backend selection via environment variables
- Support both DuckDB (default) and PostgreSQL backends
- Add comprehensive PostgreSQL configuration documentation

## Changes
- Modified `server.go` to support storage backend selection based on `KECS_STORAGE_TYPE` environment variable
- Added `NewPostgreSQLStorage` alias function in `postgres.go` for naming consistency
- Created detailed PostgreSQL documentation in `docs/postgresql-storage.md`

## Configuration
The storage backend can be selected using environment variables:

### DuckDB (Default)
```bash
export KECS_STORAGE_TYPE=duckdb  # or leave unset
./bin/kecs start
```

### PostgreSQL
```bash
# Using connection URL
export KECS_STORAGE_TYPE=postgresql
export KECS_DATABASE_URL="postgres://user:pass@host:5432/db"
./bin/kecs start

# Using individual environment variables
export KECS_STORAGE_TYPE=postgresql
export KECS_POSTGRES_HOST=localhost
export KECS_POSTGRES_USER=kecs
export KECS_POSTGRES_PASSWORD=secret
export KECS_POSTGRES_DATABASE=kecs
./bin/kecs start
```

## Security
- Passwords are masked in logs for security
- Connection strings with passwords are shown as `postgres://user:***@host:port/db`

## Test Results
✅ All controlplane tests passed
✅ DuckDB backend tested and working
✅ PostgreSQL configuration tested (connection string generation verified)

## Related PRs
- Follows PR #708 (PostgreSQL storage tests implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)