### PR TITLE
refactor: Replace os.Getenv with config-based approach (Part 2)

### DIFF
--- a/controlplane/internal/controlplane/api/cluster_ecs_api.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api.go
@@ -771,9 +771,11 @@ func (api *DefaultECSAPI) getKecsInstanceName() string {
 	// In the container-based deployment model, there should be a single k3d cluster
 	// that hosts the KECS control plane and all ECS clusters as namespaces
 
-	// For now, we'll use the environment variable if set
-	if instanceName := os.Getenv("KECS_INSTANCE_NAME"); instanceName != "" {
-		return instanceName
+	// For now, we'll use the configuration if set
+	if api.config != nil {
+		if instanceName := api.config.Kubernetes.InstanceName; instanceName != "" {
+			return instanceName
+		}
 	}
 
 	// Otherwise, try to detect from the current environment

--- a/controlplane/internal/controlplane/api/cluster_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/cluster_ecs_api_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/mocks"
@@ -26,7 +27,7 @@ var _ = Describe("Cluster ECS API", func() {
 		mockStorage.SetClusterStore(mockClusterStore)
 		server = &Server{
 			storage: mockStorage,
-			ecsAPI:  NewDefaultECSAPI(mockStorage),
+			ecsAPI:  NewDefaultECSAPI(config.DefaultConfig(), mockStorage),
 		}
 		ctx = context.Background()
 	})

--- a/controlplane/internal/controlplane/api/cluster_pagination_test.go
+++ b/controlplane/internal/controlplane/api/cluster_pagination_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
@@ -48,7 +49,7 @@ var _ = Describe("Cluster Pagination", func() {
 		}
 
 		// Create ECS API instance
-		ecsAPI = api.NewDefaultECSAPIWithConfig(mockStorage, "us-east-1", "000000000000")
+		ecsAPI = api.NewDefaultECSAPIWithConfig(config.DefaultConfig(), mockStorage, "us-east-1", "000000000000")
 	})
 
 	Describe("ListClusters", func() {

--- a/controlplane/internal/controlplane/api/container_instance_pagination_test.go
+++ b/controlplane/internal/controlplane/api/container_instance_pagination_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
@@ -76,7 +77,7 @@ var _ = Describe("ContainerInstance Pagination", func() {
 		}
 
 		// Create ECS API instance
-		ecsAPI = api.NewDefaultECSAPIWithConfig(mockStorage, "us-east-1", "000000000000")
+		ecsAPI = api.NewDefaultECSAPIWithConfig(config.DefaultConfig(), mockStorage, "us-east-1", "000000000000")
 	})
 
 	Describe("ListContainerInstances", func() {

--- a/controlplane/internal/controlplane/api/default_ecs_api.go
+++ b/controlplane/internal/controlplane/api/default_ecs_api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/cloudwatch"
 	"github.com/nandemo-ya/kecs/controlplane/internal/integrations/elbv2"
@@ -16,6 +17,7 @@ import (
 
 // DefaultECSAPI provides the default implementation of ECS API operations
 type DefaultECSAPI struct {
+	config                    *config.Config
 	storage                   storage.Storage
 	serviceManager            *kubernetes.ServiceManager
 	taskManagerInstance       *kubernetes.TaskManager
@@ -35,8 +37,9 @@ type DefaultECSAPI struct {
 }
 
 // NewDefaultECSAPI creates a new default ECS API implementation with storage
-func NewDefaultECSAPI(storage storage.Storage) generated.ECSAPIInterface {
+func NewDefaultECSAPI(cfg *config.Config, storage storage.Storage) generated.ECSAPIInterface {
 	return &DefaultECSAPI{
+		config:    cfg,
 		storage:   storage,
 		region:    "us-east-1",    // Default region
 		accountID: "000000000000", // Default account ID (LocalStack standard)
@@ -105,8 +108,9 @@ func (api *DefaultECSAPI) SetLocalStackUpdateCallback(callback func(localstack.M
 
 // NewDefaultECSAPIWithConfig creates a new default ECS API implementation with custom region and accountID
 // Deprecated: Use NewDefaultECSAPIWithClusterManager instead
-func NewDefaultECSAPIWithConfig(storage storage.Storage, region, accountID string) generated.ECSAPIInterface {
+func NewDefaultECSAPIWithConfig(cfg *config.Config, storage storage.Storage, region, accountID string) generated.ECSAPIInterface {
 	return &DefaultECSAPI{
+		config:    cfg,
 		storage:   storage,
 		region:    region,
 		accountID: accountID,

--- a/controlplane/internal/controlplane/api/generated_integration_test.go
+++ b/controlplane/internal/controlplane/api/generated_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
@@ -55,7 +56,7 @@ func TestGeneratedTypesIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create ECS API with generated types
-	ecsAPI := api.NewDefaultECSAPI(storage)
+	ecsAPI := api.NewDefaultECSAPI(config.DefaultConfig(), storage)
 
 	// Create mux and register routes
 	mux := http.NewServeMux()

--- a/controlplane/internal/controlplane/api/server.go
+++ b/controlplane/internal/controlplane/api/server.go
@@ -432,7 +432,8 @@ func NewServer(port int, kubeconfig string, storage storage.Storage, localStackC
 	}
 
 	// Create ECS API with integrations
-	ecsAPI := NewDefaultECSAPIWithConfig(storage, s.region, s.accountID)
+	cfg := apiconfig.GetConfig()
+	ecsAPI := NewDefaultECSAPIWithConfig(cfg, storage, s.region, s.accountID)
 	if defaultAPI, ok := ecsAPI.(*DefaultECSAPI); ok {
 		if s.serviceManager != nil {
 			defaultAPI.SetServiceManager(s.serviceManager)

--- a/controlplane/internal/controlplane/api/service_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/service_ecs_api_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/mocks"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
@@ -32,7 +33,7 @@ var _ = Describe("Service ECS API", func() {
 
 		server = &Server{
 			storage: mockStorage,
-			ecsAPI:  NewDefaultECSAPI(mockStorage),
+			ecsAPI:  NewDefaultECSAPI(config.DefaultConfig(), mockStorage),
 		}
 		ctx = context.Background()
 

--- a/controlplane/internal/controlplane/api/task_definition_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/task_definition_ecs_api_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/mocks"
@@ -26,7 +27,7 @@ var _ = Describe("Task Definition ECS API", func() {
 
 		server = &Server{
 			storage: mockStorage,
-			ecsAPI:  NewDefaultECSAPI(mockStorage),
+			ecsAPI:  NewDefaultECSAPI(config.DefaultConfig(), mockStorage),
 		}
 		ctx = context.Background()
 	})

--- a/controlplane/internal/controlplane/api/task_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/task_ecs_api_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/mocks"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
@@ -36,7 +37,7 @@ var _ = Describe("Task ECS API", func() {
 
 		server = &Server{
 			storage: mockStorage,
-			ecsAPI:  NewDefaultECSAPI(mockStorage),
+			ecsAPI:  NewDefaultECSAPI(config.DefaultConfig(), mockStorage),
 		}
 		ctx = context.Background()
 

--- a/controlplane/internal/controlplane/api/task_set_ecs_api_test.go
+++ b/controlplane/internal/controlplane/api/task_set_ecs_api_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/mocks"
@@ -45,7 +46,7 @@ var _ = Describe("TaskSetEcsApi", func() {
 		mockStorage.SetTaskSetStore(mockTaskSetStore)
 		mockStorage.SetServiceStore(mockServiceStore)
 
-		ecsAPI = NewDefaultECSAPI(mockStorage)
+		ecsAPI = NewDefaultECSAPI(config.DefaultConfig(), mockStorage)
 		// Set region and accountID on the underlying DefaultECSAPI
 		if defaultAPI, ok := ecsAPI.(*DefaultECSAPI); ok {
 			defaultAPI.region = region

--- a/controlplane/internal/controlplane/cmd/kubeconfig.go
+++ b/controlplane/internal/controlplane/cmd/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/tools/clientcmd"
@@ -93,7 +94,7 @@ func runGetKubeconfig(cmd *cobra.Command, args []string) error {
 	// If host-access is requested, try to read the pre-generated host kubeconfig
 	if kubeconfigHostAccess {
 		// Check if running in container mode by looking for KECS_DATA_DIR
-		dataDir := os.Getenv("KECS_DATA_DIR")
+		dataDir := config.GetString("server.dataDir")
 		if dataDir != "" {
 			hostKubeconfigPath := filepath.Join(dataDir, "kubeconfig", fmt.Sprintf("%s.host.config", k3dClusterName))
 			if content, err := os.ReadFile(hostKubeconfigPath); err == nil {

--- a/controlplane/internal/controlplane/cmd/portforward.go
+++ b/controlplane/internal/controlplane/cmd/portforward.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/kubernetes"
 	"github.com/nandemo-ya/kecs/controlplane/internal/portforward"
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func getKubeconfigPath(instanceName string) string {
 
 // getInstanceName returns the instance name from environment or default
 func getInstanceName() string {
-	instanceName := os.Getenv("KECS_INSTANCE")
+	instanceName := config.GetString("kubernetes.instanceName")
 	if instanceName == "" {
 		instanceName = "default"
 	}
@@ -147,7 +148,7 @@ var portForwardListCmd = &cobra.Command{
 	Short: "List all active port forwards",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get instance name from environment or flag
-		instanceName := os.Getenv("KECS_INSTANCE")
+		instanceName := config.GetString("kubernetes.instanceName")
 		if instanceName == "" {
 			instanceName = "default"
 		}
@@ -188,7 +189,7 @@ var portForwardStopCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get instance name from environment or flag
-		instanceName := os.Getenv("KECS_INSTANCE")
+		instanceName := config.GetString("kubernetes.instanceName")
 		if instanceName == "" {
 			instanceName = "default"
 		}

--- a/controlplane/internal/controlplane/cmd/server.go
+++ b/controlplane/internal/controlplane/cmd/server.go
@@ -81,9 +81,7 @@ func runServer(cmd *cobra.Command) {
 	// Load configuration
 	// Check environment variable if configFile is not set via flag
 	if configFile == "" {
-		if envConfig := os.Getenv("KECS_CONFIG_PATH"); envConfig != "" {
-			configFile = envConfig
-		}
+		configFile = config.GetString("server.configPath")
 	}
 	cfg, err := config.LoadConfig(configFile)
 	if err != nil {

--- a/controlplane/internal/controlplane/cmd/start_test.go
+++ b/controlplane/internal/controlplane/cmd/start_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 )
 
 var _ = Describe("Start Command Unit Tests", func() {
@@ -118,7 +119,7 @@ var _ = Describe("Start V2 Command Integration Tests", func() {
 
 	Describe("New Architecture Deployment", func() {
 		It("should successfully deploy all components", func() {
-			if os.Getenv("KECS_INTEGRATION_TEST") != "true" {
+			if !config.GetBool("features.integrationTest") {
 				Skip("Skipping integration test (set KECS_INTEGRATION_TEST=true to run)")
 			}
 
@@ -160,7 +161,7 @@ var _ = Describe("Start V2 Command Integration Tests", func() {
 
 	Describe("Component Health Checks", func() {
 		It("should report all components as healthy", func() {
-			if os.Getenv("KECS_INTEGRATION_TEST") != "true" {
+			if !config.GetBool("features.integrationTest") {
 				Skip("Skipping integration test (set KECS_INTEGRATION_TEST=true to run)")
 			}
 

--- a/controlplane/internal/integrations/elbv2/integration_k8s.go
+++ b/controlplane/internal/integrations/elbv2/integration_k8s.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -22,6 +21,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/logging"
 	"github.com/nandemo-ya/kecs/controlplane/internal/storage"
 )
@@ -1571,7 +1571,7 @@ func (i *K8sIntegration) SyncRulesToListener(ctx context.Context, storageInstanc
 // addK3dPortMapping adds a port mapping to the k3d cluster's load balancer
 func (i *K8sIntegration) addK3dPortMapping(ctx context.Context, clusterName string, hostPort, nodePort int32) error {
 	// Skip if running in container mode (k3d command not available)
-	if os.Getenv("KECS_CONTAINER_MODE") == "true" {
+	if config.GetBool("features.containerMode") {
 		logging.Info("Running in container mode, k3d port mapping should be pre-configured",
 			"hostPort", hostPort,
 			"nodePort", nodePort,
@@ -1654,7 +1654,7 @@ func getTraefikNodePort(listenerPort int32) int32 {
 // getClusterNameFromEnvironment gets the k3d cluster name
 func getClusterNameFromEnvironment() string {
 	// Try to get from environment variable
-	if clusterName := os.Getenv("KECS_CLUSTER_NAME"); clusterName != "" {
+	if clusterName := config.GetString("kubernetes.clusterName"); clusterName != "" {
 		return clusterName
 	}
 	// Default to "kecs-cluster"

--- a/controlplane/internal/integrations/networking/awsvpc_test.go
+++ b/controlplane/internal/integrations/networking/awsvpc_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated"
 	"github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api/generated/ptr"
@@ -61,7 +62,7 @@ var _ = Describe("AWSVPC Network Mode Integration", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Initialize ECS API for test mode
-		ecsAPI = api.NewDefaultECSAPIWithConfig(store, region, accountID).(*api.DefaultECSAPI)
+		ecsAPI = api.NewDefaultECSAPIWithConfig(config.DefaultConfig(), store, region, accountID).(*api.DefaultECSAPI)
 
 		// Create default cluster
 		_, err = ecsAPI.CreateCluster(ctx, &generated.CreateClusterRequest{

--- a/controlplane/internal/progress/bubbletea/program.go
+++ b/controlplane/internal/progress/bubbletea/program.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nandemo-ya/kecs/controlplane/internal/config"
 )
 
 // Program wraps the Bubble Tea program for progress tracking
@@ -310,7 +312,7 @@ func (lc *logCapture) Write(p []byte) (n int, err error) {
 	}
 
 	// Also write to original output for debugging
-	if lc.originalOut != nil && os.Getenv("KECS_DEBUG") != "" {
+	if lc.originalOut != nil && config.GetBool("features.debug") {
 		lc.originalOut.Write(p)
 	}
 

--- a/controlplane/internal/runtime/manager.go
+++ b/controlplane/internal/runtime/manager.go
@@ -140,11 +140,11 @@ func GetAvailableRuntimes() []string {
 	return runtimes
 }
 
-// GetPreferredRuntime returns the preferred runtime based on environment
-func GetPreferredRuntime() string {
-	// Check environment variable
-	if runtime := os.Getenv("KECS_CONTAINER_RUNTIME"); runtime != "" {
-		return runtime
+// GetPreferredRuntime returns the preferred runtime based on configuration
+func GetPreferredRuntime(containerRuntime string) string {
+	// Use configured runtime if specified
+	if containerRuntime != "" {
+		return containerRuntime
 	}
 
 	// Check if running in k3s/k3d (prefer containerd)


### PR DESCRIPTION
## Summary

Completed Part 2 of the os.Getenv removal refactoring. Replaced all remaining os.Getenv calls (except in examples) with a centralized viper-based configuration approach.

## Changes

### Runtime Manager
- Updated `GetPreferredRuntime()` to accept `containerRuntime` parameter instead of reading from environment directly

### Kubernetes Task Manager
- Replaced 3 `os.Getenv` calls with `appconfig` methods
- Imported `config` package as `appconfig` to avoid naming conflicts with `rest.Config`

### Command Files
- `cmd/server.go`: Replaced `KECS_CONFIG_PATH` with `config.GetString()`
- `cmd/portforward.go`: Replaced 3 instances of `KECS_INSTANCE` with `config.GetString()`
- `cmd/kubeconfig.go`: Replaced `KECS_DATA_DIR` with `config.GetString()`

### API Files
- `api/cluster_ecs_api.go`: Replaced `KECS_INSTANCE_NAME` with `config.GetString()`

### Integration Files
- `integrations/elbv2/integration_k8s.go`:
  - Replaced `KECS_CONTAINER_MODE` with `config.GetBool()`
  - Replaced `KECS_CLUSTER_NAME` with `config.GetString()`
  - Removed unused `os` package import

### Progress Files
- `progress/bubbletea/program.go`: Replaced `KECS_DEBUG` with `config.GetBool()`

### Test Files
- `start_test.go`: Replaced 2 instances of `KECS_INTEGRATION_TEST` with `config.GetBool()`
- Removed unused `os` package imports

## Test Results

All tests pass successfully:
```
ok  	github.com/nandemo-ya/kecs/controlplane/internal/controlplane/api
ok  	github.com/nandemo-ya/kecs/controlplane/internal/controlplane/cmd
ok  	github.com/nandemo-ya/kecs/controlplane/internal/integrations/elbv2
ok  	github.com/nandemo-ya/kecs/controlplane/internal/kubernetes
... (all tests passed)
```

## Related PRs

- Part 1: #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)