### PR TITLE
feat: Make PostgreSQL the default storage backend

### DIFF
--- a/controlplane/internal/controlplane/cmd/server.go
+++ b/controlplane/internal/controlplane/cmd/server.go
@@ -11,8 +11,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -30,7 +28,6 @@ import (
 	"github.com/nandemo-ya/kecs/controlplane/internal/restoration"
 	storageTypes "github.com/nandemo-ya/kecs/controlplane/internal/storage"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage/cache"
-	"github.com/nandemo-ya/kecs/controlplane/internal/storage/duckdb"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage/postgres"
 	"github.com/nandemo-ya/kecs/controlplane/internal/webhook"
 )
@@ -125,87 +122,57 @@ func runServer(cmd *cobra.Command) {
 		logging.Info("Using in-cluster configuration or default kubeconfig")
 	}
 
-	// Initialize storage backend based on environment configuration
+	// Initialize storage backend - PostgreSQL as default
 	var dbStorage storageTypes.Storage
 	ctx := context.Background()
 
-	storageType := os.Getenv("KECS_STORAGE_TYPE")
-	if storageType == "" {
-		storageType = "duckdb" // Default to DuckDB
+	// PostgreSQL storage (default)
+	databaseURL := os.Getenv("KECS_DATABASE_URL")
+	if databaseURL == "" {
+		// Build database URL from individual environment variables
+		host := os.Getenv("KECS_POSTGRES_HOST")
+		if host == "" {
+			host = "localhost"
+		}
+		port := os.Getenv("KECS_POSTGRES_PORT")
+		if port == "" {
+			port = "5432"
+		}
+		user := os.Getenv("KECS_POSTGRES_USER")
+		if user == "" {
+			user = "kecs"
+		}
+		password := os.Getenv("KECS_POSTGRES_PASSWORD")
+		if password == "" {
+			password = "kecs"
+		}
+		database := os.Getenv("KECS_POSTGRES_DATABASE")
+		if database == "" {
+			database = "kecs"
+		}
+		sslMode := os.Getenv("KECS_POSTGRES_SSLMODE")
+		if sslMode == "" {
+			sslMode = "disable"
+		}
+		databaseURL = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+			user, password, host, port, database, sslMode)
 	}
 
-	switch strings.ToLower(storageType) {
-	case "postgresql", "postgres", "pg":
-		// PostgreSQL storage
-		databaseURL := os.Getenv("KECS_DATABASE_URL")
-		if databaseURL == "" {
-			// Build database URL from individual environment variables
-			host := os.Getenv("KECS_POSTGRES_HOST")
-			if host == "" {
-				host = "localhost"
-			}
-			port := os.Getenv("KECS_POSTGRES_PORT")
-			if port == "" {
-				port = "5432"
-			}
-			user := os.Getenv("KECS_POSTGRES_USER")
-			if user == "" {
-				user = "kecs"
-			}
-			password := os.Getenv("KECS_POSTGRES_PASSWORD")
-			if password == "" {
-				password = "kecs"
-			}
-			database := os.Getenv("KECS_POSTGRES_DATABASE")
-			if database == "" {
-				database = "kecs"
-			}
-			sslMode := os.Getenv("KECS_POSTGRES_SSLMODE")
-			if sslMode == "" {
-				sslMode = "disable"
-			}
-			databaseURL = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-				user, password, host, port, database, sslMode)
+	// Mask password in logs using proper URL parsing
+	maskedURL := databaseURL
+	if parsed, err := url.Parse(databaseURL); err == nil && parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			// Create a copy with masked password
+			userInfo := url.UserPassword(parsed.User.Username(), "***")
+			parsed.User = userInfo
+			maskedURL = parsed.String()
 		}
+	}
+	logging.Info("Using PostgreSQL storage", "url", maskedURL)
 
-		// Mask password in logs using proper URL parsing
-		maskedURL := databaseURL
-		if parsed, err := url.Parse(databaseURL); err == nil && parsed.User != nil {
-			if _, hasPassword := parsed.User.Password(); hasPassword {
-				// Create a copy with masked password
-				userInfo := url.UserPassword(parsed.User.Username(), "***")
-				parsed.User = userInfo
-				maskedURL = parsed.String()
-			}
-		}
-		logging.Info("Using PostgreSQL storage", "url", maskedURL)
-
-		dbStorage = postgres.NewPostgreSQLStorage(databaseURL)
-		if err := dbStorage.Initialize(ctx); err != nil {
-			log.Fatalf("Failed to initialize PostgreSQL storage: %v", err)
-		}
-
-	default:
-		// DuckDB storage (default)
-		dbPath := filepath.Join(cfg.Server.DataDir, "kecs.db")
-		logging.Info("Using DuckDB storage",
-			"path", dbPath)
-
-		// Create data directory if it doesn't exist
-		if err := os.MkdirAll(cfg.Server.DataDir, 0o755); err != nil {
-			log.Fatalf("Failed to create data directory: %v", err)
-		}
-
-		duckdbStorage, err := duckdb.NewDuckDBStorage(dbPath)
-		if err != nil {
-			log.Fatalf("Failed to initialize DuckDB storage: %v", err)
-		}
-
-		if err := duckdbStorage.Initialize(ctx); err != nil {
-			log.Fatalf("Failed to initialize DuckDB storage tables: %v", err)
-		}
-
-		dbStorage = duckdbStorage
+	dbStorage = postgres.NewPostgreSQLStorage(databaseURL)
+	if err := dbStorage.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize PostgreSQL storage: %v", err)
 	}
 
 	// Wrap storage with cache layer

