### PR TITLE
feat: Migrate single-task-nginx example to Terraform

### DIFF
--- a/examples/single-task-nginx/README.md
+++ b/examples/single-task-nginx/README.md
@@ -11,28 +11,110 @@ This example demonstrates a simple nginx web server deployment using KECS with a
 
 ## Prerequisites
 
-Before deploying this example, ensure you have:
-
 1. KECS running locally
-2. AWS CLI configured to point to KECS endpoint
+2. Terraform installed (>= 1.0)
+3. AWS CLI configured
 
-## Setup Instructions
+## Quick Start with Terraform (Recommended)
 
-### 1. Start KECS (if not already running)
+### 1. Start KECS
 
 ```bash
+# Start KECS instance
 kecs start
+
+# Wait for KECS to be ready
+kecs list
 ```
 
-### 2. Create the ECS cluster
+### 2. Deploy Infrastructure with Terraform
 
 ```bash
-aws ecs create-cluster --cluster-name default \
+# Initialize Terraform
+terraform init
+
+# Review the planned changes
+terraform plan
+
+# Apply the configuration
+terraform apply
+
+# Type 'yes' when prompted
+```
+
+This will create:
+- ECS Cluster: `single-task-nginx`
+- CloudWatch Logs Log Group: `/ecs/single-task-nginx` (7 days retention)
+
+### 3. Verify Resources
+
+```bash
+# Verify ECS cluster
+aws ecs describe-clusters \
+  --cluster single-task-nginx \
+  --endpoint-url http://localhost:5373 \
+  --region us-east-1
+
+# Verify CloudWatch Logs log group
+aws logs describe-log-groups \
+  --log-group-name-prefix /ecs/single-task-nginx \
+  --endpoint-url http://localhost:5373 \
+  --region us-east-1
+
+# View Terraform outputs
+terraform output
+```
+
+### 4. View Terraform Outputs
+
+```bash
+# Show all outputs
+terraform output
+
+# Show specific output
+terraform output cluster_name
+terraform output log_group_name
+```
+
+After applying, Terraform provides several outputs:
+
+- `cluster_name`: ECS cluster name
+- `cluster_arn`: ECS cluster ARN
+- `log_group_name`: CloudWatch Logs log group name
+- `log_group_arn`: CloudWatch Logs log group ARN
+
+### 5. Terraform Configuration
+
+You can customize the configuration by creating a `terraform.tfvars` file:
+
+```hcl
+aws_region     = "us-east-1"
+kecs_endpoint  = "http://localhost:5373"
+cluster_name   = "single-task-nginx"
+service_name   = "single-task-nginx"
+environment    = "development"
+```
+
+Or override via command line:
+
+```bash
+terraform apply -var="cluster_name=my-cluster" -var="environment=staging"
+```
+
+## Manual Setup (Alternative)
+
+<details>
+<summary>Click to expand manual setup instructions using AWS CLI</summary>
+
+### 1. Create the ECS Cluster
+
+```bash
+aws ecs create-cluster --cluster-name single-task-nginx \
   --region us-east-1 \
   --endpoint-url http://localhost:5373
 ```
 
-### 3. Create CloudWatch Log Group
+### 2. Create CloudWatch Log Group
 
 ```bash
 aws logs create-log-group \
@@ -42,6 +124,8 @@ aws logs create-log-group \
 ```
 
 Note: The `ecsTaskExecutionRole` is automatically created by KECS when it starts LocalStack. No need to create it manually.
+
+</details>
 
 ## Deployment
 
