### PR TITLE
docs: Fix TUI command from 'kecs tui' to 'kecs'

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -78,7 +78,7 @@ chmod +x kecs
 ./kecs start
 
 # Or use the TUI for interactive management
-./kecs tui
+./kecs
 ```
 
 The `kecs` command automatically:

--- a/docs/tui-api-integration-phase1.md
+++ b/docs/tui-api-integration-phase1.md
@@ -49,14 +49,14 @@ This document summarizes the completion of Phase 1 of the TUI backend integratio
 ### Running with Mock Data (Default)
 ```bash
 # Just run the TUI normally
-./bin/kecs tui
+./bin/kecs
 ```
 
 ### Running with Real API
 ```bash
 # Set the API endpoint
 export KECS_API_ENDPOINT=http://localhost:8080
-./bin/kecs tui
+./bin/kecs
 ```
 
 ### Forcing Mock Mode
@@ -64,7 +64,7 @@ export KECS_API_ENDPOINT=http://localhost:8080
 # Force mock mode even with API endpoint set
 export KECS_API_ENDPOINT=http://localhost:8080
 export KECS_TUI_MOCK=true
-./bin/kecs tui
+./bin/kecs
 ```
 
 ## Architecture Changes

--- a/docs/tui-backend-api.md
+++ b/docs/tui-backend-api.md
@@ -196,7 +196,7 @@ The TUI uses these endpoints through the API client:
 
 2. Run the TUI:
    ```bash
-   ./bin/kecs tui
+   ./bin/kecs
    ```
 
 The TUI will automatically use the real API instead of mock data.

--- a/docs/tui/DEVELOPER_GUIDE.md
+++ b/docs/tui/DEVELOPER_GUIDE.md
@@ -280,7 +280,7 @@ var _ = Describe("NewView", func() {
 ```bash
 cd controlplane
 go build -o bin/kecs ./cmd/controlplane
-./bin/kecs tui
+./bin/kecs
 ```
 
 2. Test all keyboard shortcuts

--- a/docs/tui/README.md
+++ b/docs/tui/README.md
@@ -25,16 +25,16 @@ The KECS TUI provides a powerful, interactive terminal-based interface for manag
 
 ```bash
 # Start the TUI with default settings (auto-detects running instances)
-kecs tui
+kecs
 
 # Connect to a specific endpoint
-kecs tui --endpoint http://localhost:8080
+kecs --endpoint http://localhost:8080
 
 # Connect to a specific instance by name
-kecs tui --instance dev-cluster
+kecs --instance dev-cluster
 
 # Connect to remote KECS instance
-kecs tui --endpoint http://remote-kecs:8080
+kecs --endpoint http://remote-kecs:8080
 ```
 
 ## Key Features in Action

--- a/docs/tui/USER_GUIDE.md
+++ b/docs/tui/USER_GUIDE.md
@@ -7,13 +7,13 @@ The KECS Terminal User Interface (TUI) provides an interactive, keyboard-driven 
 To launch the TUI, run:
 
 ```bash
-kecs tui
+kecs
 ```
 
 You can specify a custom endpoint:
 
 ```bash
-kecs tui --endpoint http://remote-kecs:8080
+kecs --endpoint http://remote-kecs:8080
 ```
 
 ## Navigation

--- a/docs/tui/kecs-startup-implementation.md
+++ b/docs/tui/kecs-startup-implementation.md
@@ -73,7 +73,7 @@ Unit tests have been implemented for:
 
 ## Usage
 
-When users run `kecs tui` and KECS is not running:
+When users run `kecs` and KECS is not running:
 
 1. The TUI detects KECS is not running
 2. Shows a confirmation dialog

--- a/docs/tui/kecs-startup.md
+++ b/docs/tui/kecs-startup.md
@@ -100,7 +100,7 @@ The system automatically detects the appropriate port based on:
 ## Configuration
 
 No additional configuration is required. The feature works automatically when:
-- TUI is launched with `kecs tui`
+- TUI is launched with `kecs`
 - KECS is not running at the specified endpoint
 
 ## Future Enhancements


### PR DESCRIPTION
## Summary
Updates all documentation to use the correct TUI launch command. The TUI is launched with just `kecs` (not `kecs tui`).

## Changes
Fixed TUI command in 8 documentation files:

### User Documentation
- **docs/tui/README.md** - Quick start examples
- **docs/tui/USER_GUIDE.md** - Starting the TUI section  
- **docs/production-deployment.md** - TUI usage example

### Developer Documentation
- **docs/tui/DEVELOPER_GUIDE.md** - Development instructions
- **docs/tui/kecs-startup-implementation.md** - Usage description
- **docs/tui/kecs-startup.md** - Configuration notes
- **docs/tui-api-integration-phase1.md** - Testing examples
- **docs/tui-backend-api.md** - Testing instructions

### Correct Command
```bash
# Before (incorrect)
kecs tui

# After (correct)
kecs
```

### Note
ADR documents (Architecture Decision Records) were intentionally left unchanged as they document historical design decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)