### PR TITLE
fix: Improve service-to-service-communication example deployment

### DIFF
--- a/examples/service-to-service-communication/README.md
+++ b/examples/service-to-service-communication/README.md
@@ -70,7 +70,7 @@ kecs start --instance service-demo
 export KECS_ENDPOINT=http://localhost:5373
 ```
 
-### 2. Build Docker Images
+### 2. Build and Push Docker Images
 
 ```bash
 # Navigate to example directory
@@ -79,6 +79,14 @@ cd examples/service-to-service-communication
 # Build both service images
 docker build -t backend-api:latest ./backend
 docker build -t frontend-web:latest ./frontend
+
+# Tag images for k3d registry
+docker tag backend-api:latest localhost:5000/kecs-example-backend:latest
+docker tag frontend-web:latest localhost:5000/kecs-example-frontend:latest
+
+# Push images to k3d registry
+docker push localhost:5000/kecs-example-backend:latest
+docker push localhost:5000/kecs-example-frontend:latest
 ```
 
 ### 3. Deploy Services with Service Discovery
@@ -151,14 +159,18 @@ Services are accessible via DNS names in the format:
 
 If you prefer to deploy manually:
 
-### 1. Build Docker Images
+### 1. Build and Push Docker Images
 
 ```bash
 # Build backend
 docker build -t backend-api:latest ./backend
+docker tag backend-api:latest localhost:5000/kecs-example-backend:latest
+docker push localhost:5000/kecs-example-backend:latest
 
-# Build frontend  
+# Build frontend
 docker build -t frontend-web:latest ./frontend
+docker tag frontend-web:latest localhost:5000/kecs-example-frontend:latest
+docker push localhost:5000/kecs-example-frontend:latest
 ```
 
 ### 2. Create Service Discovery Namespace

--- a/examples/service-to-service-communication/README.md
+++ b/examples/service-to-service-communication/README.md
@@ -173,7 +173,15 @@ docker tag frontend-web:latest localhost:5000/kecs-example-frontend:latest
 docker push localhost:5000/kecs-example-frontend:latest
 ```
 
-### 2. Create Service Discovery Namespace
+### 2. Create ECS Cluster
+
+```bash
+aws ecs create-cluster \
+  --cluster-name default \
+  --region us-east-1 --endpoint-url $KECS_ENDPOINT
+```
+
+### 3. Create Service Discovery Namespace
 
 ```bash
 aws servicediscovery create-private-dns-namespace \
@@ -182,7 +190,7 @@ aws servicediscovery create-private-dns-namespace \
   --region us-east-1 --endpoint-url $KECS_ENDPOINT
 ```
 
-### 3. Create Service Discovery Services
+### 4. Create Service Discovery Services
 
 ```bash
 # Get namespace ID
@@ -191,22 +199,31 @@ NAMESPACE_ID=$(aws servicediscovery list-namespaces \
   --output text \
   --region us-east-1 --endpoint-url $KECS_ENDPOINT)
 
-# Create backend discovery service
-aws servicediscovery create-service \
+# Create backend discovery service and get ARN
+BACKEND_SERVICE_ARN=$(aws servicediscovery create-service \
   --name backend-api \
   --namespace-id $NAMESPACE_ID \
   --dns-config "NamespaceId=$NAMESPACE_ID,DnsRecords=[{Type=A,TTL=60}]" \
-  --region us-east-1 --endpoint-url $KECS_ENDPOINT
+  --health-check-config "Type=HTTP,ResourcePath=/health,FailureThreshold=3" \
+  --query 'Service.Arn' \
+  --output text \
+  --region us-east-1 --endpoint-url $KECS_ENDPOINT)
 
-# Create frontend discovery service
-aws servicediscovery create-service \
+# Create frontend discovery service and get ARN
+FRONTEND_SERVICE_ARN=$(aws servicediscovery create-service \
   --name frontend-web \
   --namespace-id $NAMESPACE_ID \
   --dns-config "NamespaceId=$NAMESPACE_ID,DnsRecords=[{Type=A,TTL=60}]" \
-  --region us-east-1 --endpoint-url $KECS_ENDPOINT
+  --health-check-config "Type=HTTP,ResourcePath=/health,FailureThreshold=3" \
+  --query 'Service.Arn' \
+  --output text \
+  --region us-east-1 --endpoint-url $KECS_ENDPOINT)
+
+echo "Backend Service Discovery ARN: $BACKEND_SERVICE_ARN"
+echo "Frontend Service Discovery ARN: $FRONTEND_SERVICE_ARN"
 ```
 
