### PR TITLE
fix: Handle ErrResourceNotFound in ELBv2 Create operations

### DIFF
--- a/controlplane/internal/controlplane/api/elbv2_api_impl.go
+++ b/controlplane/internal/controlplane/api/elbv2_api_impl.go
@@ -57,7 +57,7 @@ func (api *ELBv2APIImpl) CreateLoadBalancer(ctx context.Context, input *generate
 
 	// Check if load balancer already exists
 	existingLB, err := api.storage.ELBv2Store().GetLoadBalancerByName(ctx, input.Name)
-	if err != nil {
+	if err != nil && err != storage.ErrResourceNotFound {
 		return nil, err
 	}
 	if existingLB != nil {
@@ -239,7 +239,7 @@ func (api *ELBv2APIImpl) CreateTargetGroup(ctx context.Context, input *generated
 
 	// Check if target group already exists
 	existingTG, err := api.storage.ELBv2Store().GetTargetGroupByName(ctx, input.Name)
-	if err != nil {
+	if err != nil && err != storage.ErrResourceNotFound {
 		return nil, err
 	}
 	if existingTG != nil {


### PR DESCRIPTION
## Summary
Fixed bug in ELBv2 API implementation where `CreateLoadBalancer` and `CreateTargetGroup` were incorrectly treating `storage.ErrResourceNotFound` as a fatal error.

## Problem
When creating a new load balancer or target group, the code checked if the resource already exists by calling `GetLoadBalancerByName` or `GetTargetGroupByName`. These storage methods correctly return `storage.ErrResourceNotFound` when a resource doesn't exist.

However, the Create methods were treating this as a fatal error and returning immediately, preventing new resources from being created.

## Solution
Updated error handling in both methods to only return an error if it's NOT `storage.ErrResourceNotFound`:

```go
// Before (buggy):
existingLB, err := api.storage.ELBv2Store().GetLoadBalancerByName(ctx, input.Name)
if err != nil {
    return nil, err  // Returns ErrResourceNotFound for new resources!
}

// After (fixed):
existingLB, err := api.storage.ELBv2Store().GetLoadBalancerByName(ctx, input.Name)
if err != nil && err != storage.ErrResourceNotFound {
    return nil, err
}
```

## Changes
- `CreateLoadBalancer` (line 60): Added check for `storage.ErrResourceNotFound`
- `CreateTargetGroup` (line 242): Added check for `storage.ErrResourceNotFound`

## Testing
Verified fix by running `examples/multi-container-alb/setup_elb.sh`:
- ✅ Application Load Balancer created successfully
- ✅ Target Group created successfully  
- ✅ HTTP Listener created successfully
- ✅ All unit tests passing

## Related
This fix unblocks the Terraform migration work in PR #757 for the multi-container-alb example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)