### PR TITLE
feat: Add ECS API reference skills for KECS development

### DIFF
--- a/.claude/skills/ecs-api-reference/SKILL.md
+++ b/.claude/skills/ecs-api-reference/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ecs-api-reference
+description: Amazon ECS API specification reference. Use when implementing ECS-compatible APIs in KECS to accurately reproduce request/response structures, parameters, error codes, and behaviors. Reference for implementing APIs like CreateCluster, CreateService, RunTask, RegisterTaskDefinition.
+allowed-tools: Read, Grep, Glob
+---
+
+# Amazon ECS API Reference for KECS
+
+Reference skill for implementing ECS-compatible APIs in KECS.
+
+## Overview
+
+This skill provides detailed specifications for the following ECS API categories:
+
+1. **Cluster API** - Cluster management (`cluster-api.md`)
+2. **Service API** - Service management (`service-api.md`)
+3. **Task API** - Task execution and management (`task-api.md`)
+4. **Task Definition API** - Task definition management (`task-definition-api.md`)
+5. **Other APIs** - Tags, TaskSets, Attributes, Account Settings, etc. (`other-apis.md`)
+
+## Use Cases
+
+- Implementing new ECS API endpoints
+- Verifying request/response structures of existing APIs
+- Aligning error codes and behaviors with AWS ECS
+- Writing API compatibility tests
+
+## Common API Specifications
+
+### HTTP Request Format
+```
+POST / HTTP/1.1
+Host: ecs.{region}.amazonaws.com
+Content-Type: application/x-amz-json-1.1
+X-Amz-Target: AmazonEC2ContainerServiceV20141113.{ActionName}
+```
+
+### Common Error Codes
+| Error | HTTP | Description |
+|-------|------|-------------|
+| ClientException | 400 | Client-side error (insufficient permissions, invalid ID, etc.) |
+| InvalidParameterException | 400 | Invalid parameter |
+| ServerException | 500 | Server error |
+| ClusterNotFoundException | 400 | Cluster not found |
+| ServiceNotFoundException | 400 | Service not found |
+
+### Tag Limits
+- Maximum 50 tags per resource
+- Key length: Maximum 128 characters (UTF-8)
+- Value length: Maximum 256 characters (UTF-8)
+- `aws:` prefix is reserved (cannot edit or delete)
+
+### Pagination
+- maxResults: 1-100 (default 10 or 100 depending on API)
+- nextToken: Opaque continuation token
+
+### ARN Format
+```
+arn:aws:ecs:{region}:{account}:{resource-type}/{resource-id}
+```
+Resource types: cluster, service, task, task-definition, container-instance, capacity-provider, task-set
+
+## Detailed Specifications
+
+Refer to the following support files for detailed API specifications:
+
+- `cluster-api.md` - CreateCluster, DescribeClusters, ListClusters, DeleteCluster, UpdateCluster
+- `service-api.md` - CreateService, DescribeServices, UpdateService, DeleteService, ListServices
+- `task-api.md` - RunTask, StopTask, DescribeTasks, ListTasks, ExecuteCommand
+- `task-definition-api.md` - RegisterTaskDefinition, DeregisterTaskDefinition, DescribeTaskDefinition, ListTaskDefinitions
+- `other-apis.md` - TagResource, ListTagsForResource, CreateTaskSet, PutAttributes, PutAccountSetting, etc.

