### PR TITLE
refactor: Compact navigation panel summary to single line

### DIFF
--- a/controlplane/internal/tui/app.go
+++ b/controlplane/internal/tui/app.go
@@ -791,8 +791,8 @@ func (m Model) View() string {
 	// So if we want a panel to take N lines total, we pass N as panelHeight
 	// and renderXxxPanelWithHeight will calculate contentHeight = N - 4
 
-	// Calculate base heights (30/70 split of available height)
-	navPanelHeight := int(float64(availableHeight) * 0.3)
+	// Calculate base heights (25/75 split of available height)
+	navPanelHeight := int(float64(availableHeight) * 0.25)
 	resourcePanelHeight := availableHeight - navPanelHeight
 
 	// Ensure minimum heights (accounting for 4 line overhead)

--- a/controlplane/internal/tui/render.go
+++ b/controlplane/internal/tui/render.go
@@ -543,15 +543,9 @@ func (m Model) renderSummary() string {
 				}
 			}
 
-			// Build vertical layout with proper alignment
-			line1 := fmt.Sprintf("Clusters: %-4d  API:   %d", len(m.clusters), apiPort)
-			line2 := fmt.Sprintf("Services: %-4d  Admin: %d", totalServices, adminPort)
-			line3 := fmt.Sprintf("Tasks:    %-4d", totalTasks)
-
-			// Create multi-line summary with consistent styling
-			summary = summaryStyle.Render(line1) + "\n" +
-				summaryStyle.Render(line2) + "\n" +
-				summaryStyle.Render(line3)
+			// Build horizontal layout with stats and ports
+			summary = fmt.Sprintf("Clusters: %d    Services: %d    Tasks: %d        API: %d    Admin: %d",
+				len(m.clusters), totalServices, totalTasks, apiPort, adminPort)
 		}
 
 	case ViewServices:


### PR DESCRIPTION
## Changes

### 1. Summary Layout
Changed cluster statistics from 3-line vertical layout to single horizontal line:

**Before:**
```
Clusters: 1     API:   5373
Services: 0     Admin: 5374
Tasks:    0
```

**After:**
```
Clusters: 1    Services: 0    Tasks: 0        API: 5373    Admin: 5374
```

### 2. Panel Height Ratio
Adjusted navigation panel height from 30% to 25%:
- Navigation panel: 30% → 25%
- Resource panel: 70% → 75%

This provides more space for resource display while maintaining sufficient room for navigation elements with the new compact summary layout.

## Benefits
- **More compact**: Single line vs 3 lines saves vertical space
- **Better information density**: All stats visible at a glance
- **More resource space**: 75% vs 70% for viewing clusters, services, and tasks
- **Cleaner layout**: Horizontal alignment is easier to scan

## Visual Impact
The change eliminates unnecessary vertical spacing in the navigation panel that appeared after moving to single-line summary, resulting in a more balanced layout.