### PR TITLE
refactor: Remove GITHUB_ACTIONS and CI environment variable checks

### DIFF
--- a/controlplane/internal/controlplane/cmd/start.go
+++ b/controlplane/internal/controlplane/cmd/start.go
@@ -45,6 +45,7 @@ var (
 	startConfigFile              string
 	startAdditionalLocalServices string
 	startTimeout                 time.Duration
+	startTestMode                bool
 )
 
 var startCmd = &cobra.Command{
@@ -65,6 +66,7 @@ func init() {
 	startCmd.Flags().StringVar(&startConfigFile, "config", "", "Configuration file path")
 	startCmd.Flags().StringVar(&startAdditionalLocalServices, "additional-localstack-services", "", "Additional LocalStack services (comma-separated, e.g., s3,dynamodb,sqs)")
 	startCmd.Flags().DurationVar(&startTimeout, "timeout", 10*time.Minute, "Timeout for cluster creation")
+	startCmd.Flags().BoolVar(&startTestMode, "test-mode", false, "Enable test mode (uses mock cluster instead of real k3d cluster)")
 }
 
 func runStart(cmd *cobra.Command, args []string) error {
@@ -102,6 +104,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		AdditionalLocalStackServices: startAdditionalLocalServices,
 		ApiPort:                      startApiPort,
 		AdminPort:                    startAdminPort,
+		TestMode:                     startTestMode,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), startTimeout)

--- a/controlplane/internal/host/instance/manager.go
+++ b/controlplane/internal/host/instance/manager.go
@@ -36,7 +36,8 @@ type StartOptions struct {
 	AdditionalLocalStackServices string // Comma-separated list of additional LocalStack services
 	ApiPort                      int
 	AdminPort                    int
-	KubePort                     int // Kubernetes API server port (0 for auto-assign)
+	KubePort                     int  // Kubernetes API server port (0 for auto-assign)
+	TestMode                     bool // Enable test mode (uses mock cluster)
 }
 
 // CreationStatus represents the status of instance creation
@@ -109,6 +110,9 @@ func (m *Manager) GetCreationStatus(instanceName string) *CreationStatus {
 
 // Start starts a KECS instance with the given options
 func (m *Manager) Start(ctx context.Context, opts *StartOptions) error {
+	// Set test mode in k3d manager config
+	m.k3dManager.SetTestMode(opts.TestMode)
+
 	// Generate instance name if not provided
 	if opts.InstanceName == "" {
 		opts.InstanceName = generateInstanceName()


### PR DESCRIPTION
## Overview

Fixes #739

This PR removes the implicit environment variable detection pattern for test mode and replaces it with an explicit `--test-mode` flag.

## Changes

### Core Changes
- **K3dClusterManager**: Replaced all 12 instances of `os.Getenv("GITHUB_ACTIONS") == "true" || os.Getenv("CI") == "true"` with `k.config.TestMode` checks
- **start command**: Added `--test-mode` flag to explicitly enable test mode
- **StartOptions**: Added `TestMode` field to propagate test mode setting
- **Manager**: Added `SetTestMode()` method and propagation logic

### Files Changed
- `internal/host/k3d/manager.go`: Replaced all env var checks with TestMode checks, added SetTestMode() method
- `internal/controlplane/cmd/start.go`: Added --test-mode flag
- `internal/host/instance/manager.go`: Added TestMode field to StartOptions and propagation logic

## Benefits

1. **Explicit over Implicit**: Test mode is now explicitly controlled via CLI flag instead of implicitly detected from environment variables
2. **GitHub Actions Compatible**: KECS can now run properly in GitHub Actions environments without accidentally triggering test mode
3. **Backward Compatible**: Existing tests continue to work by setting TestMode programmatically
4. **Better Control**: Users can explicitly enable test mode when needed for testing without setting environment variables

## Testing

- All existing unit tests pass
- TestMode functionality is preserved for unit tests
- K3dClusterManager behavior remains unchanged except for how TestMode is activated

## Migration Notes

For users who relied on GITHUB_ACTIONS or CI environment variables to trigger test mode:
- Use `--test-mode` flag explicitly: `kecs start --test-mode`
- For programmatic usage, set `StartOptions.TestMode = true`

## Related

This PR enables kecs-action (GitHub Action) to run KECS properly in CI environments without the temporary environment variable workaround.