--- a/.claude/skills/ecs-api-reference/cluster-api.md
+++ b/.claude/skills/ecs-api-reference/cluster-api.md
@@ -1,0 +1,162 @@
+# ECS Cluster API Specifications
+
+## CreateCluster
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| clusterName | String | No | Cluster name (max 255 chars). Defaults to `default` |
+| capacityProviders | Array[String] | No | Capacity providers (FARGATE/FARGATE_SPOT, etc.) |
+| defaultCapacityProviderStrategy | Array[CapacityProviderStrategyItem] | No | Default strategy |
+| configuration | ClusterConfiguration | No | Execute Command/Managed Storage settings |
+| serviceConnectDefaults | ClusterServiceConnectDefaultsRequest | No | Service Connect default namespace |
+| settings | Array[ClusterSetting] | No | Container Insights settings, etc. |
+| tags | Array[Tag] | No | Metadata tags (max 50) |
+
+### ClusterConfiguration Structure
+```json
+{
+  "executeCommandConfiguration": {
+    "kmsKeyId": "string",
+    "logging": "NONE|DEFAULT|OVERRIDE",
+    "logConfiguration": {
+      "cloudWatchLogGroupName": "string",
+      "cloudWatchEncryptionEnabled": boolean,
+      "s3BucketName": "string",
+      "s3EncryptionEnabled": boolean,
+      "s3KeyPrefix": "string"
+    }
+  },
+  "managedStorageConfiguration": {
+    "kmsKeyId": "string",
+    "fargateEphemeralStorageKmsKeyId": "string"
+  }
+}
+```
+
+### Response - Cluster Object
+```json
+{
+  "cluster": {
+    "clusterArn": "string",
+    "clusterName": "string",
+    "status": "ACTIVE|PROVISIONING|DEPROVISIONING|FAILED|INACTIVE",
+    "activeServicesCount": number,
+    "runningTasksCount": number,
+    "pendingTasksCount": number,
+    "registeredContainerInstancesCount": number,
+    "capacityProviders": ["string"],
+    "defaultCapacityProviderStrategy": [...],
+    "configuration": {...},
+    "serviceConnectDefaults": {"namespace": "string"},
+    "settings": [{"name": "containerInsights", "value": "enabled|disabled|enhanced"}],
+    "tags": [...]
+  }
+}
+```
+
+### Important Notes
+- Attempts to automatically create service-linked role
+- Auto Scaling group-based capacity providers cannot be shared with other clusters
+- Returns HTTP 200 on success
+
+---
+
+## DescribeClusters
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| clusters | Array[String] | No | Max 100 cluster names/ARNs |
+| include | Array[String] | No | ATTACHMENTS, CONFIGURATIONS, SETTINGS, STATISTICS, TAGS |
+
+### Response
+```json
+{
+  "clusters": [Cluster],
+  "failures": [
+    {
+      "arn": "string",
+      "reason": "string",
+      "detail": "string"
+    }
+  ]
+}
+```
+
+### STATISTICS Content
+Task/service counts by launch type
+
+---
+
+## ListClusters
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| maxResults | Integer | No | 1-100 (default 100) |
+| nextToken | String | No | Pagination token |
+
+### Response
+```json
+{
+  "clusterArns": ["arn:aws:ecs:region:account:cluster/name"],
+  "nextToken": "string"
+}
+```
+
+---
+
+## DeleteCluster
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name or ARN |
+
+### Prerequisites for Deletion
+1. Deregister all container instances
+2. Delete all services (desiredCount=0 -> DeleteService)
+3. Delete all capacity providers
+4. Stop all active tasks
+
+### Specific Errors
+- ClusterContainsCapacityProviderException
+- ClusterContainsContainerInstancesException
+- ClusterContainsServicesException
+- ClusterContainsTasksException
+- UpdateInProgressException
+
+### Important Notes
+- Remains discoverable in INACTIVE state for a period after deletion
+- Behavior may change in the future
+
+---
+
+## UpdateCluster
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name |
+| configuration | ClusterConfiguration | No | Update Execute Command settings |
+| serviceConnectDefaults | Object | No | Service Connect namespace |
+| settings | Array[ClusterSetting] | No | Cluster settings |
+
+### ClusterSetting
+```json
+{
+  "name": "containerInsights",
+  "value": "enabled|disabled|enhanced"
+}
+```
+
+---
+
+## UpdateClusterSettings
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name |
+| settings | Array[ClusterSetting] | Yes | Settings to update |

