### PR TITLE
fix: Update Dockerfile Go version to 1.25.2

### DIFF
--- a/controlplane/Dockerfile
+++ b/controlplane/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.2 AS builder
 WORKDIR /app
 
 ARG TARGETOS=linux

--- a/controlplane/Dockerfile.api
+++ b/controlplane/Dockerfile.api
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.2 AS builder
 WORKDIR /app
 
 ARG TARGETOS=linux

--- a/controlplane/Dockerfile.test
+++ b/controlplane/Dockerfile.test
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.2 AS builder
 WORKDIR /app
 
 ARG TARGETOS=linux

--- a/controlplane/awsproxy/Dockerfile
+++ b/controlplane/awsproxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.2 AS builder
 WORKDIR /app
 
 ARG TARGETOS=linux

--- a/examples/service-to-service-communication/backend/Dockerfile
+++ b/examples/service-to-service-communication/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.2-bookworm AS builder
 
 WORKDIR /app
 COPY main.go .

--- a/examples/service-to-service-communication/frontend/Dockerfile
+++ b/examples/service-to-service-communication/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.2-bookworm AS builder
 
 WORKDIR /app
 COPY main.go .


### PR DESCRIPTION
## Summary
- Update all Dockerfiles to use Go 1.25.2 to match go.mod updates
- Fixes Docker build error caused by Go version mismatch

## Problem
After upgrading Go version in go.mod to 1.25.2 (#746), Docker builds were failing with:
```
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download && go mod verify" did not complete successfully: exit code: 1
```

This was caused by Dockerfiles still using older Go versions (1.25.0 or 1.25).

## Changes
- `controlplane/Dockerfile`: golang:1.25.0 → golang:1.25.2
- `controlplane/Dockerfile.api`: golang:1.25.0 → golang:1.25.2
- `controlplane/Dockerfile.test`: golang:1.25.0 → golang:1.25.2
- `controlplane/awsproxy/Dockerfile`: golang:1.25.0 → golang:1.25.2
- `examples/service-to-service-communication/backend/Dockerfile`: golang:1.25-bookworm → golang:1.25.2-bookworm
- `examples/service-to-service-communication/frontend/Dockerfile`: golang:1.25-bookworm → golang:1.25.2-bookworm

## Test plan
- [x] All unit tests passed
- [x] Pre-commit hooks passed
- [ ] Docker build verification (will be tested in CI)

## Related
- Fixes the Docker build issue introduced in #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)