--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -473,7 +473,9 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 
 // createContainers creates the containers for the deployment based on configuration
 func createContainers(config *ControlPlaneConfig, envVars []corev1.EnvVar) []corev1.Container {
+	// Add PostgreSQL sidecar first so it starts before controlplane
 	containers := []corev1.Container{
+		createPostgresSidecar(config),
 		{
 			Name:            "controlplane",
 			Image:           config.Image,
@@ -515,9 +517,9 @@ func createContainers(config *ControlPlaneConfig, envVars []corev1.EnvVar) []cor
 						Port: intstr.FromString("admin"),
 					},
 				},
-				InitialDelaySeconds: 5,  // Start checking early
-				PeriodSeconds:       2,  // Check frequently during startup
-				FailureThreshold:    60, // Allow up to 2 minutes for startup (60 * 2s)
+				InitialDelaySeconds: 10, // Give PostgreSQL time to start
+				PeriodSeconds:       3,  // Check frequently during startup
+				FailureThreshold:    40, // Allow up to 2 minutes for startup (40 * 3s)
 				SuccessThreshold:    1,
 			},
 			LivenessProbe: &corev1.Probe{
@@ -556,9 +558,6 @@ func createContainers(config *ControlPlaneConfig, envVars []corev1.EnvVar) []cor
 			},
 		},
 	}
-
-	// Add PostgreSQL sidecar (always enabled)
-	containers = append(containers, createPostgresSidecar(config))
 
 	return containers
 }
@@ -672,6 +671,41 @@ func createDeployment(config *ControlPlaneConfig) *appsv1.Deployment {
 				},
 			},
 		},
+		// PostgreSQL connection configuration
+		{
+			Name:  "KECS_POSTGRES_HOST",
+			Value: "localhost", // Sidecar container
+		},
+		{
+			Name:  "KECS_POSTGRES_PORT",
+			Value: "5432",
+		},
+		{
+			Name:  "KECS_POSTGRES_USER",
+			Value: "kecs",
+		},
+		{
+			Name:  "KECS_POSTGRES_PASSWORD",
+			Value: config.PostgresPassword,
+		},
+		{
+			Name:  "KECS_POSTGRES_DATABASE",
+			Value: "kecs",
+		},
+		{
+			Name:  "KECS_POSTGRES_SSLMODE",
+			Value: "disable",
+		},
+	}
+
+	// Use default password if not set
+	if config.PostgresPassword == "" {
+		for i := range envVars {
+			if envVars[i].Name == "KECS_POSTGRES_PASSWORD" {
+				envVars[i].Value = "kecs-postgres-2024"
+				break
+			}
+		}
 	}
 
 	// Add debug environment variable if enabled


### PR DESCRIPTION
## Summary
- Remove KECS_STORAGE_TYPE environment variable check, making PostgreSQL the default storage backend
- Fix container startup order to ensure PostgreSQL is ready before controlplane
- Add proper PostgreSQL connection environment variables

## Changes
1. **Removed storage type selection** (`server.go`)
   - Removed KECS_STORAGE_TYPE environment variable check
   - PostgreSQL is now initialized directly as the default storage
   - DuckDB code remains but is not actively used

2. **Fixed container startup order** (`controlplane.go`)
   - Placed PostgreSQL sidecar container first in the containers array
   - Adjusted startup probe timing (10s initial delay, 40 failure threshold)
   - Added PostgreSQL connection environment variables to controlplane

## Testing
- Created new KECS instance with the updated binary
- Verified both containers start successfully (2/2 Running)
- Tested ECS API operations (create cluster)
- Confirmed data persistence in PostgreSQL tables

## Test Output
```
$ ./bin/kecs start --instance postgres-test-v2
🎉 KECS instance 'postgres-test-v2' is ready!

$ kubectl get pods -n kecs-system | grep controlplane
kecs-controlplane-55b697d8dd-xbw5c   2/2     Running   0          25s

$ aws ecs create-cluster --cluster-name test-v2-cluster --endpoint-url http://localhost:5383
{
    "cluster": {
        "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/test-v2-cluster",
        "clusterName": "test-v2-cluster",
        "status": "ACTIVE"
    }
}
```

## Migration Notes
- Existing instances will automatically use PostgreSQL on next restart
- No configuration changes required
- DuckDB code will be removed in a future PR

Closes #708 (PostgreSQL storage layer implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)