--- a/.claude/skills/ecs-api-reference/other-apis.md
+++ b/.claude/skills/ecs-api-reference/other-apis.md
@@ -1,0 +1,393 @@
+# ECS Other APIs Specifications
+
+## Tags API
+
+### TagResource
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| resourceArn | String | Yes | Resource ARN to tag |
+| tags | Array[Tag] | Yes | Tags to apply |
+
+#### Supported Resources
+- ECS capacity providers
+- Tasks
+- Services
+- Task definitions
+- Clusters
+- Container instances
+
+#### Important Notes
+- Short ARN format not supported for services:
+  - Invalid: `arn:aws:ecs:region:account:service/service-name`
+  - Valid: `arn:aws:ecs:region:account:service/cluster-name/service-name`
+- Existing tags not included in request are unchanged (add-only operation)
+
+#### Response
+HTTP 200 with empty body `{}`
+
+#### Errors
+- ResourceNotFoundException
+
+---
+
+### UntagResource
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| resourceArn | String | Yes | Resource ARN |
+| tagKeys | Array[String] | Yes | Tag keys to remove |
+
+#### Response
+HTTP 200 with empty body `{}`
+
+---
+
+### ListTagsForResource
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| resourceArn | String | Yes | Resource ARN |
+
+#### Response
+```json
+{
+  "tags": [
+    {
+      "key": "string",
+      "value": "string"
+    }
+  ]
+}
+```
+
+---
+
+## TaskSet API
+
+### CreateTaskSet
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name/ARN |
+| service | String | Yes | Service name/ARN |
+| taskDefinition | String | Yes | Task definition |
+| capacityProviderStrategy | Array | No | Mutually exclusive with launchType |
+| launchType | String | No | EC2/FARGATE/EXTERNAL/MANAGED_INSTANCES |
+| loadBalancers | Array | No | ALB/NLB configuration |
+| networkConfiguration | Object | No | VPC/subnet/security group settings |
+| platformVersion | String | No | Fargate platform version (default: LATEST) |
+| scale | Scale | No | Floating-point percentage of desired task count |
+| serviceRegistries | Array | No | Service discovery registries |
+| tags | Array | No | Metadata tags (max 50) |
+| externalId | String | No | External system identifier |
+| clientToken | String | No | Idempotency token (max 36 chars) |
+
+#### Important Notes
+- Used with services using EXTERNAL deployment controller type
+- capacityProviderStrategy and launchType are mutually exclusive
+
+#### Response
+```json
+{
+  "taskSet": {
+    "id": "string",
+    "taskSetArn": "string",
+    "clusterArn": "string",
+    "serviceArn": "string",
+    "status": "string",
+    "taskDefinition": "string",
+    "launchType": "string",
+    "platformVersion": "string",
+    "computedDesiredCount": number,
+    "pendingCount": number,
+    "runningCount": number,
+    "createdAt": number,
+    "updatedAt": number,
+    "stabilityStatus": "string",
+    "stabilityStatusAt": number,
+    "scale": {
+      "value": number,
+      "unit": "string"
+    },
+    "loadBalancers": [...],
+    "networkConfiguration": {...},
+    "tags": [...]
+  }
+}
+```
+
+---
+
+### DescribeTaskSets
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name/ARN |
+| service | String | Yes | Service name/ARN |
+| taskSets | Array[String] | No | Task set IDs/ARNs to describe |
+| include | Array[String] | No | TAGS |
+
+#### Response
+```json
+{
+  "taskSets": [TaskSet],
+  "failures": [Failure]
+}
+```
+
+---
+
+### UpdateTaskSet
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name/ARN |
+| service | String | Yes | Service name/ARN |
+| taskSet | String | Yes | Task set ID/ARN |
+| scale | Scale | Yes | New scale value |
+
+---
+
+### DeleteTaskSet
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name/ARN |
+| service | String | Yes | Service name/ARN |
+| taskSet | String | Yes | Task set ID/ARN |
+| force | Boolean | No | Force delete |
+
+---
+
+## Attributes API
+
+### PutAttributes
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| attributes | Array[Attribute] | Yes | Max 10 attributes per call |
+| cluster | String | No | Cluster name/ARN |
+
+#### Attribute Object
+```json
+{
+  "name": "string",
+  "targetId": "string",  // Container instance ARN, etc.
+  "targetType": "string",
+  "value": "string"
+}
+```
+
+#### Limits
+- Max 10 custom attributes per resource
+- Max 10 attributes per single call
+
+#### Response
+```json
+{
+  "attributes": [Attribute]
+}
+```
+
+#### Errors
+- AttributeLimitExceededException
+
+---
+
+### DeleteAttributes
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| attributes | Array[Attribute] | Yes | Attributes to delete |
+| cluster | String | No | Cluster name/ARN |
+
+---
+
+### ListAttributes
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| targetType | String | Yes | container-instance |
+| attributeName | String | No | Filter by attribute name |
+| attributeValue | String | No | Filter by value |
+| cluster | String | No | Cluster name/ARN |
+| maxResults | Integer | No | 1-100 |
+| nextToken | String | No | Pagination token |
+
+#### Response
+```json
+{
+  "attributes": [Attribute],
+  "nextToken": "string"
+}
+```
+
+---
+
+## Account Settings API
+
+### PutAccountSetting
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | String | Yes | Setting name |
+| value | String | Yes | Setting value |
+| principalArn | String | No | User/role/root user ARN |
+
+#### Valid Setting Names
+| Name | Description | Values |
+|------|-------------|--------|
+| serviceLongArnFormat | Service ARN/ID format | enabled/disabled |
+| taskLongArnFormat | Task ARN/ID format | enabled/disabled |
+| containerInstanceLongArnFormat | Container instance ARN/ID format | enabled/disabled |
+| awsvpcTrunking | ENI limit changes | enabled/disabled |
+| containerInsights | Container Insights monitoring | enabled/disabled/enhanced |
+| dualStackIPv6 | IPv6 address assignment in dual-stack VPC | enabled/disabled |
+| fargateTaskRetirementWaitPeriod | Fargate task retirement wait time | 0/7/14 (days) |
+| tagResourceAuthorization | Tag authorization on resource creation | enabled/disabled/on/off |
+| defaultLogDriverMode | Default log driver delivery mode | blocking/non-blocking |
+| guardDutyActivate | ECS Runtime Monitoring (read-only) | - |
+
+#### Important Notes
+- fargateTaskRetirementWaitPeriod requires root user principalArn
+- Federated users cannot specify principalArn
+- Settings are region-specific
+
+---
+
+### PutAccountSettingDefault
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | String | Yes | Setting name |
+| value | String | Yes | Setting value |
+
+Sets default for entire account (all users/roles)
+
+---
+
+### ListAccountSettings
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| effectiveSettings | Boolean | No | Return root user or default settings |
+| maxResults | Integer | No | 1-10 (default: 10) |
+| name | String | No | Setting name filter |
+| nextToken | String | No | Pagination token |
+| principalArn | String | No | User/role ARN |
+| value | String | No | Filter by value (requires name) |
+
+#### Response
+```json
+{
+  "settings": [
+    {
+      "name": "string",
+      "principalArn": "string",
+      "type": "string",
+      "value": "string"
+    }
+  ],
+  "nextToken": "string"
+}
+```
+
+---
+
+### DeleteAccountSetting
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | String | Yes | Setting name |
+| principalArn | String | No | User/role ARN |
+
+---
+
+## Capacity Provider API
+
+### CreateCapacityProvider
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | String | Yes | Capacity provider name |
+| autoScalingGroupProvider | Object | Yes | Auto Scaling group settings |
+| tags | Array | No | Tags |
+
+#### autoScalingGroupProvider Structure
+```json
+{
+  "autoScalingGroupArn": "string",
+  "managedScaling": {
+    "status": "ENABLED|DISABLED",
+    "targetCapacity": number,
+    "minimumScalingStepSize": number,
+    "maximumScalingStepSize": number,
+    "instanceWarmupPeriod": number
+  },
+  "managedTerminationProtection": "ENABLED|DISABLED",
+  "managedDraining": "ENABLED|DISABLED"
+}
+```
+
+---
+
+### DescribeCapacityProviders
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| capacityProviders | Array[String] | No | Capacity provider names/ARNs |
+| include | Array[String] | No | TAGS |
+| maxResults | Integer | No | 1-100 |
+| nextToken | String | No | Pagination token |
+
+---
+
+### UpdateCapacityProvider
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | String | Yes | Capacity provider name |
+| autoScalingGroupProvider | Object | Yes | Updated settings |
+
+---
+
+### DeleteCapacityProvider
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| capacityProvider | String | Yes | Capacity provider name/ARN |
+
+#### Prerequisites
+- Not associated with any cluster
+
+---
+
+### PutClusterCapacityProviders
+
+#### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | Yes | Cluster name |
+| capacityProviders | Array[String] | Yes | Capacity providers to associate |
+| defaultCapacityProviderStrategy | Array | Yes | Default strategy |
+
+Associates capacity providers with a cluster and sets default strategy.

