### PR TITLE
fix: Fix unused vertical space at bottom of TUI (#662)

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -787,16 +787,21 @@ func (m Model) View() string {
 	footerHeight := 1
 	availableHeight := totalHeight - footerHeight
 
+	// Each panel has borders (2 lines) and padding (2 lines) = 4 lines overhead
+	// So if we want a panel to take N lines total, we pass N as panelHeight
+	// and renderXxxPanelWithHeight will calculate contentHeight = N - 4
+
 	// Calculate base heights (30/70 split of available height)
 	navPanelHeight := int(float64(availableHeight) * 0.3)
 	resourcePanelHeight := availableHeight - navPanelHeight
 
-	// Ensure minimum heights
-	if navPanelHeight < 10 {
-		navPanelHeight = 10
+	// Ensure minimum heights (accounting for 4 line overhead)
+	minPanelHeight := 10
+	if navPanelHeight < minPanelHeight {
+		navPanelHeight = minPanelHeight
 	}
-	if resourcePanelHeight < 10 {
-		resourcePanelHeight = 10
+	if resourcePanelHeight < minPanelHeight {
+		resourcePanelHeight = minPanelHeight
 	}
 
 	// Adjust to ensure they exactly fill the available height

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -2589,8 +2589,11 @@ func (m Model) renderNavigationPanelWithHeight(panelHeight int) string {
 
 	navContent := lipgloss.JoinVertical(lipgloss.Top, components...)
 
-	// Use the exact height provided, accounting for borders (2) and padding (2)
-	contentHeight := panelHeight - 4
+	// lipgloss.Height() includes padding but NOT borders
+	// So if we want total height of panelHeight:
+	// - Borders add 2 lines (top + bottom)
+	// - Height() should be panelHeight - 2
+	contentHeight := panelHeight - 2
 	if contentHeight < 1 {
 		contentHeight = 1
 	}
@@ -2605,8 +2608,13 @@ func (m Model) renderNavigationPanelWithHeight(panelHeight int) string {
 func (m Model) renderResourcePanelWithHeight(panelHeight int) string {
 	var content string
 
-	// Use the provided height for content calculation
-	contentHeight := panelHeight - 4 // Account for borders and padding
+	// lipgloss.Height() includes padding but NOT borders
+	// So if we want total height of panelHeight:
+	// - Borders add 2 lines (top + bottom)
+	// - Height() should be panelHeight - 2
+	// - contentHeight for rendering lists should be panelHeight - 2 - 2(padding) = panelHeight - 4
+	styleHeight := panelHeight - 2
+	contentHeight := panelHeight - 4 // For rendering lists (excludes borders and padding)
 
 	// Render view-specific content
 	switch m.currentView {
@@ -2649,7 +2657,7 @@ func (m Model) renderResourcePanelWithHeight(panelHeight int) string {
 	}
 
 	return resourcePanelStyle.
-		Width(m.width - 4).    // Account for borders and padding
-		Height(contentHeight). // Use exact height provided
+		Width(m.width - 4).  // Account for borders and padding
+		Height(styleHeight). // Height including padding (borders added automatically)
 		Render(content)
 }


### PR DESCRIPTION
## Problem
There was unused vertical space at the bottom of the terminal that should have been utilized by the main content panels. The navigation panel (30% height) and resource panel (70% height) were not filling the full terminal height, leaving a noticeable gap.

## Root Cause
Misunderstanding of `lipgloss.Height()` behavior:
- `lipgloss.Height(n)` sets height **INCLUDING padding** but **EXCLUDING borders**
- Borders are added **AFTER** the height calculation
- Original code used `Height(panelHeight - 4)`, assuming it needed to subtract both borders (2) and padding (2)
- This resulted in actual height of `(panelHeight - 4) + 2(border) = panelHeight - 2`
- With two panels, this created a 4-line gap at the bottom

## Solution
- Changed `Height()` parameter from `(panelHeight - 4)` to `(panelHeight - 2)`
- Now actual height = `(panelHeight - 2) + 2(border) = panelHeight`
- Panels now correctly fill the available terminal height without gaps

## Testing
Verified with lipgloss test program:
```go
style := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
// Height(5) + Padding(1,2) + Border = 7 lines total (not 9)
// Height(10) + Padding(1,2) + Border = 12 lines total (not 14)
```

This proves that `.Height(n)` includes padding but borders are added on top.

## Impact
- Eliminates unused vertical space at bottom of terminal
- Panels now fully utilize available screen height
- Improves visual consistency across different terminal sizes

Fixes #662