### PR TITLE
docs: Fix instance flag from --name to --instance

### DIFF
--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -15,8 +15,8 @@ kecs status         # Show container status
 kecs logs -f        # Follow container logs
 
 # Multiple instances
-kecs start --name dev --api-port 8080
-kecs start --name staging --api-port 8090 --auto-port
+kecs start --instance dev --api-port 8080
+kecs start --instance staging --api-port 8090 --auto-port
 kecs instances list # List all instances
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ kecs status         # Show container status
 kecs logs -f        # Follow container logs
 
 # Multiple instances
-kecs start --name dev --api-port 8080
-kecs start --name staging --api-port 8090 --auto-port
+kecs start --instance dev --api-port 8080
+kecs start --instance staging --api-port 8090 --auto-port
 kecs list           # List all instances
 ```
 

--- a/docs-site/deployment/local.md
+++ b/docs-site/deployment/local.md
@@ -171,7 +171,7 @@ KECS provides convenient container commands for running instances:
 kecs start
 
 # Start with custom name and port
-kecs start --name myinstance --api-port 9090
+kecs start --instance myinstance --api-port 9090
 
 # View logs from control plane
 kubectl logs -n kecs-system deployment/kecs-server -f

--- a/docs/alb-port-mapping.md
+++ b/docs/alb-port-mapping.md
@@ -25,7 +25,7 @@ KECS instances are created with the following default port mappings:
 
 ```bash
 # 1. Start KECS instance (port mappings are automatically configured)
-kecs start --name myapp
+kecs start --instance myapp
 
 # 2. Create an ECS cluster and deploy your service
 aws ecs create-cluster --cluster-name myapp-cluster
@@ -49,7 +49,7 @@ export KECS_ALB_PORT_RANGE_START=9000
 export KECS_ALB_PORT_RANGE_END=9099
 
 # Start KECS with custom port range
-kecs start --name myapp
+kecs start --instance myapp
 ```
 
 This allows you to:

--- a/docs/container-commands.md
+++ b/docs/container-commands.md
@@ -99,13 +99,13 @@ Run multiple KECS instances with different names:
 
 ```bash
 # Development instance
-kecs start --name kecs-dev --api-port 8080 --admin-port 8081
+kecs start --instance kecs-dev --api-port 8080 --admin-port 8081
 
 # Staging instance
-kecs start --name kecs-staging --api-port 8090 --admin-port 8091
+kecs start --instance kecs-staging --api-port 8090 --admin-port 8091
 
 # Test instance with auto-port assignment
-kecs start --name kecs-test --auto-port
+kecs start --instance kecs-test --auto-port
 ```
 
 ### Local Build
@@ -235,7 +235,7 @@ kecs instances stop-all
 Use `--auto-port` to automatically find available ports:
 
 ```bash
-kecs start --name test --auto-port
+kecs start --instance test --auto-port
 ```
 
 This will:
@@ -310,7 +310,7 @@ jobs:
       
       - name: Start KECS
         run: |
-          kecs start --name ci-test --auto-port
+          kecs start --instance ci-test --auto-port
           kecs status
       
       - name: Run Tests

--- a/examples/service-discovery-route53/README.md
+++ b/examples/service-discovery-route53/README.md
@@ -17,7 +17,7 @@ export AWS_SECRET_ACCESS_KEY=test
 export AWS_REGION=us-east-1
 
 # Start KECS (includes Route53 support)
-kecs start --name discovery-demo
+kecs start --instance discovery-demo
 ```
 
 ### 2. Create Service Discovery Namespace
@@ -69,7 +69,7 @@ With Route53 integration, services in different KECS instances can discover each
 
 ### Instance 1 (Port 5373)
 ```bash
-kecs start --name cluster1 --api-port 5373
+kecs start --instance cluster1 --api-port 5373
 export AWS_ENDPOINT_URL=http://localhost:5373
 
 # Create namespace and service
@@ -79,7 +79,7 @@ aws servicediscovery create-private-dns-namespace --name shared.local --vpc vpc-
 
 ### Instance 2 (Port 8090)
 ```bash
-kecs start --name cluster2 --api-port 8090
+kecs start --instance cluster2 --api-port 8090
 export AWS_ENDPOINT_URL=http://localhost:8090
 
 # Services can discover cluster1 services via Route53

--- a/examples/service-to-service-communication/README.md
+++ b/examples/service-to-service-communication/README.md
@@ -64,7 +64,7 @@ This demo demonstrates service-to-service communication where:
 
 ```bash
 # Start KECS instance
-kecs start --name service-demo
+kecs start --instance service-demo
 
 # Set environment variable
 export KECS_ENDPOINT=http://localhost:5373


### PR DESCRIPTION
## Summary
Updates all documentation to use the correct `--instance` flag instead of the incorrect `--name` flag for the `kecs start` command.

## Changes
Fixed instance flag in 7 documentation files:

### Project Documentation
- **CLAUDE.md** - Multiple instances examples
- **.serena/memories/suggested_commands.md** - Serena AI memory file

### Examples
- **examples/service-discovery-route53/README.md** - Service discovery setup
- **examples/service-to-service-communication/README.md** - Service-to-service communication

### Documentation Files
- **docs/container-commands.md** - Container commands guide
- **docs/alb-port-mapping.md** - ALB port mapping examples
- **docs-site/deployment/local.md** - Local deployment guide

### Correct Usage
```bash
# Correct (after fix)
kecs start --instance myinstance

# Incorrect (before fix)
kecs start --name myinstance
```

The `--name` flag does not exist. The correct flag for specifying an instance name is `--instance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)