### PR TITLE
feat: Add --format flag to kecs list command

### DIFF
--- a/controlplane/internal/controlplane/cmd/list.go
+++ b/controlplane/internal/controlplane/cmd/list.go
@@ -2,12 +2,19 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/nandemo-ya/kecs/controlplane/internal/host/instance"
+)
+
+var (
+	listFormat string
 )
 
 var listCmd = &cobra.Command{
@@ -19,6 +26,7 @@ var listCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(listCmd)
+	listCmd.Flags().StringVarP(&listFormat, "format", "f", "table", "Output format: table, json, yaml")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -36,9 +44,45 @@ func runList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list instances: %w", err)
 	}
 
-	if len(instances) == 0 {
+	if len(instances) == 0 && listFormat == "table" {
 		fmt.Println("No KECS instances found")
 		fmt.Println("\nCreate a new instance with: kecs start")
+		return nil
+	}
+
+	// Output based on format
+	switch strings.ToLower(listFormat) {
+	case "json":
+		return outputJSON(instances)
+	case "yaml":
+		return outputYAML(instances)
+	case "table":
+		return outputTable(instances)
+	default:
+		return fmt.Errorf("unsupported format: %s (supported: table, json, yaml)", listFormat)
+	}
+}
+
+func outputJSON(instances []instance.InstanceInfo) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(instances); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+	return nil
+}
+
+func outputYAML(instances []instance.InstanceInfo) error {
+	encoder := yaml.NewEncoder(os.Stdout)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(instances); err != nil {
+		return fmt.Errorf("failed to encode YAML: %w", err)
+	}
+	return nil
+}
+
+func outputTable(instances []instance.InstanceInfo) error {
+	if len(instances) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
## Overview

Fixes #740

Added support for multiple output formats (table, json, yaml) to the `kecs list` and `kecs kubeconfig list` commands, enabling better integration with scripts and automation tools.

## Changes

### Core Changes
- **Added `--format/-f` flag** to both `kecs list` and `kecs kubeconfig list` with options: `table` (default), `json`, `yaml`
- **Implemented JSON/YAML formatters** for structured output
- **Refactored table output** into dedicated functions for consistency
- **Empty list handling**: Returns empty array for json/yaml formats instead of help text

### Files Changed
- `internal/controlplane/cmd/list.go`: Added format flag and output formatters for instance list
- `internal/controlplane/cmd/kubeconfig.go`: Added format flag and output formatters for kubeconfig list

## Usage Examples

### kecs list

```bash
# Default table format
kecs list

# JSON output (for scripting)
kecs list --format json
kecs list -f json

# YAML output (for configuration)
kecs list --format yaml
kecs list -f yaml
```

### kecs kubeconfig list

```bash
# Default table format
kecs kubeconfig list

# JSON output (for scripting)
kecs kubeconfig list --format json
kecs kubeconfig list -f json

# YAML output
kecs kubeconfig list -f yaml
```

## Example Outputs

### kecs list - JSON Format
```json
[
  {
    "Name": "my-instance",
    "Status": "RUNNING",
    "ApiPort": 5373,
    "AdminPort": 5374,
    "HasData": true,
    "LocalStack": true
  }
]
```

### kecs list - YAML Format
```yaml
- name: my-instance
  status: RUNNING
  apiport: 5373
  adminport: 5374
  hasdata: true
  localstack: true
```

### kecs kubeconfig list - JSON Format
```json
[
  "my-instance",
  "another-instance"
]
```

### kecs kubeconfig list - YAML Format
```yaml
- my-instance
- another-instance
```

### kecs list - Table Format (Default)
```
KECS Instances:
=========================================================
NAME                 STATUS     API PORT   ADMIN PORT LOCALSTACK
---------------------------------------------------------
my-instance          running    5373       5374       yes       
=========================================================

Commands:
  Start instance:   kecs start --instance <name>
  Stop instance:    kecs stop --instance <name>
  Destroy instance: kecs destroy --instance <name>
  Get kubeconfig:   kecs kubeconfig get <name>
```

## Testing

- All existing unit tests pass
- Manual testing confirmed all three output formats work correctly for both commands
- Empty instance/cluster lists handled properly for each format

## Benefits

1. **Script Integration**: JSON/YAML output enables easy parsing in automation scripts
2. **Backward Compatible**: Default table format preserved for human-readable output
3. **Consistency**: Both list commands now support the same output formats
4. **CLI Conventions**: Follows common patterns (similar to `kubectl`, `docker`)
5. **kecs-action Integration**: Enables GitHub Action to parse instance/cluster information programmatically

## Related

This PR enables kecs-action to extract instance names and cluster information from KECS commands more reliably, complementing the workaround currently in place for Phase 2.