@@ -67,17 +151,18 @@ aws ecs create-service \
 
 ```bash
 aws ecs describe-services \
-  --cluster default \
+  --cluster single-task-nginx \
   --services single-task-nginx \
   --region us-east-1 \
-  --endpoint-url http://localhost:5373
+  --endpoint-url http://localhost:5373 \
+  --query 'services[0].{Status:status,Desired:desiredCount,Running:runningCount}'
 ```
 
 ### 2. List Running Tasks
 
 ```bash
 aws ecs list-tasks \
-  --cluster default \
+  --cluster single-task-nginx \
   --service-name single-task-nginx \
   --region us-east-1 \
   --endpoint-url http://localhost:5373
@@ -88,7 +173,7 @@ aws ecs list-tasks \
 ```bash
 # Get task ARN from list-tasks output
 TASK_ARN=$(aws ecs list-tasks \
-  --cluster default \
+  --cluster single-task-nginx \
   --service-name single-task-nginx \
   --region us-east-1 \
   --endpoint-url http://localhost:5373 \
@@ -96,7 +181,7 @@ TASK_ARN=$(aws ecs list-tasks \
 
 # Describe task to check status
 aws ecs describe-tasks \
-  --cluster default \
+  --cluster single-task-nginx \
   --tasks $TASK_ARN \
   --region us-east-1 \
   --endpoint-url http://localhost:5373 \
@@ -127,7 +212,36 @@ aws logs tail /ecs/single-task-nginx \
 
 ## Troubleshooting
 
-### Check Task Logs
+### Terraform Issues
+
+#### Connection Refused
+
+If Terraform can't connect to KECS:
+
+```bash
+# Check KECS is running
+kecs status
+
+# Verify endpoint is accessible
+curl http://localhost:5373/health
+```
+
+#### Resource Already Exists
+
+If resources were manually created:
+
+```bash
+# Option 1: Destroy existing resources first using terraform
+terraform destroy
+
+# Option 2: Import existing resources
+terraform import aws_ecs_cluster.main single-task-nginx
+terraform import aws_cloudwatch_log_group.nginx /ecs/single-task-nginx
+```
+
+### Task and Service Issues
+
+#### Check Task Logs
 
 ```bash
 aws logs tail /ecs/single-task-nginx \
@@ -136,11 +250,11 @@ aws logs tail /ecs/single-task-nginx \
   --follow
 ```
 
-### Check Service Events
+#### Check Service Events
 
 ```bash
 aws ecs describe-services \
-  --cluster default \
+  --cluster single-task-nginx \
   --services single-task-nginx \
   --region us-east-1 \
   --endpoint-url http://localhost:5373 \
@@ -149,10 +263,26 @@ aws ecs describe-services \
 
 ## Cleanup
 
+### Using Terraform (Recommended)
+
+```bash
+# Destroy all infrastructure
+terraform destroy
+
+# Type 'yes' when prompted
+```
+
+This will remove all resources created by Terraform.
+
+### Manual Cleanup (Alternative)
+
+<details>
+<summary>Click to expand manual cleanup instructions</summary>
+
 ```bash
 # Delete service
 aws ecs delete-service \
-  --cluster default \
+  --cluster single-task-nginx \
   --service single-task-nginx \
   --force \
   --region us-east-1 \
@@ -169,4 +299,12 @@ aws logs delete-log-group \
   --log-group-name /ecs/single-task-nginx \
   --region us-east-1 \
   --endpoint-url http://localhost:5373
+
+# Delete ECS cluster
+aws ecs delete-cluster \
+  --cluster single-task-nginx \
+  --region us-east-1 \
+  --endpoint-url http://localhost:5373
 ```
+
+</details>

--- a/examples/single-task-nginx/main.tf
+++ b/examples/single-task-nginx/main.tf
@@ -1,0 +1,21 @@
+# ECS Cluster
+resource "aws_ecs_cluster" "main" {
+  name = var.cluster_name
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# CloudWatch Logs Log Group
+resource "aws_cloudwatch_log_group" "nginx" {
+  name              = "/ecs/${var.service_name}"
+  retention_in_days = 7
+
+  tags = {
+    Environment = var.environment
+    Service     = var.service_name
+    ManagedBy   = "terraform"
+  }
+}

--- a/examples/single-task-nginx/outputs.tf
+++ b/examples/single-task-nginx/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "cluster_arn" {
+  description = "ECS cluster ARN"
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch Logs log group name"
+  value       = aws_cloudwatch_log_group.nginx.name
+}
+
+output "log_group_arn" {
+  description = "CloudWatch Logs log group ARN"
+  value       = aws_cloudwatch_log_group.nginx.arn
+}

--- a/examples/single-task-nginx/provider.tf
+++ b/examples/single-task-nginx/provider.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  # KECS endpoint configuration
+  endpoints {
+    ecs  = var.kecs_endpoint
+    logs = var.kecs_endpoint
+    iam  = var.kecs_endpoint
+  }
+
+  # Skip credential validation for local KECS environment
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+
+  # Use fake credentials for KECS
+  access_key = "test"
+  secret_key = "test"
+}

--- a/examples/single-task-nginx/service_def.json
+++ b/examples/single-task-nginx/service_def.json
@@ -1,6 +1,6 @@
 {
   "serviceName": "single-task-nginx",
-  "cluster": "default",
+  "cluster": "single-task-nginx",
   "taskDefinition": "single-task-nginx:1",
   "desiredCount": 1,
   "launchType": "FARGATE",

--- a/examples/single-task-nginx/variables.tf
+++ b/examples/single-task-nginx/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "kecs_endpoint" {
+  description = "KECS endpoint URL"
+  type        = string
+  default     = "http://localhost:5373"
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+  default     = "single-task-nginx"
+}
+
+variable "service_name" {
+  description = "ECS service name"
+  type        = string
+  default     = "single-task-nginx"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "development"
+}


### PR DESCRIPTION
## Summary
Migrate the `single-task-nginx` example to declarative Terraform configuration for better maintainability, reproducibility, and infrastructure-as-code best practices.

## Motivation
Following the pattern established in #754, this PR migrates single-task-nginx from manual AWS CLI resource creation to declarative Terraform management.

## Changes

### 1. Terraform Configuration
Created Terraform configuration managing all AWS resources, placed directly in the example directory:

**Resources Created (2 total)**:
- ECS Cluster: `single-task-nginx` (renamed from `default`)
- CloudWatch Logs Log Group: `/ecs/single-task-nginx` (7 days retention)

**Configuration Files** (in `examples/single-task-nginx/`):
- `provider.tf` - AWS provider with KECS endpoint configuration
- `variables.tf` - Configurable variables (region, endpoint, names)
- `main.tf` - Resource definitions (ECS cluster, CloudWatch Logs)
- `outputs.tf` - Useful outputs (cluster/log group names and ARNs)

### 2. Update service_def.json
- Changed cluster name from `default` to `single-task-nginx`

### 3. Refactored README.md
- **Quick Start**: Now features Terraform workflow (recommended)
- **Manual Setup**: Moved AWS CLI instructions to collapsible section
- **Cluster Name**: Updated all references from `default` to `single-task-nginx`
- **Integrated Documentation**: Comprehensive Terraform documentation
- **Outputs Section**: Description of available Terraform outputs
- **Enhanced Troubleshooting**: Covers both Terraform and ECS-specific issues

### 4. Directory Structure
Terraform files are placed directly in the example directory:
```
examples/single-task-nginx/
├── README.md (integrated Terraform docs)
├── provider.tf
├── variables.tf
├── main.tf
├── outputs.tf
├── service_def.json
├── task_def.json
└── test_logs.sh
```

## Testing

### Verified Operations
✅ `terraform init` - Provider initialization successful  
✅ `terraform apply` - 2 resources created successfully  
✅ ECS task definition registered  
✅ ECS service created and deployed  
✅ Service status: ACTIVE, Running: 1/1  
✅ Pod running in `single-task-nginx-us-east-1` namespace  
✅ Full test suite passed  

### Test Output
```bash
# Terraform resources created
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

# ECS service status
Status: ACTIVE
Desired: 1
Running: 1
Pending: 0
```

## Breaking Changes
- ⚠️ ECS Cluster name changed from `default` to `single-task-nginx`
  - Aligns with example directory name
  - More descriptive and avoids conflicts
  - Existing deployments using `default` cluster need manual migration

## Documentation
- Updated main README with Terraform-first approach
- Added comprehensive sections:
  - Prerequisites and setup instructions
  - Configuration variables and customization
  - Terraform outputs description
  - Troubleshooting guide (Terraform and ECS issues)
  - Manual setup as alternative (in collapsible section)

## Benefits
- 📝 **Declarative**: Define desired state, Terraform handles the rest
- 🔁 **Idempotent**: Safe to run multiple times
- 👀 **Plan before apply**: Preview changes before execution
- 🧹 **Single-command cleanup**: `terraform destroy`
- 📊 **State management**: Track infrastructure changes
- 🔄 **Version control**: Infrastructure as code in Git

## Related
- Follows pattern from #754 (service-with-secrets Terraform migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>