--- a/.claude/skills/ecs-api-reference/service-api.md
+++ b/.claude/skills/ecs-api-reference/service-api.md
@@ -1,0 +1,293 @@
+# ECS Service API Specifications
+
+## CreateService
+
+### Required Parameters
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| serviceName | String | Service name (max 255 chars) |
+
+### Key Optional Parameters
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| cluster | String | Cluster name/ARN (default: default) |
+| taskDefinition | String | family:revision format or ARN |
+| desiredCount | Integer | Number of tasks to run (required for REPLICA) |
+| launchType | String | EC2/FARGATE/EXTERNAL/MANAGED_INSTANCES |
+| capacityProviderStrategy | Array | Max 20 capacity provider strategies |
+| deploymentController | Object | ECS/CODE_DEPLOY/EXTERNAL |
+| deploymentConfiguration | Object | Deployment settings |
+| schedulingStrategy | String | REPLICA/DAEMON |
+| networkConfiguration | Object | VPC settings (required for awsvpc) |
+| loadBalancers | Array | Load balancer configuration |
+| placementStrategy | Array | Placement strategies (max 5) |
+| placementConstraints | Array | Placement constraints (max 10) |
+| healthCheckGracePeriodSeconds | Integer | Health check grace period (seconds) |
+| enableExecuteCommand | Boolean | Enable Execute Command |
+| enableECSManagedTags | Boolean | Enable ECS managed tags |
+| propagateTags | String | TASK_DEFINITION/SERVICE/NONE |
+| serviceConnectConfiguration | Object | Service Connect settings |
+| volumeConfigurations | Array | EBS volume settings (REPLICA only) |
+| availabilityZoneRebalancing | String | ENABLED/DISABLED |
+| clientToken | String | Idempotency token (max 36 chars) |
+
+### Deployment Strategies
+
+#### ROLLING (Rolling Update)
+```json
+{
+  "deploymentConfiguration": {
+    "strategy": "ROLLING",
+    "maximumPercent": 200,
+    "minimumHealthyPercent": 100
+  }
+}
+```
+
+#### BLUE_GREEN
+```json
+{
+  "deploymentConfiguration": {
+    "strategy": "BLUE_GREEN"
+  },
+  "loadBalancers": [{...}]  // Required
+}
+```
+
+#### LINEAR
+```json
+{
+  "deploymentConfiguration": {
+    "strategy": "LINEAR",
+    "linearConfiguration": {
+      "stepPercent": 10,
+      "stepBakeTimeInMinutes": 5
+    }
+  }
+}
+```
+
+#### CANARY
+```json
+{
+  "deploymentConfiguration": {
+    "strategy": "CANARY",
+    "canaryConfiguration": {
+      "canaryPercent": 10,
+      "canaryBakeTimeInMinutes": 5
+    }
+  }
+}
+```
+
+### Network Configuration (required for awsvpc)
+```json
+{
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-xxx"],
+      "securityGroups": ["sg-xxx"],
+      "assignPublicIp": "ENABLED|DISABLED"
+    }
+  }
+}
+```
+
+### Load Balancer Configuration
+```json
+{
+  "loadBalancers": [{
+    "targetGroupArn": "arn:aws:elasticloadbalancing:...",
+    "containerName": "app",
+    "containerPort": 80,
+    "advancedConfiguration": {
+      "alternateTargetGroupArn": "string",
+      "productionListenerRule": "string",
+      "testListenerRule": "string",
+      "roleArn": "string"
+    }
+  }]
+}
+```
+
+### Placement Strategies
+```json
+{
+  "placementStrategy": [
+    {"type": "spread", "field": "attribute:ecs.availability-zone"},
+    {"type": "binpack", "field": "memory"}
+  ],
+  "placementConstraints": [
+    {"type": "distinctInstance"}
+  ]
+}
+```
+Types:
+- spread: Distribute across instances
+- binpack: Maximize resource utilization
+- random: Random placement
+- distinctInstance: One task per instance
+- memberOf: Attribute matching
+
+### Service Connect Configuration
+```json
+{
+  "serviceConnectConfiguration": {
+    "enabled": true,
+    "namespace": "my-namespace",
+    "logConfiguration": {...},
+    "services": [{
+      "portName": "http",
+      "discoveryName": "backend",
+      "clientAliases": [{
+        "port": 80,
+        "dnsName": "backend.internal"
+      }],
+      "timeout": {
+        "idleTimeoutSeconds": 60,
+        "perRequestTimeoutSeconds": 5
+      },
+      "tls": {...}
+    }]
+  }
+}
+```
+
+### Response - Service Object
+```json
+{
+  "service": {
+    "serviceArn": "string",
+    "serviceName": "string",
+    "clusterArn": "string",
+    "status": "ACTIVE|DRAINING|INACTIVE",
+    "desiredCount": number,
+    "runningCount": number,
+    "pendingCount": number,
+    "taskDefinition": "string",
+    "launchType": "string",
+    "platformFamily": "string",
+    "platformVersion": "string",
+    "schedulingStrategy": "REPLICA|DAEMON",
+    "deploymentController": {"type": "ECS|CODE_DEPLOY|EXTERNAL"},
+    "deploymentConfiguration": {...},
+    "deployments": [{
+      "id": "string",
+      "status": "PRIMARY|ACTIVE|INACTIVE",
+      "taskDefinition": "string",
+      "desiredCount": number,
+      "pendingCount": number,
+      "runningCount": number,
+      "failedTasks": number,
+      "createdAt": number,
+      "updatedAt": number,
+      "rolloutState": "COMPLETED|IN_PROGRESS|FAILED",
+      "rolloutStateReason": "string"
+    }],
+    "loadBalancers": [...],
+    "networkConfiguration": {...},
+    "events": [...],
+    "createdAt": number,
+    "createdBy": "string",
+    "tags": [...]
+  }
+}
+```
+
+---
+
+## DescribeServices
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | No | Cluster name/ARN |
+| services | Array[String] | Yes | Max 10 service names/ARNs |
+| include | Array[String] | No | TAGS |
+
+### Response
+```json
+{
+  "services": [Service],
+  "failures": [Failure]
+}
+```
+
+---
+
+## UpdateService
+
+### Request (Key Parameters)
+| Parameter | Type | Required | Triggers New Deployment |
+|-----------|------|----------|------------------------|
+| service | String | Yes | - |
+| cluster | String | No | No |
+| desiredCount | Integer | No | No |
+| taskDefinition | String | No | Yes |
+| forceNewDeployment | Boolean | No | Yes |
+| networkConfiguration | Object | No | Yes |
+| loadBalancers | Array | No | Yes |
+| platformVersion | String | No | Yes |
+| serviceConnectConfiguration | Object | No | Yes |
+
+### forceNewDeployment Use Cases
+- Pull new image with same image:tag
+- Update Fargate platform
+- Apply tag propagation settings to all tasks
+
+### SIGTERM/SIGKILL Processing
+1. When stopping tasks, SIGTERM is sent to containers
+2. 30 second timeout
+3. SIGKILL sent if not terminated within 30 seconds
+
+---
+
+## DeleteService
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | No | Cluster name/ARN |
+| service | String | Yes | Service name |
+| force | Boolean | No | Delete even if task count > 0 (REPLICA only) |
+
+### Deletion Conditions
+- No running tasks, or desiredCount=0
+- Or force=true
+
+### Status Transition
+```
+ACTIVE -> DRAINING -> INACTIVE
+```
+
+---
+
+## ListServices
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | No | Cluster name/ARN |
+| launchType | String | No | EC2/FARGATE/EXTERNAL/MANAGED_INSTANCES |
+| maxResults | Integer | No | 1-100 (default 10) |
+| nextToken | String | No | Pagination token |
+| schedulingStrategy | String | No | REPLICA/DAEMON |
+| resourceManagementType | String | No | CUSTOMER/ECS |
+
+### Response
+```json
+{
+  "serviceArns": ["string"],
+  "nextToken": "string"
+}
+```
+
+---
+
+## Specific Errors
+- AccessDeniedException
+- PlatformTaskDefinitionIncompatibilityException
+- PlatformUnknownException
+- UnsupportedFeatureException
+- NamespaceNotFoundException
+- ServiceNotActiveException

