### PR TITLE
fix: Remove CoreDNS answer rewrite to fix Go DNS resolver

### DIFF
--- a/controlplane/internal/servicediscovery/coredns.go
+++ b/controlplane/internal/servicediscovery/coredns.go
@@ -29,9 +29,10 @@ const coreDNSConfigTemplate = `{{.NamespaceName}}:53 {
     ready
 
     # Rewrite Service Discovery queries to default namespace
+    # Note: Only rewrite the query name, not the answer
+    # This prevents CNAME chain issues with Go's DNS resolver
     rewrite stop {
         name regex (.*)\.{{.NamespaceNameEscaped}} {1}.{{.K8sNamespace}}.svc.cluster.local
-        answer name (.*)\.{{.K8sNamespaceEscaped}}\.svc\.cluster\.local {1}.{{.NamespaceNameEscaped}}
     }
 
     kubernetes cluster.local in-addr.arpa ip6.arpa {

--- a/examples/service-to-service-communication/backend/Dockerfile
+++ b/examples/service-to-service-communication/backend/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-bookworm AS builder
 
 WORKDIR /app
 COPY main.go .
 COPY go.mod .
 
-RUN go build -o backend main.go
+RUN CGO_ENABLED=1 go build -o backend main.go
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/
 COPY --from=builder /app/backend .

--- a/examples/service-to-service-communication/frontend/Dockerfile
+++ b/examples/service-to-service-communication/frontend/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-bookworm AS builder
 
 WORKDIR /app
 COPY main.go .
 COPY go.mod .
 
-RUN go build -o frontend main.go
+RUN CGO_ENABLED=1 go build -o frontend main.go
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/
 COPY --from=builder /app/frontend .


### PR DESCRIPTION
## Problem
Go's HTTP client failed to resolve Service Discovery DNS names with error:
```
dial tcp: lookup backend-api.production.local on 10.43.0.10:53: cannot unmarshal DNS message
```

## Root Cause
CoreDNS rewrite plugin with **bidirectional rewriting** (query + answer) created complex DNS responses with CNAME chains that Go's DNS resolver couldn't parse correctly.

The issue was not:
- ❌ Alpine vs Debian base images
- ❌ Pure Go vs CGO resolver
- ✅ CoreDNS answer rewrite causing CNAME chain parsing issues

## Solution
Remove the `answer` directive from CoreDNS rewrite configuration. Now only the query is rewritten, which prevents CNAME chain issues while maintaining correct DNS resolution.

### Before (broken)
```
rewrite stop {
    name regex (.*)\.production\.local {1}.default.svc.cluster.local
    answer name (.*)\.default\.svc\.cluster\.local {1}.production\.local
}
```

### After (working)
```
rewrite stop {
    name regex (.*)\.production\.local {1}.default.svc.cluster.local
}
```

## Changes
- Remove `answer name` directive from CoreDNS template in `coredns.go`
- Update example Dockerfiles to use Go 1.25 + Debian base with CGO
- Add wget to example images for health checks

## Testing
Verified that Go net/http client now successfully resolves Service Discovery DNS names:
```bash
$ kubectl exec frontend-web-service -- wget -qO- http://localhost:3000/health
{"backend":"ok","frontend":"ok","status":"healthy"}
```

All unit tests pass ✅

Fixes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)