-### 4. Register Task Definitions
+### 5. Register Task Definitions
 
 ```bash
 aws ecs register-task-definition \
@@ -218,7 +235,7 @@ aws ecs register-task-definition \
   --region us-east-1 --endpoint-url $KECS_ENDPOINT
 ```
 
-### 5. Create ECS Services
+### 6. Create ECS Services
 
 ```bash
 # Create backend service
@@ -228,7 +245,8 @@ aws ecs create-service \
   --task-definition backend-api:1 \
   --desired-count 2 \
   --launch-type FARGATE \
-  --service-registries "registryArn=<backend-service-arn>" \
+  --service-registries "registryArn=$BACKEND_SERVICE_ARN,containerName=backend,containerPort=8080" \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}" \
   --region us-east-1 --endpoint-url $KECS_ENDPOINT
 
 # Create frontend service
@@ -238,7 +256,8 @@ aws ecs create-service \
   --task-definition frontend-web:1 \
   --desired-count 1 \
   --launch-type FARGATE \
-  --service-registries "registryArn=<frontend-service-arn>" \
+  --service-registries "registryArn=$FRONTEND_SERVICE_ARN,containerName=frontend,containerPort=3000" \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}" \
   --region us-east-1 --endpoint-url $KECS_ENDPOINT
 ```
 

--- a/examples/service-to-service-communication/scripts/deploy.sh
+++ b/examples/service-to-service-communication/scripts/deploy.sh
@@ -36,14 +36,20 @@ check_command docker
 # Set AWS endpoint for KECS
 export AWS_ENDPOINT_URL=$KECS_ENDPOINT
 
-# Step 1: Build Docker images
+# Step 1: Build and push Docker images
 echo -e "\n${YELLOW}📦 Building Docker images...${NC}"
 
 echo "Building backend image..."
 docker build -t backend-api:latest ./backend
+docker tag backend-api:latest localhost:5000/kecs-example-backend:latest
 
 echo "Building frontend image..."
 docker build -t frontend-web:latest ./frontend
+docker tag frontend-web:latest localhost:5000/kecs-example-frontend:latest
+
+echo -e "\n${YELLOW}📤 Pushing images to k3d registry...${NC}"
+docker push localhost:5000/kecs-example-backend:latest
+docker push localhost:5000/kecs-example-frontend:latest
 
 # Step 2: Create ECS cluster if not exists
 echo -e "\n${YELLOW}☁️  Creating ECS cluster...${NC}"


### PR DESCRIPTION
## Summary
- Add Docker image tagging and push steps to deploy.sh and README.md
- Align manual deployment steps with deploy.sh script order

## Problems Fixed

### Missing Docker Registry Steps
The example was failing with `ErrImagePull` errors because:
- Docker images were built but not pushed to k3d registry
- Task definitions referenced `registry.kecs.local:5000/kecs-example-*` images that didn't exist

**Solution**: Added tag and push steps to both deploy.sh and README.md

### Inconsistent Manual Deployment Steps
The Manual Deployment Steps in README.md were incomplete and didn't match deploy.sh:
- Missing ECS cluster creation step
- Service Discovery ARN retrieval was unclear (used placeholders like `<backend-service-arn>`)
- Steps were in different order than deploy.sh

**Solution**: Restructured manual steps to match deploy.sh exactly:
1. Build and Push Docker Images
2. Create ECS Cluster
3. Create Service Discovery Namespace
4. Create Service Discovery Services (with ARN capture)
5. Register Task Definitions
6. Create ECS Services (with actual ARN variables)

## Changes

### deploy.sh
- Added docker tag commands for both images
- Added docker push commands to k3d registry (localhost:5000)

### README.md
**Quick Start section**:
- Added tag and push steps after docker build

**Manual Deployment Steps**:
- Added Step 2: Create ECS Cluster
- Enhanced Step 4: Capture Service Discovery ARNs in variables
- Updated Step 6: Use actual variables instead of placeholders
- Added containerName and containerPort to service registries
- Added network configuration for FARGATE services

🤖 Generated with [Claude Code](https://claude.com/claude-code)