--- a/.claude/skills/ecs-api-reference/task-api.md
+++ b/.claude/skills/ecs-api-reference/task-api.md
@@ -1,0 +1,264 @@
+# ECS Task API Specifications
+
+## RunTask
+
+### Required Parameters
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| taskDefinition | String | family:revision or ARN (uses latest ACTIVE if not specified) |
+
+### Key Optional Parameters
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| cluster | String | Cluster name/ARN |
+| count | Integer | Number of tasks to start (max 10) |
+| launchType | String | EC2/FARGATE/EXTERNAL/MANAGED_INSTANCES |
+| capacityProviderStrategy | Array | Max 20 (mutually exclusive with launchType) |
+| networkConfiguration | Object | Required for awsvpc |
+| overrides | Object | Container setting overrides |
+| placementConstraints | Array | Placement constraints (max 10) |
+| placementStrategy | Array | Placement strategies (max 5) |
+| tags | Array | Tags (max 50) |
+| enableExecuteCommand | Boolean | Enable Execute Command |
+| propagateTags | String | TASK_DEFINITION/SERVICE/NONE |
+| clientToken | String | Idempotency ID (max 64 chars) |
+
+### Overrides Structure
+```json
+{
+  "overrides": {
+    "containerOverrides": [{
+      "name": "container-name",
+      "command": ["string"],
+      "environment": [{"name": "ENV", "value": "val"}],
+      "environmentFiles": [{"type": "s3", "value": "arn:..."}],
+      "cpu": number,
+      "memory": number,
+      "memoryReservation": number,
+      "resourceRequirements": [{
+        "type": "GPU|InferenceAccelerator",
+        "value": "string"
+      }]
+    }],
+    "cpu": "string",
+    "memory": "string",
+    "taskRoleArn": "string",
+    "executionRoleArn": "string",
+    "ephemeralStorage": {"sizeInGiB": number},
+    "inferenceAcceleratorOverrides": [...]
+  }
+}
+```
+
+### Response
+```json
+{
+  "tasks": [{
+    "taskArn": "string",
+    "taskDefinitionArn": "string",
+    "clusterArn": "string",
+    "desiredStatus": "RUNNING|PENDING|STOPPED",
+    "lastStatus": "string",
+    "containers": [{
+      "containerArn": "string",
+      "name": "string",
+      "lastStatus": "string"
+    }],
+    "createdAt": number,
+    "launchType": "string",
+    "platformVersion": "string",
+    "startedAt": number,
+    "stoppedAt": number,
+    "tags": [...]
+  }],
+  "failures": [{
+    "arn": "string",
+    "reason": "string",
+    "detail": "string"
+  }]
+}
+```
+
+### Specific Errors
+- BlockedException (AWS account blocked)
+- ConflictException (another RunTask with same clientToken in progress)
+
+### Important Notes
+1. **Eventual Consistency Model**: Results may not be immediately reflected
+   - Solution: Check state with DescribeTasks (exponential backoff, max 5 minutes)
+2. **capacityProviderStrategy vs launchType**: Mutually exclusive, cannot specify both
+3. **Maximum 10 tasks per single call**
+
+---
+
+## StopTask
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| task | String | Yes | Task ARN |
+| cluster | String | No | Cluster name/ARN |
+| reason | String | No | Stop reason message |
+
+### Response
+```json
+{
+  "task": {
+    "taskArn": "string",
+    "desiredStatus": "STOPPED",
+    "lastStatus": "string",
+    "stopCode": "UserInitiated|...",
+    "stoppedReason": "string",
+    "stoppingAt": number,
+    ...
+  }
+}
+```
+
+### Signal Processing
+1. Issues docker stop equivalent
+2. Sends SIGTERM to container
+3. 30 second timeout
+4. SIGKILL if not terminated within 30 seconds
+- Timeout setting: ECS_CONTAINER_STOP_TIMEOUT
+- Windows containers: CTRL_SHUTDOWN_EVENT
+
+### Important Notes
+- All tags are deleted when task stops
+
+---
+
+## DescribeTasks
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | No | Cluster name/ARN |
+| tasks | Array[String] | Yes | Max 100 task IDs/ARNs |
+| include | Array[String] | No | TAGS |
+
+### Task Object Key Fields
+| Field | Type | Description |
+|-------|------|-------------|
+| taskArn | String | Task ARN |
+| clusterArn | String | Cluster ARN |
+| taskDefinitionArn | String | Task definition ARN |
+| containers | Array | Container information |
+| lastStatus | String | Last status |
+| desiredStatus | String | Desired state |
+| launchType | String | Launch type |
+| platformVersion | String | Platform version |
+| platformFamily | String | Platform family |
+| cpu | String | CPU allocation |
+| memory | String | Memory allocation |
+| createdAt | Number | Creation time |
+| startedAt | Number | Start time |
+| stoppedAt | Number | Stop time |
+| stoppedReason | String | Stop reason |
+| healthStatus | String | UNKNOWN/HEALTHY/UNHEALTHY |
+| attachments | Array | Connection info (ENI, etc.) |
+| ephemeralStorage | Object | Ephemeral storage |
+| enableExecuteCommand | Boolean | ExecuteCommand enabled |
+
+### lastStatus Values
+- PROVISIONING
+- PENDING
+- ACTIVATING
+- RUNNING
+- DEACTIVATING
+- STOPPING
+- DEPROVISIONING
+- STOPPED
+
+### Container Object
+```json
+{
+  "containerArn": "string",
+  "name": "string",
+  "image": "string",
+  "imageDigest": "string",
+  "runtimeId": "string",
+  "lastStatus": "string",
+  "exitCode": number,
+  "reason": "string",
+  "healthStatus": "string",
+  "cpu": "string",
+  "memory": "string",
+  "networkBindings": [...],
+  "networkInterfaces": [...],
+  "managedAgents": [...]
+}
+```
+
+### Important Notes
+- Stopped tasks are included in response for at least 1 hour
+- Tagged tasks from deleted clusters are not returned even with same-named new clusters
+
+---
+
+## ListTasks
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | No | Cluster name/ARN |
+| containerInstance | String | No | Container instance ID/ARN |
+| desiredStatus | String | No | RUNNING/PENDING/STOPPED (default: RUNNING) |
+| family | String | No | Task definition family name |
+| launchType | String | No | EC2/FARGATE/EXTERNAL/MANAGED_INSTANCES |
+| maxResults | Integer | No | 1-100 (default 100) |
+| nextToken | String | No | Pagination token |
+| serviceName | String | No | Service name |
+| startedBy | String | No | Task starter (standalone filter only) |
+
+### Response
+```json
+{
+  "taskArns": ["string"],
+  "nextToken": "string"
+}
+```
+
+### Important Notes
+- desiredStatus=PENDING can be specified but returns no results
+- startedBy cannot be combined with other filters
+- Recently stopped tasks may be included
+
+---
+
+## ExecuteCommand
+
+### Request
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| cluster | String | No | Cluster name/ARN |
+| command | String | Yes | Command to execute |
+| container | String | No | Container name (required for multi-container tasks) |
+| interactive | Boolean | Yes | Must be true |
+| task | String | Yes | Task ARN/ID |
+
+### Response
+```json
+{
+  "clusterArn": "string",
+  "taskArn": "string",
+  "containerArn": "string",
+  "containerName": "string",
+  "interactive": true,
+  "session": {
+    "sessionId": "string",
+    "streamUrl": "wss://...",
+    "tokenValue": "string"
+  }
+}
+```
+
+### Specific Errors
+- TargetNotConnectedException
+  - Invalid IAM permissions
+  - SSM agent not installed/running
+  - Session Manager VPC endpoint not configured
+
+### Prerequisites
+- Task started with enableExecuteCommand=true
+- AWS SSM Session Manager integration

