### PR TITLE
refactor: Rename Deployment from kecs-controlplane to kecs-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,15 +176,15 @@ docker-build:
 .PHONY: docker-build-dev
 docker-build-dev:
 	@echo "Building Docker image for local k3d registry..."
-	$(DOCKER) build -t localhost:5000/nandemo-ya/kecs-controlplane:$(VERSION) $(CONTROLPLANE_DIR)
-	$(DOCKER) tag localhost:5000/nandemo-ya/kecs-controlplane:$(VERSION) localhost:5000/nandemo-ya/kecs-controlplane:latest
+	$(DOCKER) build -t localhost:5000/nandemo-ya/kecs-server:$(VERSION) $(CONTROLPLANE_DIR)
+	$(DOCKER) tag localhost:5000/nandemo-ya/kecs-server:$(VERSION) localhost:5000/nandemo-ya/kecs-server:latest
 
 # Push Docker image to local k3d registry (dev mode)
 .PHONY: docker-push-dev
 docker-push-dev: docker-build-dev
 	@echo "Pushing to k3d registry..."
-	$(DOCKER) push localhost:5000/nandemo-ya/kecs-controlplane:$(VERSION)
-	$(DOCKER) push localhost:5000/nandemo-ya/kecs-controlplane:latest
+	$(DOCKER) push localhost:5000/nandemo-ya/kecs-server:$(VERSION)
+	$(DOCKER) push localhost:5000/nandemo-ya/kecs-server:latest
 
 # Hot reload: Build and replace controlplane in running KECS instance
 .PHONY: hot-reload
@@ -213,8 +213,8 @@ hot-reload: docker-push-dev
 	fi; \
 	echo "Updating controlplane in cluster: $$CLUSTER_NAME"; \
 	kubectl config use-context "k3d-$$CLUSTER_NAME" && \
-	kubectl set image deployment/kecs-controlplane controlplane=registry.kecs.local:5000/nandemo-ya/kecs-controlplane:$(VERSION) -n kecs-system && \
-	kubectl rollout status deployment/kecs-controlplane -n kecs-system && \
+	kubectl set image deployment/kecs-server controlplane=registry.kecs.local:5000/nandemo-ya/kecs-server:$(VERSION) -n kecs-system && \
+	kubectl rollout status deployment/kecs-server -n kecs-system && \
 	echo "✅ Controlplane updated successfully!"
 
 # Dev workflow: Build and hot reload in one command
@@ -239,7 +239,7 @@ dev-logs: dev
 		fi; \
 	fi; \
 	kubectl config use-context "k3d-$$CLUSTER_NAME" && \
-	kubectl logs -f deployment/kecs-controlplane -n kecs-system
+	kubectl logs -f deployment/kecs-server -n kecs-system
 
 
 

--- a/controlplane/internal/host/instance/helpers.go
+++ b/controlplane/internal/host/instance/helpers.go
@@ -359,7 +359,7 @@ func (m *Manager) waitForReady(ctx context.Context, instanceName string, cfg *co
 	}
 
 	// Wait for control plane
-	if err := waitForDeployment(ctx, client, "kecs-system", "kecs-controlplane"); err != nil {
+	if err := waitForDeployment(ctx, client, "kecs-system", "kecs-server"); err != nil {
 		return fmt.Errorf("control plane failed to become ready: %w", err)
 	}
 

--- a/controlplane/internal/kubernetes/namespace_manager.go
+++ b/controlplane/internal/kubernetes/namespace_manager.go
@@ -37,7 +37,7 @@ func (n *NamespaceManager) CreateNamespace(ctx context.Context, clusterName, reg
 				"kecs.dev/type":    "ecs-cluster",
 			},
 			Annotations: map[string]string{
-				"kecs.dev/created-by": "kecs-controlplane",
+				"kecs.dev/created-by": "kecs-server",
 			},
 		},
 	}

