### PR TITLE
fix: Fix cache invalidation for paginated cluster lists

### DIFF
--- a/controlplane/internal/storage/cache/cached_storage.go
+++ b/controlplane/internal/storage/cache/cached_storage.go
@@ -119,8 +119,9 @@ func (s *cachedClusterStore) Create(ctx context.Context, cluster *storage.Cluste
 	s.cache.Set(ctx, clusterKey(cluster.Name), cluster)
 	s.cache.Set(ctx, clusterKeyByArn(cluster.ARN), cluster)
 
-	// Invalidate list cache
+	// Invalidate list caches (both simple list and paginated lists)
 	s.cache.Delete(ctx, "clusters:list")
+	s.cache.DeleteWithPrefix(ctx, "clusters:list:page:")
 
 	return nil
 }
@@ -211,8 +212,9 @@ func (s *cachedClusterStore) Update(ctx context.Context, cluster *storage.Cluste
 	s.cache.Set(ctx, clusterKey(cluster.Name), cluster)
 	s.cache.Set(ctx, clusterKeyByArn(cluster.ARN), cluster)
 
-	// Invalidate list cache
+	// Invalidate list caches (both simple list and paginated lists)
 	s.cache.Delete(ctx, "clusters:list")
+	s.cache.DeleteWithPrefix(ctx, "clusters:list:page:")
 
 	return nil
 }
@@ -231,8 +233,9 @@ func (s *cachedClusterStore) Delete(ctx context.Context, name string) error {
 		s.cache.Delete(ctx, clusterKeyByArn(cluster.ARN))
 	}
 
-	// Invalidate list cache
+	// Invalidate list caches (both simple list and paginated lists)
 	s.cache.Delete(ctx, "clusters:list")
+	s.cache.DeleteWithPrefix(ctx, "clusters:list:page:")
 
 	return nil
 }

--- a/controlplane/internal/storage/cache/memory_cache.go
+++ b/controlplane/internal/storage/cache/memory_cache.go
@@ -123,6 +123,23 @@ func (c *MemoryCache) Delete(ctx context.Context, key string) {
 	}
 }
 
+// DeleteWithPrefix removes all items whose keys start with the given prefix
+func (c *MemoryCache) DeleteWithPrefix(ctx context.Context, prefix string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var toRemove []*cacheItem
+	for key, item := range c.items {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			toRemove = append(toRemove, item)
+		}
+	}
+
+	for _, item := range toRemove {
+		c.removeItem(item)
+	}
+}
+
 // Clear removes all items from the cache
 func (c *MemoryCache) Clear() {
 	c.mu.Lock()

--- a/controlplane/internal/storage/cache/memory_cache.go
+++ b/controlplane/internal/storage/cache/memory_cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"container/list"
 	"context"
+	"strings"
 	"sync"
 	"time"
 )
@@ -130,7 +131,7 @@ func (c *MemoryCache) DeleteWithPrefix(ctx context.Context, prefix string) {
 
 	var toRemove []*cacheItem
 	for key, item := range c.items {
-		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+		if strings.HasPrefix(key, prefix) {
 			toRemove = append(toRemove, item)
 		}
 	}


### PR DESCRIPTION
## Problem
After creating, updating, or deleting a cluster, `aws ecs list-clusters` would return an empty response for approximately 10 seconds to 1 minute. This occurred because the cache was not properly invalidated.

## Root Cause
The cache invalidation logic had a key mismatch:
- Cache deletion used key: `"clusters:list"`
- ListWithPagination cached with key: `"clusters:list:page:{limit}:{token}"`

When clusters were created/updated/deleted, only the simple list key was invalidated, leaving paginated list entries in the cache. These stale entries would persist for their 1-minute TTL, causing the API to return outdated (often empty) results.

## Solution
1. Added `DeleteWithPrefix` method to `MemoryCache` to support prefix-based cache invalidation
2. Updated `Create`, `Update`, and `Delete` methods in `cachedClusterStore` to invalidate all paginated list caches using `DeleteWithPrefix(ctx, "clusters:list:page:")`

## Impact
- Fixes immediate consistency for list-clusters operations
- Clusters now appear in list results immediately after creation
- Changes are reflected immediately after updates/deletions
- No more 10-second to 1-minute delay in list responses

## Testing
- Verified build succeeds
- All unit tests pass
- Manually tested cluster creation followed by immediate list-clusters call