### PR TITLE
docs: Update AWS integration status and fix license in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ KECS provides strong AWS service integration while remaining completely standalo
 | AWS Service | Status | Description |
 |-------------|--------|-------------|
 | **ELBv2** (Application Load Balancer) | 🟡 Experimental | Target group and load balancer management |
-| **Secrets Manager** | 🟡 Experimental | Secret injection into containers |
-| **Parameter Store** | 🟡 Experimental | Parameter injection into containers |
+| **Secrets Manager** | 🟢 Stable | Secret injection into containers |
+| **Parameter Store** | 🟢 Stable | Parameter injection into containers |
 | **CloudWatch Logs** | 🟡 Experimental | Container log streaming |
 | **Cloud Map** (Service Discovery) | 🟡 Experimental | Service registry and discovery |
 | **IAM** | ⚪ Pending | Task roles and execution roles |
@@ -54,7 +54,7 @@ KECS provides strong AWS service integration while remaining completely standalo
 | **EFS** | ⚪ Pending | Elastic File System mounting |
 
 **Legend:**
-- 🟢 **Stable**: Production-ready with comprehensive testing
+- 🟢 **Stable**: Feature-complete with comprehensive testing
 - 🟡 **Experimental**: Basic functionality available, under active development
 - ⚪ **Pending**: Planned for future releases
 

--- a/docs-site/.vitepress/config.js
+++ b/docs-site/.vitepress/config.js
@@ -124,7 +124,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'Released under the MIT License.',
+      message: 'Released under the Apache 2.0 License.',
       copyright: 'Copyright © 2025 KECS Project'
     }
   }

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -66,7 +66,7 @@ KECS (Kubernetes-based ECS Compatible Service) provides a complete local Amazon 
 - Interactive TUI for resource management
 - Hot reload for rapid development
 
-### 🔧 Production-Ready Features
+### 🔧 Stable Features
 - PostgreSQL for reliable state persistence
 - Graceful shutdown and cleanup
 - Resource monitoring and health checks


### PR DESCRIPTION
## Summary
- Mark Secrets Manager and Parameter Store as Stable
- Rename "Production-Ready Features" to "Stable Features" for better clarity
- Fix docs-site footer license from MIT to Apache 2.0

## Changes
- `README.md`: Update Secrets Manager/Parameter Store status to 🟢 Stable
- `docs-site/index.md`: Rename section to "Stable Features"
- `docs-site/.vitepress/config.js`: Fix footer license text

## Rationale
- Secrets Manager and Parameter Store integration has proven stable through comprehensive testing
- "Stable Features" is simpler and clearer than "Production-Ready Features" (especially since KECS is designed for local/CI environments, not production)
- The footer incorrectly showed MIT license instead of Apache 2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)