### PR TITLE
chore: Upgrade Go version to 1.25.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ builds:
       - -X github.com/nandemo-ya/kecs/controlplane/internal/version.Version={{.Tag}}
       - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GitCommit={{.Commit}}
       - -X github.com/nandemo-ya/kecs/controlplane/internal/version.BuildDate={{.Date}}
-      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GoVersion=go1.25
+      - -X github.com/nandemo-ya/kecs/controlplane/internal/version.GoVersion=go1.25.2
 
 archives:
   - id: kecs

--- a/controlplane/awsproxy/go.mod
+++ b/controlplane/awsproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/nandemo-ya/kecs/controlplane/awsproxy
 
-go 1.21
+go 1.25.2
 
 require (
 	// No external dependencies required for the basic proxy

--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -1,6 +1,6 @@
 module github.com/nandemo-ya/kecs/controlplane
 
-go 1.25.0
+go 1.25.2
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/examples/service-to-service-communication/backend/go.mod
+++ b/examples/service-to-service-communication/backend/go.mod
@@ -1,3 +1,3 @@
 module backend
 
-go 1.21
+go 1.25.2

--- a/examples/service-to-service-communication/frontend/go.mod
+++ b/examples/service-to-service-communication/frontend/go.mod
@@ -1,3 +1,3 @@
 module frontend
 
-go 1.21
+go 1.25.2


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25.0 to 1.25.2 across all modules
- Update GoReleaser configuration to reflect the new Go version

## Changes
- `controlplane/go.mod`: 1.25.0 → 1.25.2
- `controlplane/awsproxy/go.mod`: 1.21 → 1.25.2
- `examples/service-to-service-communication/backend/go.mod`: 1.21 → 1.25.2
- `examples/service-to-service-communication/frontend/go.mod`: 1.21 → 1.25.2
- `.goreleaser.yml`: go1.25 → go1.25.2

## Test plan
- [x] All unit tests passed
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)