--- a/.claude/skills/ecs-api-reference/task-definition-api.md
+++ b/.claude/skills/ecs-api-reference/task-definition-api.md
@@ -1,0 +1,317 @@
+# ECS Task Definition API Specifications
+
+## RegisterTaskDefinition
+
+### Required Parameters
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| family | String | Task definition family name (max 255 chars: alphanumeric, underscore, hyphen) |
+| containerDefinitions | Array | Container definition array |
+
+### Key Optional Parameters
+| Parameter | Type | Description | Notes |
+|-----------|------|-------------|-------|
+| cpu | String | Task CPU units (e.g., `1024` or `1 vCPU`) | Required for Fargate |
+| memory | String | Memory (MiB) (e.g., `512` or `1GB`) | Required for Fargate |
+| networkMode | String | none/bridge/awsvpc/host | awsvpc required for Fargate |
+| taskRoleArn | String | Task IAM Role ARN | Used by containers |
+| executionRoleArn | String | Task execution Role ARN | For ECS Agent permissions |
+| volumes | Array | Volume definitions (Docker/EFS/FSx, etc.) | - |
+| tags | Array | Metadata (max 50) | Key/value pairs |
+| ephemeralStorage | Object | Ephemeral storage allocation | Fargate Linux 1.4.0+ |
+| requiresCompatibilities | Array | Launch type validation: EC2/FARGATE/EXTERNAL/MANAGED_INSTANCES | - |
+| runtimePlatform | Object | OS/CPU architecture | cpuArchitecture/operatingSystemFamily |
+| pidMode | String | Process namespace: host/task | Not supported on Windows/Fargate Windows |
+| ipcMode | String | IPC namespace: host/task/none | Not supported on Windows/Fargate |
+| proxyConfiguration | Object | App Mesh proxy settings | - |
+| inferenceAccelerators | Array | Elastic Inference accelerators | - |
+| placementConstraints | Array | Placement constraints (max 10) | - |
+| enableFaultInjection | Boolean | Enable fault injection (default: false) | - |
+
+### containerDefinitions Parameter Details
+```json
+{
+  "name": "string",           // Required: Container name
+  "image": "string",          // Required: Image URI
+  "cpu": number,              // CPU units
+  "memory": number,           // Memory (MiB)
+  "memoryReservation": number,// Soft memory limit
+  "essential": boolean,       // Default: true
+  "portMappings": [
+    {
+      "containerPort": number,
+      "hostPort": number,
+      "protocol": "tcp|udp",
+      "appProtocol": "string",
+      "name": "string",
+      "containerPortRange": "string"
+    }
+  ],
+  "environment": [
+    {
+      "name": "string",
+      "value": "string"
+    }
+  ],
+  "environmentFiles": [
+    {
+      "type": "s3",
+      "value": "arn:aws:s3:::..."
+    }
+  ],
+  "command": ["string"],      // CMD instruction
+  "entryPoint": ["string"],   // ENTRYPOINT
+  "workingDirectory": "string",
+  "user": "string",           // Execution user
+  "logConfiguration": {
+    "logDriver": "awslogs|splunk|awsfirelens",
+    "options": {},
+    "secretOptions": []       // From Secrets Manager
+  },
+  "healthCheck": {
+    "command": ["CMD-SHELL", "curl -f http://localhost/"],
+    "interval": 30,           // seconds
+    "timeout": 5,             // seconds
+    "retries": 3,
+    "startPeriod": 0          // seconds
+  },
+  "mountPoints": [
+    {
+      "sourceVolume": "string",
+      "containerPath": "string",
+      "readOnly": boolean
+    }
+  ],
+  "volumesFrom": [
+    {
+      "sourceContainer": "string",
+      "readOnly": boolean
+    }
+  ],
+  "linuxParameters": {
+    "capabilities": {
+      "add": ["string"],
+      "drop": ["string"]
+    },
+    "devices": [],
+    "initProcessEnabled": boolean,
+    "maxSwap": number,
+    "sharedMemorySize": number,
+    "swappiness": number,
+    "tmpfs": []
+  },
+  "privileged": boolean,
+  "readonlyRootFilesystem": boolean,
+  "interactive": boolean,
+  "pseudoTerminal": boolean,
+  "restartPolicy": {
+    "enabled": boolean,
+    "restartAttemptPeriod": number,
+    "ignoredExitCodes": [number]
+  },
+  "secrets": [
+    {
+      "name": "string",
+      "valueFrom": "arn:aws:secretsmanager:..."
+    }
+  ],
+  "dependsOn": [
+    {
+      "containerName": "string",
+      "condition": "START|COMPLETE|SUCCESS|HEALTHY"
+    }
+  ]
+}
+```
+
+### Fargate Memory/CPU Combinations
+```
+CPU 0.25 vCPU (256):  512MB, 1GB, 2GB
+CPU 0.5 vCPU (512):   1GB-4GB (1GB increments)
+CPU 1 vCPU (1024):    2GB-8GB (1GB increments)
+CPU 2 vCPU (2048):    4GB-16GB (1GB increments)
+CPU 4 vCPU (4096):    8GB-30GB (1GB increments)
+CPU 8 vCPU (8192):    16GB-60GB (4GB increments) *Linux 1.4.0+
+CPU 16 vCPU (16384):  32GB-120GB (8GB increments) *Linux 1.4.0+
+```
+
+### Response Structure
+```json
+{
+  "taskDefinition": {
+    "family": "string",
+    "taskDefinitionArn": "arn:aws:ecs:region:account:task-definition/family:revision",
+    "revision": number,
+    "status": "ACTIVE|INACTIVE",
+    "registeredAt": number,           // Unix timestamp
+    "deregisteredAt": number,
+    "registeredBy": "string",
+    "containerDefinitions": [...],
+    "cpu": "string",
+    "memory": "string",
+    "networkMode": "string",
+    "taskRoleArn": "string",
+    "executionRoleArn": "string",
+    "requiresAttributes": [
+      {
+        "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18",
+        "targetId": "string",
+        "targetType": "container-instance",
+        "value": "string"
+      }
+    ],
+    "requiresCompatibilities": ["EC2"|"FARGATE"|"EXTERNAL"],
+    "runtimePlatform": {
+      "cpuArchitecture": "X86_64|ARM64",
+      "operatingSystemFamily": "LINUX|WINDOWS_SERVER_2019_*"
+    },
+    "volumes": [...],
+    "placementConstraints": [...],
+    "compatibilities": ["EC2"|"FARGATE"],
+    "ephemeralStorage": {
+      "sizeInGiB": number
+    },
+    "enableFaultInjection": boolean
+  },
+  "tags": [
+    {
+      "key": "string",
+      "value": "string"
+    }
+  ]
+}
+```
+
+### Important Constraints
+
+#### Windows Containers
+- Task-level CPU/Memory parameters are ignored -> **Must specify at container level**
+- pidMode, ipcMode not supported
+
+#### Fargate
+- networkMode: **awsvpc required**
+- cpu, memory: Required
+- requiresCompatibilities: `["FARGATE"]` recommended
+
+#### EC2
+- cpu, memory: Optional
+- CPU: 128-196608 CPU units (0.125-192 vCPUs)
+
+#### Network Mode `awsvpc`
+- NetworkConfiguration required in `RunTask`/`CreateService`
+
+---
+
+## DeregisterTaskDefinition
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| taskDefinition | String | Yes | family:revision or full ARN. Revision is required |
+
+### Response
+Returns TaskDefinition object with status: "INACTIVE"
+
+### Allowed Operations
+- Existing tasks/services continue running without interruption
+- Services referencing INACTIVE task definitions can adjust scale (desiredCount changes)
+
+### Disallowed Operations
+- Run new tasks with INACTIVE task definitions
+- Create new services with INACTIVE task definitions
+- Update services to reference INACTIVE task definitions
+
+### Important Notes
+- **10-minute grace period**: Restrictions may not take effect for up to 10 minutes after deregistration
+- **Persistence**: INACTIVE task definitions are currently discoverable indefinitely, but this may change
+- **Deletion prerequisite**: Deregistration required before deletion (`DeleteTaskDefinitions`)
+
+---
+
+## DescribeTaskDefinition
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| taskDefinition | String | Yes | Identifier: `family` (latest ACTIVE), `family:revision`, or full ARN |
+| include | Array[String] | No | `TAGS` to include resource tags |
+
+### Response
+```json
+{
+  "taskDefinition": {...},  // TaskDefinition object
+  "tags": [...]             // Only if include: ["TAGS"]
+}
+```
+
+### Important Notes
+- INACTIVE task definitions can only be described if active tasks or services reference them
+
+---
+
+## ListTaskDefinitions
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| familyPrefix | String | No | Filter by family name |
+| maxResults | Integer | No | 1-100 (default: max 100) |
+| nextToken | String | No | Pagination token |
+| sort | String | No | ASC (default) / DESC |
+| status | String | No | ACTIVE (default) / INACTIVE / DELETE_IN_PROGRESS |
+
+### Response
+```json
+{
+  "taskDefinitionArns": [
+    "arn:aws:ecs:region:account:task-definition/family:1",
+    "arn:aws:ecs:region:account:task-definition/family:2"
+  ],
+  "nextToken": "string"
+}
+```
+
+### Sort Behavior
+- Default (ASC): Alphabetical by family name, ascending by revision (latest last)
+- DESC: Reverse alphabetical, descending by revision (latest first)
+
+---
+
+## ListTaskDefinitionFamilies
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| familyPrefix | String | No | Filter by prefix |
+| maxResults | Integer | No | 1-100 |
+| nextToken | String | No | Pagination token |
+| status | String | No | ACTIVE (default) / INACTIVE / ALL |
+
+### Response
+```json
+{
+  "families": ["family1", "family2"],
+  "nextToken": "string"
+}
+```
+
+---
+
+## DeleteTaskDefinitions
+
+### Request Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| taskDefinitions | Array[String] | Yes | Max 10 task definition ARNs |
+
+### Prerequisites
+- Task definition must be INACTIVE (deregistered)
+- No running tasks or services referencing it
+
+### Response
+```json
+{
+  "taskDefinitions": [...],
+  "failures": [...]
+}
+```


### PR DESCRIPTION
## Summary
- Add comprehensive ECS API reference documentation as Claude Code skills
- Skills provide accurate request/response structures, parameters, error codes, and behaviors for implementing ECS-compatible APIs in KECS

## Skills Structure
```
.claude/skills/ecs-api-reference/
├── SKILL.md              - Main skill file with overview and common specs
├── cluster-api.md        - CreateCluster, DescribeClusters, ListClusters, etc.
├── service-api.md        - CreateService, UpdateService, deployment strategies, etc.
├── task-api.md           - RunTask, StopTask, DescribeTasks, ExecuteCommand, etc.
├── task-definition-api.md - RegisterTaskDefinition, container definitions, etc.
└── other-apis.md         - Tags, TaskSets, Attributes, Account Settings, Capacity Providers
```

## Use Cases
- Implementing new ECS API endpoints
- Verifying request/response structures of existing APIs
- Aligning error codes and behaviors with AWS ECS
- Writing API compatibility tests

## Test plan
- [x] Skills files are properly formatted
- [x] Skills directory structure follows Claude Code conventions
- [x] Existing tests pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)