### PR TITLE
docs: Add important notes about Debian + CGO for DNS resolution

### DIFF
--- a/examples/service-to-service-communication/README.md
+++ b/examples/service-to-service-communication/README.md
@@ -58,6 +58,22 @@ This demo demonstrates service-to-service communication where:
 3. AWS CLI configured
 4. (Optional) LocalStack for Route53 integration
 
+## Important Notes
+
+### Docker Images
+
+The example services use **Debian-based Docker images with Go 1.25 and CGO enabled**. This is important for proper DNS resolution with Go's HTTP client when using Service Discovery.
+
+**Why Debian + CGO?**
+- Alpine Linux (musl libc) has compatibility issues with Go's DNS resolver
+- CGO-enabled builds ensure proper DNS resolution for Service Discovery names
+- Health checks use `wget` which is included in the Debian image
+
+If you modify the Dockerfiles, ensure you:
+1. Use Debian or Ubuntu base images (not Alpine)
+2. Build with `CGO_ENABLED=1`
+3. Include `wget` for health checks
+
 ## Quick Start
 
 ### 1. Start KECS


### PR DESCRIPTION
## Changes
Added important notes to the service-to-service-communication example README explaining why Debian-based Docker images with CGO are required for proper DNS resolution.

## Why This Documentation Is Important
Users need to understand that:
- Alpine Linux (musl libc) has compatibility issues with Go's DNS resolver
- CGO-enabled builds are required for Service Discovery DNS to work correctly
- Health checks require  which is included in Debian images

## Context
This documentation complements the fix in #735 which removed the CoreDNS answer rewrite that was causing DNS parsing issues.

Related to #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)