### PR TITLE
fix: Remove unsupported lambda and sts services from ConfigMap template

### DIFF
--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -318,13 +318,12 @@ database:
 localstack:
   enabled: true
   services:
-    - s3
     - iam
-    - secretsmanager
-    - ssm
     - logs
-    - lambda
-    - sts
+    - ssm
+    - secretsmanager
+    - elbv2
+    - s3
   image: localstack/localstack
   version: latest
 


### PR DESCRIPTION
## Summary
Fixes CrashLoopBackOff issue caused by unsupported LocalStack services in the ConfigMap template.

## Problem
The ConfigMap template in `controlplane.go` was hardcoding `lambda` and `sts` services in the LocalStack services list. These services are not included in the `DefaultServices` list and are not supported by `ServicePortMap` validation, causing the control plane to crash on startup with the error:
```
Invalid configuration: invalid LocalStack config: invalid service: lambda
```

## Solution
Updated the ConfigMap template to match the `DefaultServices` list defined in `internal/localstack/types.go`:
- `iam`
- `logs`
- `ssm`
- `secretsmanager`
- `elbv2`
- `s3`

Removed:
- `lambda` (not currently used by KECS)
- `sts` (not currently used by KECS)

## Testing
- ✅ All unit tests pass
- ✅ Verified ConfigMap template matches DefaultServices

## Related
This issue was discovered when starting a new KECS instance after the PostgreSQL migration.