### PR TITLE
refactor: Remove duplicate legacy admin service

### DIFF
--- a/controlplane/internal/kubernetes/resources/controlplane.go
+++ b/controlplane/internal/kubernetes/resources/controlplane.go
@@ -32,7 +32,6 @@ const (
 	ControlPlanePVC            = "kecs-data"
 	ControlPlaneAPIService     = "kecs-api"
 	ControlPlaneAdminService   = "kecs-admin"
-	ControlPlaneService        = "kecs-server" // Deprecated, kept for backward compatibility
 
 	// Labels
 	LabelManagedBy = "kecs.dev/managed"
@@ -435,32 +434,6 @@ func createServices(config *ControlPlaneConfig) []*corev1.Service {
 						Name:       "webhook",
 						Port:       443,
 						TargetPort: intstr.FromInt(9443),
-						Protocol:   corev1.ProtocolTCP,
-					},
-				},
-				Type: corev1.ServiceTypeClusterIP,
-			},
-		},
-		// Legacy Admin Service (ClusterIP for backward compatibility)
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ControlPlaneService,
-				Namespace: ControlPlaneNamespace,
-				Labels: map[string]string{
-					LabelManagedBy: "true",
-					LabelComponent: "controlplane",
-					LabelType:      "admin-legacy",
-				},
-			},
-			Spec: corev1.ServiceSpec{
-				Selector: map[string]string{
-					LabelApp: ControlPlaneName,
-				},
-				Ports: []corev1.ServicePort{
-					{
-						Name:       "admin",
-						Port:       config.AdminPort,
-						TargetPort: intstr.FromInt(ControlPlaneInternalAdminPort),
 						Protocol:   corev1.ProtocolTCP,
 					},
 				},


### PR DESCRIPTION
## Summary
- Removed the legacy `kecs-server` ClusterIP service that was kept for backward compatibility
- The `kecs-admin` NodePort service is sufficient for admin server access
- This eliminates the duplication of services listening on port 5374

## Changes
- Removed `ControlPlaneService` constant definition
- Removed legacy admin service definition from `createServices()`

## Impact
- No functional impact - `kecs-server` name is still used for Deployment and hostnames
- Only the Service resource named `kecs-server` has been removed
- All tests pass successfully

## Testing
- ✅ Code compiles successfully
- ✅ All unit tests pass
- ✅ Verified no references to the Service (only Deployment and hostname references remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)