### PR TITLE
fix: Add database config and prevent Kubernetes env var conflicts

### DIFF
--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -155,10 +155,10 @@ func InitConfig() error {
 		v.SetDefault("localstack.image", "localstack/localstack")
 		v.SetDefault("localstack.version", "latest")
 
-		// Enable environment variable support
+		// Enable environment variable support with KECS prefix only
 		v.SetEnvPrefix("KECS")
 		v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-		v.AutomaticEnv()
+		// REMOVED: v.AutomaticEnv() - this was causing Kubernetes service env vars to override config
 
 		// Map legacy environment variables to new structure
 		bindLegacyEnvVars()
@@ -281,13 +281,6 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	config := &Config{
 		LocalStack: *localstack.DefaultConfig(),
-	}
-
-	// Debug: print all settings before unmarshal
-	if os.Getenv("KECS_DEBUG_CONFIG") == "true" {
-		allSettings := v.AllSettings()
-		fmt.Printf("DEBUG: All viper settings: %+v\n", allSettings)
-		fmt.Printf("DEBUG: server.port type: %T, value: %v\n", v.Get("server.port"), v.Get("server.port"))
 	}
 
 	if err := v.Unmarshal(config); err != nil {

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 // Config represents the KECS configuration
 type Config struct {
 	Server     ServerConfig      `yaml:"server"`
+	Database   DatabaseConfig    `yaml:"database"`
 	LocalStack localstack.Config `yaml:"localstack"`
 	Kubernetes KubernetesConfig  `yaml:"kubernetes"`
 	Features   FeaturesConfig    `yaml:"features"`
@@ -32,6 +33,22 @@ type ServerConfig struct {
 	AllowedOrigins    []string `yaml:"allowedOrigins" mapstructure:"allowedOrigins"`
 	Endpoint          string   `yaml:"endpoint" mapstructure:"endpoint"`
 	ControlPlaneImage string   `yaml:"controlPlaneImage" mapstructure:"controlPlaneImage"`
+}
+
+// DatabaseConfig represents database configuration
+type DatabaseConfig struct {
+	Type     string         `yaml:"type" mapstructure:"type"`
+	Postgres PostgresConfig `yaml:"postgres" mapstructure:"postgres"`
+}
+
+// PostgresConfig represents PostgreSQL-specific configuration
+type PostgresConfig struct {
+	Host     string `yaml:"host" mapstructure:"host"`
+	Port     int    `yaml:"port" mapstructure:"port"`
+	Database string `yaml:"database" mapstructure:"database"`
+	User     string `yaml:"user" mapstructure:"user"`
+	Password string `yaml:"password" mapstructure:"password"`
+	SSLMode  string `yaml:"sslMode" mapstructure:"sslMode"`
 }
 
 // KubernetesConfig represents Kubernetes-related configuration
@@ -95,6 +112,15 @@ func InitConfig() error {
 		v.SetDefault("server.allowedOrigins", []string{})
 		v.SetDefault("server.endpoint", "")
 		v.SetDefault("server.controlPlaneImage", computeControlPlaneImage())
+
+		// Database defaults
+		v.SetDefault("database.type", "postgres")
+		v.SetDefault("database.postgres.host", "localhost")
+		v.SetDefault("database.postgres.port", 5432)
+		v.SetDefault("database.postgres.database", "kecs")
+		v.SetDefault("database.postgres.user", "kecs")
+		v.SetDefault("database.postgres.password", "")
+		v.SetDefault("database.postgres.sslMode", "disable")
 
 		// Kubernetes defaults
 		v.SetDefault("kubernetes.kubeconfigPath", "")
@@ -163,7 +189,13 @@ func bindLegacyEnvVars() {
 	v.BindEnv("localstack.enabled", "KECS_LOCALSTACK_ENABLED")
 	v.BindEnv("localstack.useTraefik", "KECS_LOCALSTACK_USE_TRAEFIK")
 	v.BindEnv("server.controlPlaneImage", "KECS_CONTROLPLANE_IMAGE")
-	v.BindEnv("database.url", "KECS_DATABASE_URL")
+	v.BindEnv("database.type", "KECS_DATABASE_TYPE")
+	v.BindEnv("database.postgres.host", "KECS_POSTGRES_HOST")
+	v.BindEnv("database.postgres.port", "KECS_POSTGRES_PORT")
+	v.BindEnv("database.postgres.database", "KECS_POSTGRES_DATABASE")
+	v.BindEnv("database.postgres.user", "KECS_POSTGRES_USER")
+	v.BindEnv("database.postgres.password", "KECS_POSTGRES_PASSWORD")
+	v.BindEnv("database.postgres.sslMode", "KECS_POSTGRES_SSLMODE")
 }
 
 // DefaultConfig returns the default configuration

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -282,6 +282,14 @@ func LoadConfig(configPath string) (*Config, error) {
 	config := &Config{
 		LocalStack: *localstack.DefaultConfig(),
 	}
+
+	// Debug: print all settings before unmarshal
+	if os.Getenv("KECS_DEBUG_CONFIG") == "true" {
+		allSettings := v.AllSettings()
+		fmt.Printf("DEBUG: All viper settings: %+v\n", allSettings)
+		fmt.Printf("DEBUG: server.port type: %T, value: %v\n", v.Get("server.port"), v.Get("server.port"))
+	}
+
 	if err := v.Unmarshal(config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -16,12 +16,12 @@ import (
 
 // Config represents the KECS configuration
 type Config struct {
-	Server     ServerConfig      `yaml:"server"`
-	Database   DatabaseConfig    `yaml:"database"`
-	LocalStack localstack.Config `yaml:"localstack"`
-	Kubernetes KubernetesConfig  `yaml:"kubernetes"`
-	Features   FeaturesConfig    `yaml:"features"`
-	AWS        AWSConfig         `yaml:"aws"`
+	Server     ServerConfig      `yaml:"server" mapstructure:"server"`
+	Database   DatabaseConfig    `yaml:"database" mapstructure:"database"`
+	LocalStack localstack.Config `yaml:"localstack" mapstructure:"localstack"`
+	Kubernetes KubernetesConfig  `yaml:"kubernetes" mapstructure:"kubernetes"`
+	Features   FeaturesConfig    `yaml:"features" mapstructure:"features"`
+	AWS        AWSConfig         `yaml:"aws" mapstructure:"aws"`
 }
 
 // ServerConfig represents server-specific configuration

--- a/controlplane/internal/config/config.go
+++ b/controlplane/internal/config/config.go
@@ -258,6 +258,7 @@ func LoadConfig(configPath string) (*Config, error) {
 		}
 
 		v.SetConfigFile(configPath)
+		v.SetConfigType("yaml") // Explicitly set config type for ConfigMap mounted files
 		if err := v.ReadInConfig(); err != nil {
 			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}

--- a/controlplane/internal/controlplane/cmd/server.go
+++ b/controlplane/internal/controlplane/cmd/server.go
@@ -79,6 +79,12 @@ func runServer(cmd *cobra.Command) {
 	}
 
 	// Load configuration
+	// Check environment variable if configFile is not set via flag
+	if configFile == "" {
+		if envConfig := os.Getenv("KECS_CONFIG_PATH"); envConfig != "" {
+			configFile = envConfig
+		}
+	}
 	cfg, err := config.LoadConfig(configFile)
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)


### PR DESCRIPTION
## Summary
Fixes configuration issues that prevented KECS control plane from starting in Kubernetes environment.

## Changes

### 1. Added Database Configuration
- Added `DatabaseConfig` and `PostgresConfig` structs to support PostgreSQL configuration
- Added database defaults (type: postgres, host: localhost, port: 5432)
- Added environment variable bindings for PostgreSQL configuration (`KECS_POSTGRES_*`)

### 2. Fixed viper Environment Variable Conflict
**Problem:** viper's `AutomaticEnv()` was reading ALL environment variables, including Kubernetes service variables like `SERVER_PORT` (e.g., `tcp://10.43.208.211:5374`), which overrode config file values and caused unmarshal errors.

**Solution:** Removed `AutomaticEnv()` call. Now only `KECS_*` prefixed environment variables are read through explicit `BindEnv()` calls.

### 3. Improved Configuration Loading
- Added support for `KECS_CONFIG_PATH` environment variable
- Added explicit `SetConfigType("yaml")` for ConfigMap-mounted files
- Added mapstructure tags to all Config struct fields for proper unmarshaling

## Testing
- ✅ All unit tests pass
- ✅ Verified control plane starts successfully in k3d cluster
- ✅ Verified PostgreSQL connection works
- ✅ Verified LocalStack integration works
- ✅ Verified readiness checks pass

## Related Issues
Fixes the CrashLoopBackOff issue discovered after PostgreSQL migration (#710, #711).