--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -26,13 +26,13 @@ func int64Ptr(i int64) *int64 {
 const (
 	// ControlPlane constants
 	ControlPlaneNamespace      = "kecs-system"
-	ControlPlaneName           = "kecs-controlplane"
-	ControlPlaneServiceAccount = "kecs-controlplane"
+	ControlPlaneName           = "kecs-server"
+	ControlPlaneServiceAccount = "kecs-server"
 	ControlPlaneConfigMap      = "kecs-config"
 	ControlPlanePVC            = "kecs-data"
 	ControlPlaneAPIService     = "kecs-api"
 	ControlPlaneAdminService   = "kecs-admin"
-	ControlPlaneService        = "kecs-controlplane" // Deprecated, kept for backward compatibility
+	ControlPlaneService        = "kecs-server" // Deprecated, kept for backward compatibility
 
 	// Labels
 	LabelManagedBy = "kecs.dev/managed"

--- a/controlplane/internal/webhook/cert.go
+++ b/controlplane/internal/webhook/cert.go
@@ -40,10 +40,10 @@ func GenerateSelfSignedCert(certPath, keyPath, hostname string) error {
 		"kecs-webhook.kecs-system",
 		"kecs-webhook.kecs-system.svc",
 		"kecs-webhook.kecs-system.svc.cluster.local",
-		"kecs-controlplane",
-		"kecs-controlplane.kecs-system",
-		"kecs-controlplane.kecs-system.svc",
-		"kecs-controlplane.kecs-system.svc.cluster.local",
+		"kecs-server",
+		"kecs-server.kecs-system",
+		"kecs-server.kecs-system.svc",
+		"kecs-server.kecs-system.svc.cluster.local",
 		"localhost",
 	}
 	template.IPAddresses = []net.IP{

--- a/docs-site/deployment/local.md
+++ b/docs-site/deployment/local.md
@@ -163,7 +163,7 @@ kecs start
 kecs start --name myinstance --api-port 9090
 
 # View logs from control plane
-kubectl logs -n kecs-system deployment/kecs-controlplane -f
+kubectl logs -n kecs-system deployment/kecs-server -f
 
 # Stop the instance
 kecs stop

--- a/docs-site/guides/elbv2-integration.md
+++ b/docs-site/guides/elbv2-integration.md
@@ -260,7 +260,7 @@ aws elbv2 describe-target-group-attributes \
 
 ```bash
 # View KECS control plane logs
-kubectl logs -n kecs-system deployment/kecs-controlplane -f
+kubectl logs -n kecs-system deployment/kecs-server -f
 
 # View Traefik access logs
 kubectl logs -n kecs-system deployment/traefik -f

--- a/docs-site/guides/getting-started.md
+++ b/docs-site/guides/getting-started.md
@@ -70,7 +70,7 @@ kubectl get pods -n kecs-system
 
 # Example output:
 # NAME                                   READY   STATUS    RESTARTS   AGE
-# kecs-controlplane-7f8b9c5d4-x2klm     1/1     Running   0          5m
+# kecs-server-7f8b9c5d4-x2klm     1/1     Running   0          5m
 # localstack-6d7f8c9b5-p3qrs            1/1     Running   0          5m
 ```
 

--- a/docs-site/guides/port-forward.md
+++ b/docs-site/guides/port-forward.md
@@ -243,7 +243,7 @@ KECS_INSTANCE=project-b kecs port-forward start service default/web --local-port
 **Solution**:
 1. Check KECS controlplane logs:
    ```bash
-   kubectl logs -n kecs-system deployment/kecs-controlplane -f
+   kubectl logs -n kecs-system deployment/kecs-server -f
    ```
 2. Ensure stable network connection
 3. Verify task isn't being frequently restarted:

--- a/docs-site/ja/deployment/local.md
+++ b/docs-site/ja/deployment/local.md
@@ -163,7 +163,7 @@ KECS は便利なコンテナコマンドを提供しています：
 ./bin/kecs start --name myinstance --api-port 9090
 
 # コントロールプレーンのログを表示
-kubectl logs -n kecs-system deployment/kecs-controlplane -f
+kubectl logs -n kecs-system deployment/kecs-server -f
 
 # インスタンスを停止
 ./bin/kecs stop

--- a/docs/dev-mode.md
+++ b/docs/dev-mode.md
@@ -28,7 +28,7 @@ make docker-push-dev
 
 This will:
 - Build the control plane Docker image
-- Tag it as `localhost:5000/nandemo-ya/kecs-controlplane:latest`
+- Tag it as `localhost:5000/nandemo-ya/kecs-server:latest`
 - Push it to the local k3d registry
 
 ### 3. Start KECS in dev mode
@@ -39,7 +39,7 @@ kecs start --dev
 
 This will:
 - Connect to the existing k3d registry
-- Configure the control plane to use `registry.kecs.local:5000/nandemo-ya/kecs-controlplane:latest` (cluster-internal name)
+- Configure the control plane to use `registry.kecs.local:5000/nandemo-ya/kecs-server:latest` (cluster-internal name)
 - Deploy KECS using the locally built image
 
 ## How it works
@@ -97,7 +97,7 @@ If pods fail with `ErrImagePull`:
 
 2. Check the image tags:
    ```bash
-   curl http://localhost:5000/v2/nandemo-ya/kecs-controlplane/tags/list
+   curl http://localhost:5000/v2/nandemo-ya/kecs-server/tags/list
    ```
 
 3. Check that the registry container is connected to the cluster network

--- a/docs/new-architecture.md
+++ b/docs/new-architecture.md
@@ -180,7 +180,7 @@ curl http://localhost:8081/health/detailed
 ### Check component status
 ```bash
 kubectl get all -n kecs-system
-kubectl logs -n kecs-system -l app=kecs-controlplane
+kubectl logs -n kecs-system -l app=kecs-server
 kubectl logs -n kecs-system -l app=traefik
 kubectl logs -n kecs-system -l app=localstack
 ```

--- a/docs/port-forward.md
+++ b/docs/port-forward.md
@@ -171,7 +171,7 @@ Error: connection refused on port 8080
 Solution:
 - Check if the target service/task is running
 - Verify the target port is correct
-- Check KECS controlplane logs: `kubectl logs -n kecs-system deployment/kecs-controlplane -f`
+- Check KECS controlplane logs: `kubectl logs -n kecs-system deployment/kecs-server -f`
 
 ### Debug Mode
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -155,7 +155,7 @@ docker run -d \
 scrape_configs:
   - job_name: 'kecs'
     static_configs:
-    - targets: ['kecs-controlplane:8081']
+    - targets: ['kecs-server:8081']
     metrics_path: '/metrics/prometheus'
 ```
 
@@ -265,7 +265,7 @@ Access pprof endpoints (admin port):
 1. Update image tag in deployment
 2. Apply rolling update:
 ```bash
-kubectl set image -n kecs-system deployment/kecs-controlplane \
+kubectl set image -n kecs-system deployment/kecs-server \
   controlplane=ghcr.io/nandemo-ya/kecs:v1.1.0
 ```
 


### PR DESCRIPTION
## Summary

Renamed the Deployment from `kecs-controlplane` to `kecs-server` to improve consistency between binary names and Kubernetes resource names.

## Changes

### Code Changes
- **Updated Deployment name constants** (`controlplane/internal/kubernetes/resources/controlplane.go`)
  - `ControlPlaneName`: `kecs-controlplane` → `kecs-server`
  - `ControlPlaneServiceAccount`: `kecs-controlplane` → `kecs-server`
  - `ControlPlaneService`: `kecs-controlplane` → `kecs-server`

- **Updated related references**
  - `helpers.go`: waitForDeployment call
  - `namespace_manager.go`: annotation `kecs.dev/created-by`
  - `webhook/cert.go`: Webhook certificate DNS names

- **Updated Makefile development workflows**
  - `docker-build-dev`: Changed image name to `kecs-server`
  - `docker-push-dev`: Changed image name to `kecs-server`
  - `hot-reload`: Changed deployment name to `kecs-server`
  - `dev-logs`: Changed log source to `kecs-server`

### Documentation Updates
- docs/
  - `dev-mode.md`
  - `new-architecture.md`
  - `port-forward.md`
  - `production-deployment.md`
- docs-site/
  - `deployment/local.md`
  - `guides/elbv2-integration.md`
  - `guides/getting-started.md`
  - `guides/port-forward.md`
  - `ja/deployment/local.md`

## Impact

- For existing KECS instances, the new Deployment name will be applied on the next `make dev` execution
- If directly referencing the Deployment with `kubectl` commands, the name must be changed to `kecs-server`

## Test plan

- [x] All unit tests pass
- [x] Pre-commit hooks pass (go-fmt, go-vet, controlplane-test, full-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)