### PR TITLE
feat: Add AWS CLI ECS command reference skills

### DIFF
--- a/.claude/skills/ecs-cli-reference/SKILL.md
+++ b/.claude/skills/ecs-cli-reference/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ecs-cli-reference
+description: AWS CLI ECS command reference. Use when understanding how users interact with ECS via AWS CLI, including command syntax, options, examples, and output formats. Essential for KECS compatibility.
+allowed-tools: Read, Grep, Glob
+---
+
+# AWS CLI ECS Command Reference
+
+This skill provides comprehensive AWS CLI ECS command specifications to ensure KECS compatibility with user expectations when using `aws ecs` commands.
+
+## Overview
+
+AWS CLI ECS commands allow users to interact with Amazon ECS services. KECS emulates these APIs, so understanding CLI behavior is crucial for compatibility.
+
+### Global CLI Options
+
+All ECS commands support these global options:
+
+| Option | Description |
+|--------|-------------|
+| `--region` | AWS region to use |
+| `--profile` | Named credential profile |
+| `--output` | Output format: `json`, `text`, `table`, `yaml`, `yaml-stream` |
+| `--query` | JMESPath filter for response |
+| `--endpoint-url` | Override service endpoint (critical for KECS) |
+| `--debug` | Enable debug logging |
+| `--no-verify-ssl` | Disable SSL verification |
+| `--no-paginate` | Disable automatic pagination |
+
+### Pagination Options
+
+For paginated operations:
+- `--max-items`: Total items to return
+- `--page-size`: Items per API call
+- `--starting-token`: Resume from previous response
+
+### Input Options
+
+- `--cli-input-json`: Read arguments from JSON
+- `--cli-input-yaml`: Read arguments from YAML
+- `--generate-cli-skeleton`: Print request skeleton
+
+## Command Categories
+
+### Core Resources
+- **Cluster Commands**: create-cluster, describe-clusters, list-clusters, delete-cluster, update-cluster
+- **Service Commands**: create-service, describe-services, list-services, update-service, delete-service
+- **Task Commands**: run-task, stop-task, describe-tasks, list-tasks, execute-command
+- **Task Definition Commands**: register-task-definition, deregister-task-definition, describe-task-definition, list-task-definitions, list-task-definition-families
+
+### Advanced Features
+- **TaskSet Commands**: create-task-set, describe-task-sets, update-task-set, delete-task-set
+- **Capacity Provider Commands**: create-capacity-provider, describe-capacity-providers, update-capacity-provider, delete-capacity-provider, put-cluster-capacity-providers
+- **Attribute Commands**: put-attributes, list-attributes, delete-attributes
+- **Tag Commands**: tag-resource, untag-resource, list-tags-for-resource
+- **Account Settings**: put-account-setting, put-account-setting-default, list-account-settings, delete-account-setting
+
+## KECS-Specific Usage
+
+When using AWS CLI with KECS:
+
+```bash
+# Point to KECS endpoint
+export AWS_ENDPOINT_URL=http://localhost:8080
+
+# Or per-command
+aws ecs list-clusters --endpoint-url http://localhost:8080
+
+# With custom kubeconfig
+export KUBECONFIG=/tmp/kecs-instance.config
+aws ecs describe-clusters --cluster default
+```
+
+## Support Files
+
+- `cluster-commands.md`: Cluster lifecycle commands
+- `service-commands.md`: Service management commands
+- `task-commands.md`: Task execution and management
+- `task-definition-commands.md`: Task definition registration
+- `other-commands.md`: Tags, attributes, account settings, capacity providers, task sets

--- a/.claude/skills/ecs-cli-reference/cluster-commands.md
+++ b/.claude/skills/ecs-cli-reference/cluster-commands.md
@@ -1,0 +1,230 @@
+# ECS Cluster CLI Commands
+
+## create-cluster
+
+### Synopsis
+```bash
+aws ecs create-cluster \
+    [--cluster-name <value>] \
+    [--tags <value>] \
+    [--settings <value>] \
+    [--configuration <value>] \
+    [--capacity-providers <value>] \
+    [--default-capacity-provider-strategy <value>] \
+    [--service-connect-defaults <value>]
+```
+
+### Key Options
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--cluster-name` | string | No | Cluster name (max 255 chars). Default: `default` |
+| `--tags` | list | No | Key-value metadata (max 50) |
+| `--settings` | list | No | Container Insights settings |
+| `--configuration` | structure | No | Execute command and storage config |
+| `--capacity-providers` | list | No | FARGATE, FARGATE_SPOT, or custom |
+| `--default-capacity-provider-strategy` | list | No | Default strategy |
+| `--service-connect-defaults` | structure | No | Service Connect namespace |
+
+### Settings Structure
+```json
+[
+  {
+    "name": "containerInsights",
+    "value": "enabled|disabled|enhanced"
+  }
+]
+```
+
+### Configuration Structure
+```json
+{
+  "executeCommandConfiguration": {
+    "kmsKeyId": "string",
+    "logging": "NONE|DEFAULT|OVERRIDE",
+    "logConfiguration": {
+      "cloudWatchLogGroupName": "string",
+      "cloudWatchEncryptionEnabled": true,
+      "s3BucketName": "string",
+      "s3EncryptionEnabled": true,
+      "s3KeyPrefix": "string"
+    }
+  },
+  "managedStorageConfiguration": {
+    "kmsKeyId": "string",
+    "fargateEphemeralStorageKmsKeyId": "string"
+  }
+}
+```
+
+### Example
+```bash
+aws ecs create-cluster \
+    --cluster-name MyCluster \
+    --settings name=containerInsights,value=enabled \
+    --capacity-providers FARGATE FARGATE_SPOT \
+    --default-capacity-provider-strategy capacityProvider=FARGATE,weight=1,base=1
+```
+
+### Output
+```json
+{
+  "cluster": {
+    "clusterArn": "arn:aws:ecs:region:account:cluster/MyCluster",
+    "clusterName": "MyCluster",
+    "status": "ACTIVE",
+    "registeredContainerInstancesCount": 0,
+    "runningTasksCount": 0,
+    "pendingTasksCount": 0,
+    "activeServicesCount": 0,
+    "capacityProviders": ["FARGATE", "FARGATE_SPOT"],
+    "defaultCapacityProviderStrategy": [...],
+    "settings": [{"name": "containerInsights", "value": "enabled"}],
+    "tags": []
+  }
+}
+```
+
+---
+
+## describe-clusters
+
+### Synopsis
+```bash
+aws ecs describe-clusters \
+    [--clusters <value>] \
+    [--include <value>]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--clusters` | list | Max 100 cluster names/ARNs. Default: default cluster |
+| `--include` | list | Additional info: `ATTACHMENTS`, `CONFIGURATIONS`, `SETTINGS`, `STATISTICS`, `TAGS` |
+
+### Example
+```bash
+aws ecs describe-clusters \
+    --clusters MyCluster \
+    --include SETTINGS STATISTICS TAGS
+```
+
+### Output
+```json
+{
+  "clusters": [
+    {
+      "clusterArn": "string",
+      "clusterName": "string",
+      "status": "ACTIVE|PROVISIONING|DEPROVISIONING|FAILED|INACTIVE",
+      "registeredContainerInstancesCount": 0,
+      "runningTasksCount": 0,
+      "pendingTasksCount": 0,
+      "activeServicesCount": 0,
+      "statistics": [
+        {"name": "runningEC2TasksCount", "value": "0"},
+        {"name": "runningFargateTasksCount", "value": "0"}
+      ],
+      "tags": []
+    }
+  ],
+  "failures": []
+}
+```
+
+---
+
+## list-clusters
+
+### Synopsis
+```bash
+aws ecs list-clusters \
+    [--max-items <value>] \
+    [--starting-token <value>]
+```
+
+### Options (Pagination)
+| Option | Type | Description |
+|--------|------|-------------|
+| `--max-items` | integer | Max total items (1-100) |
+| `--page-size` | integer | Items per API call |
+| `--starting-token` | string | Pagination token |
+
+### Example
+```bash
+aws ecs list-clusters --max-items 10
+```
+
+### Output
+```json
+{
+  "clusterArns": [
+    "arn:aws:ecs:us-west-2:123456789012:cluster/default",
+    "arn:aws:ecs:us-west-2:123456789012:cluster/MyCluster"
+  ],
+  "nextToken": "string"
+}
+```
+
+---
+
+## delete-cluster
+
+### Synopsis
+```bash
+aws ecs delete-cluster --cluster <value>
+```
+
+### Prerequisites
+1. Deregister all container instances
+2. Delete all services (set desiredCount=0 first)
+3. Stop all tasks
+4. Remove capacity providers
+
+### Errors
+- `ClusterContainsContainerInstancesException`
+- `ClusterContainsServicesException`
+- `ClusterContainsTasksException`
+- `ClusterContainsCapacityProviderException`
+
+### Example
+```bash
+aws ecs delete-cluster --cluster MyCluster
+```
+
+---
+
+## update-cluster
+
+### Synopsis
+```bash
+aws ecs update-cluster \
+    --cluster <value> \
+    [--settings <value>] \
+    [--configuration <value>] \
+    [--service-connect-defaults <value>]
+```
+
+### Example
+```bash
+aws ecs update-cluster \
+    --cluster MyCluster \
+    --settings name=containerInsights,value=enhanced
+```
+
+---
+
+## update-cluster-settings
+
+### Synopsis
+```bash
+aws ecs update-cluster-settings \
+    --cluster <value> \
+    --settings <value>
+```
+
+### Example
+```bash
+aws ecs update-cluster-settings \
+    --cluster MyCluster \
+    --settings name=containerInsights,value=disabled
+```

--- a/.claude/skills/ecs-cli-reference/other-commands.md
+++ b/.claude/skills/ecs-cli-reference/other-commands.md
@@ -1,0 +1,498 @@
+# ECS Other CLI Commands
+
+## Tags Commands
+
+### tag-resource
+
+```bash
+aws ecs tag-resource \
+    --resource-arn <value> \
+    --tags <value>
+```
+
+**Options:**
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--resource-arn` | string | Yes | ARN of resource to tag |
+| `--tags` | list | Yes | Key-value pairs (max 50) |
+
+**Supported Resources:** capacity providers, tasks, services, task definitions, clusters, container instances
+
+**Service ARN Format:** Must use long format:
+```
+arn:aws:ecs:region:account:service/cluster-name/service-name
+```
+
+**Tag Constraints:**
+- Key: 1-128 chars
+- Value: 0-256 chars
+- Cannot use `aws:` prefix
+
+**Example:**
+```bash
+aws ecs tag-resource \
+    --resource-arn arn:aws:ecs:us-west-2:123456789012:cluster/MyCluster \
+    --tags key=environment,value=production key=team,value=backend
+```
+
+**Output:** None (HTTP 200 on success)
+
+---
+
+### untag-resource
+
+```bash
+aws ecs untag-resource \
+    --resource-arn <value> \
+    --tag-keys <value>
+```
+
+**Example:**
+```bash
+aws ecs untag-resource \
+    --resource-arn arn:aws:ecs:us-west-2:123456789012:cluster/MyCluster \
+    --tag-keys environment team
+```
+
+**Output:** None (HTTP 200 on success)
+
+---
+
+### list-tags-for-resource
+
+```bash
+aws ecs list-tags-for-resource \
+    --resource-arn <value>
+```
+
+**Example:**
+```bash
+aws ecs list-tags-for-resource \
+    --resource-arn arn:aws:ecs:us-west-2:123456789012:cluster/MyCluster
+```
+
+**Output:**
+```json
+{
+  "tags": [
+    {"key": "environment", "value": "production"},
+    {"key": "team", "value": "backend"}
+  ]
+}
+```
+
+---
+
+## Attributes Commands
+
+### put-attributes
+
+```bash
+aws ecs put-attributes \
+    --attributes <value> \
+    [--cluster <value>]
+```
+
+**Attribute Structure:**
+```json
+[
+  {
+    "name": "string",
+    "value": "string",
+    "targetType": "container-instance",
+    "targetId": "string"
+  }
+]
+```
+
+**Constraints:**
+- Max 10 attributes per resource
+- Max 10 attributes per call
+- Name: 1-128 chars
+- Value: 1-128 chars
+
+**Example:**
+```bash
+aws ecs put-attributes \
+    --attributes name=stack,value=production,targetId=arn:aws:ecs:us-west-2:123456789012:container-instance/abc123
+```
+
+**Output:**
+```json
+{
+  "attributes": [
+    {"name": "stack", "value": "production", "targetId": "..."}
+  ]
+}
+```
+
+---
+
+### list-attributes
+
+```bash
+aws ecs list-attributes \
+    --target-type <value> \
+    [--cluster <value>] \
+    [--attribute-name <value>] \
+    [--attribute-value <value>] \
+    [--max-items <value>]
+```
+
+**Options:**
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--target-type` | string | Yes | `container-instance` |
+| `--attribute-name` | string | No | Filter by name |
+| `--attribute-value` | string | No | Filter by value (requires name) |
+
+**Example:**
+```bash
+aws ecs list-attributes \
+    --target-type container-instance \
+    --attribute-name stack \
+    --attribute-value production
+```
+
+---
+
+### delete-attributes
+
+```bash
+aws ecs delete-attributes \
+    --attributes <value> \
+    [--cluster <value>]
+```
+
+**Example:**
+```bash
+aws ecs delete-attributes \
+    --attributes name=stack,targetId=arn:aws:ecs:us-west-2:123456789012:container-instance/abc123
+```
+
+---
+
+## Account Settings Commands
+
+### put-account-setting
+
+```bash
+aws ecs put-account-setting \
+    --name <value> \
+    --value <value> \
+    [--principal-arn <value>]
+```
+
+**Valid Setting Names:**
+| Name | Description | Values |
+|------|-------------|--------|
+| `serviceLongArnFormat` | Service ARN format | enabled/disabled |
+| `taskLongArnFormat` | Task ARN format | enabled/disabled |
+| `containerInstanceLongArnFormat` | Container instance ARN format | enabled/disabled |
+| `awsvpcTrunking` | ENI limit changes | enabled/disabled |
+| `containerInsights` | Container Insights | enabled/disabled/enhanced |
+| `dualStackIPv6` | IPv6 in dual-stack VPC | enabled/disabled |
+| `fargateTaskRetirementWaitPeriod` | Task retirement wait | 0/7/14 (days) |
+| `tagResourceAuthorization` | Tag authorization | enabled/disabled/on/off |
+| `defaultLogDriverMode` | Log driver mode | blocking/non-blocking |
+| `guardDutyActivate` | Runtime Monitoring | read-only |
+
+**Example:**
+```bash
+aws ecs put-account-setting \
+    --name containerInsights \
+    --value enhanced
+```
+
+**Output:**
+```json
+{
+  "setting": {
+    "name": "containerInsights",
+    "value": "enhanced",
+    "principalArn": "arn:aws:iam::123456789012:user/admin",
+    "type": "user"
+  }
+}
+```
+
+---
+
+### put-account-setting-default
+
+```bash
+aws ecs put-account-setting-default \
+    --name <value> \
+    --value <value>
+```
+
+Sets default for entire account (all users/roles).
+
+---
+
+### list-account-settings
+
+```bash
+aws ecs list-account-settings \
+    [--name <value>] \
+    [--value <value>] \
+    [--principal-arn <value>] \
+    [--effective-settings | --no-effective-settings] \
+    [--max-items <value>]
+```
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `--effective-settings` | boolean | Return root user or default settings |
+| `--name` | string | Filter by setting name |
+| `--principal-arn` | string | Filter by user/role ARN |
+
+**Example:**
+```bash
+aws ecs list-account-settings --effective-settings
+```
+
+---
+
+### delete-account-setting
+
+```bash
+aws ecs delete-account-setting \
+    --name <value> \
+    [--principal-arn <value>]
+```
+
+---
+
+## Capacity Provider Commands
+
+### create-capacity-provider
+
+```bash
+aws ecs create-capacity-provider \
+    --name <value> \
+    [--auto-scaling-group-provider <value>] \
+    [--tags <value>]
+```
+
+**Auto Scaling Group Provider:**
+```json
+{
+  "autoScalingGroupArn": "string",
+  "managedScaling": {
+    "status": "ENABLED|DISABLED",
+    "targetCapacity": 100,
+    "minimumScalingStepSize": 1,
+    "maximumScalingStepSize": 10000,
+    "instanceWarmupPeriod": 300
+  },
+  "managedTerminationProtection": "ENABLED|DISABLED",
+  "managedDraining": "ENABLED|DISABLED"
+}
+```
+
+**Example:**
+```bash
+aws ecs create-capacity-provider \
+    --name MyCapacityProvider \
+    --auto-scaling-group-provider \
+      "autoScalingGroupArn=arn:aws:autoscaling:...,managedScaling={status=ENABLED,targetCapacity=100}"
+```
+
+---
+
+### describe-capacity-providers
+
+```bash
+aws ecs describe-capacity-providers \
+    [--capacity-providers <value>] \
+    [--include <value>] \
+    [--max-results <value>]
+```
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `--capacity-providers` | list | Up to 100 names/ARNs |
+| `--include` | list | `TAGS` |
+| `--max-results` | integer | 1-10 |
+
+---
+
+### update-capacity-provider
+
+```bash
+aws ecs update-capacity-provider \
+    --name <value> \
+    --auto-scaling-group-provider <value>
+```
+
+---
+
+### delete-capacity-provider
+
+```bash
+aws ecs delete-capacity-provider \
+    --capacity-provider <value>
+```
+
+**Prerequisite:** Not associated with any cluster.
+
+---
+
+### put-cluster-capacity-providers
+
+```bash
+aws ecs put-cluster-capacity-providers \
+    --cluster <value> \
+    --capacity-providers <value> \
+    --default-capacity-provider-strategy <value>
+```
+
+Associates capacity providers with cluster and sets default strategy.
+
+**Example:**
+```bash
+aws ecs put-cluster-capacity-providers \
+    --cluster MyCluster \
+    --capacity-providers FARGATE FARGATE_SPOT \
+    --default-capacity-provider-strategy \
+      capacityProvider=FARGATE,weight=1,base=1 \
+      capacityProvider=FARGATE_SPOT,weight=1
+```
+
+---
+
+## TaskSet Commands
+
+TaskSets are used with services using the `EXTERNAL` deployment controller.
+
+### create-task-set
+
+```bash
+aws ecs create-task-set \
+    --cluster <value> \
+    --service <value> \
+    --task-definition <value> \
+    [--external-id <value>] \
+    [--network-configuration <value>] \
+    [--load-balancers <value>] \
+    [--service-registries <value>] \
+    [--launch-type <value>] \
+    [--capacity-provider-strategy <value>] \
+    [--platform-version <value>] \
+    [--scale <value>] \
+    [--client-token <value>] \
+    [--tags <value>]
+```
+
+**Scale Structure:**
+```json
+{
+  "value": 50.0,
+  "unit": "PERCENT"
+}
+```
+
+**Example:**
+```bash
+aws ecs create-task-set \
+    --cluster MyCluster \
+    --service MyService \
+    --task-definition my-app:2 \
+    --scale value=100,unit=PERCENT \
+    --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345]}"
+```
+
+---
+
+### describe-task-sets
+
+```bash
+aws ecs describe-task-sets \
+    --cluster <value> \
+    --service <value> \
+    [--task-sets <value>] \
+    [--include <value>]
+```
+
+**Output:**
+```json
+{
+  "taskSets": [
+    {
+      "id": "string",
+      "taskSetArn": "string",
+      "status": "PRIMARY|ACTIVE|DRAINING",
+      "taskDefinition": "string",
+      "computedDesiredCount": 2,
+      "pendingCount": 0,
+      "runningCount": 2,
+      "scale": {"value": 100.0, "unit": "PERCENT"},
+      "stabilityStatus": "STEADY_STATE|STABILIZING"
+    }
+  ],
+  "failures": []
+}
+```
+
+---
+
+### update-task-set
+
+```bash
+aws ecs update-task-set \
+    --cluster <value> \
+    --service <value> \
+    --task-set <value> \
+    --scale <value>
+```
+
+**Example:**
+```bash
+aws ecs update-task-set \
+    --cluster MyCluster \
+    --service MyService \
+    --task-set ecs-svc/123456789 \
+    --scale value=50,unit=PERCENT
+```
+
+---
+
+### delete-task-set
+
+```bash
+aws ecs delete-task-set \
+    --cluster <value> \
+    --service <value> \
+    --task-set <value> \
+    [--force | --no-force]
+```
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `--force` | boolean | Delete even if not scaled to zero |
+
+**Example:**
+```bash
+aws ecs delete-task-set \
+    --cluster MyCluster \
+    --service MyService \
+    --task-set ecs-svc/123456789 \
+    --force
+```
+
+---
+
+### update-service-primary-task-set
+
+```bash
+aws ecs update-service-primary-task-set \
+    --cluster <value> \
+    --service <value> \
+    --primary-task-set <value>
+```
+
+Sets which task set is PRIMARY (receives production traffic).

--- a/.claude/skills/ecs-cli-reference/service-commands.md
+++ b/.claude/skills/ecs-cli-reference/service-commands.md
@@ -1,0 +1,342 @@
+# ECS Service CLI Commands
+
+## create-service
+
+### Synopsis
+```bash
+aws ecs create-service \
+    --service-name <value> \
+    [--cluster <value>] \
+    [--task-definition <value>] \
+    [--desired-count <value>] \
+    [--launch-type <value>] \
+    [--capacity-provider-strategy <value>] \
+    [--platform-version <value>] \
+    [--scheduling-strategy <value>] \
+    [--deployment-controller <value>] \
+    [--deployment-configuration <value>] \
+    [--network-configuration <value>] \
+    [--load-balancers <value>] \
+    [--service-registries <value>] \
+    [--placement-constraints <value>] \
+    [--placement-strategy <value>] \
+    [--health-check-grace-period-seconds <value>] \
+    [--enable-execute-command | --disable-execute-command] \
+    [--enable-ecs-managed-tags | --no-enable-ecs-managed-tags] \
+    [--propagate-tags <value>] \
+    [--service-connect-configuration <value>] \
+    [--volume-configurations <value>] \
+    [--tags <value>] \
+    [--client-token <value>]
+```
+
+### Required Parameters
+| Option | Type | Description |
+|--------|------|-------------|
+| `--service-name` | string | Service name (max 255 chars) |
+
+### Key Optional Parameters
+| Option | Type | Description |
+|--------|------|-------------|
+| `--cluster` | string | Cluster name/ARN. Default: `default` |
+| `--task-definition` | string | family:revision or ARN |
+| `--desired-count` | integer | Number of tasks (required for REPLICA) |
+| `--launch-type` | string | EC2, FARGATE, EXTERNAL, MANAGED_INSTANCES |
+| `--scheduling-strategy` | string | REPLICA (default) or DAEMON |
+
+### Network Configuration (awsvpc)
+```json
+{
+  "awsvpcConfiguration": {
+    "subnets": ["subnet-xxx"],
+    "securityGroups": ["sg-xxx"],
+    "assignPublicIp": "ENABLED|DISABLED"
+  }
+}
+```
+
+### Deployment Configuration
+```json
+{
+  "deploymentCircuitBreaker": {
+    "enable": true,
+    "rollback": true
+  },
+  "maximumPercent": 200,
+  "minimumHealthyPercent": 100,
+  "alarms": {
+    "alarmNames": ["string"],
+    "enable": true,
+    "rollback": true
+  }
+}
+```
+
+### Load Balancer Configuration
+```json
+[
+  {
+    "targetGroupArn": "arn:aws:elasticloadbalancing:...",
+    "containerName": "app",
+    "containerPort": 80
+  }
+]
+```
+
+### Placement Strategy
+```json
+[
+  {"type": "spread", "field": "attribute:ecs.availability-zone"},
+  {"type": "binpack", "field": "memory"}
+]
+```
+Types: `spread`, `binpack`, `random`
+
+### Service Connect Configuration
+```json
+{
+  "enabled": true,
+  "namespace": "my-namespace",
+  "services": [
+    {
+      "portName": "http",
+      "discoveryName": "backend",
+      "clientAliases": [
+        {"port": 80, "dnsName": "backend.local"}
+      ]
+    }
+  ]
+}
+```
+
+### Example
+```bash
+aws ecs create-service \
+    --cluster MyCluster \
+    --service-name MyService \
+    --task-definition my-app:1 \
+    --desired-count 2 \
+    --launch-type FARGATE \
+    --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}" \
+    --load-balancers "targetGroupArn=arn:aws:elasticloadbalancing:...,containerName=app,containerPort=80"
+```
+
+### Output
+```json
+{
+  "service": {
+    "serviceArn": "arn:aws:ecs:region:account:service/cluster/service",
+    "serviceName": "MyService",
+    "clusterArn": "string",
+    "status": "ACTIVE",
+    "desiredCount": 2,
+    "runningCount": 0,
+    "pendingCount": 0,
+    "taskDefinition": "string",
+    "deployments": [...],
+    "events": []
+  }
+}
+```
+
+---
+
+## describe-services
+
+### Synopsis
+```bash
+aws ecs describe-services \
+    --services <value> \
+    [--cluster <value>] \
+    [--include <value>]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--services` | list | Max 10 service names/ARNs |
+| `--cluster` | string | Cluster name/ARN |
+| `--include` | list | `TAGS` |
+
+### Example
+```bash
+aws ecs describe-services \
+    --cluster MyCluster \
+    --services MyService \
+    --include TAGS
+```
+
+### Output
+```json
+{
+  "services": [
+    {
+      "serviceArn": "string",
+      "serviceName": "string",
+      "status": "ACTIVE|DRAINING|INACTIVE",
+      "desiredCount": 2,
+      "runningCount": 2,
+      "pendingCount": 0,
+      "taskDefinition": "string",
+      "deploymentConfiguration": {...},
+      "deployments": [
+        {
+          "id": "string",
+          "status": "PRIMARY|ACTIVE|INACTIVE",
+          "taskDefinition": "string",
+          "desiredCount": 2,
+          "runningCount": 2,
+          "rolloutState": "COMPLETED|IN_PROGRESS|FAILED"
+        }
+      ],
+      "events": [
+        {
+          "id": "string",
+          "createdAt": "timestamp",
+          "message": "string"
+        }
+      ]
+    }
+  ],
+  "failures": []
+}
+```
+
+---
+
+## list-services
+
+### Synopsis
+```bash
+aws ecs list-services \
+    [--cluster <value>] \
+    [--launch-type <value>] \
+    [--scheduling-strategy <value>] \
+    [--max-items <value>] \
+    [--starting-token <value>]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--cluster` | string | Cluster name/ARN |
+| `--launch-type` | string | EC2, FARGATE, EXTERNAL |
+| `--scheduling-strategy` | string | REPLICA or DAEMON |
+| `--max-items` | integer | Max items (1-100, default 10) |
+
+### Example
+```bash
+aws ecs list-services --cluster MyCluster --launch-type FARGATE
+```
+
+### Output
+```json
+{
+  "serviceArns": [
+    "arn:aws:ecs:region:account:service/cluster/service1",
+    "arn:aws:ecs:region:account:service/cluster/service2"
+  ],
+  "nextToken": "string"
+}
+```
+
+---
+
+## update-service
+
+### Synopsis
+```bash
+aws ecs update-service \
+    --service <value> \
+    [--cluster <value>] \
+    [--desired-count <value>] \
+    [--task-definition <value>] \
+    [--capacity-provider-strategy <value>] \
+    [--deployment-configuration <value>] \
+    [--network-configuration <value>] \
+    [--placement-constraints <value>] \
+    [--placement-strategy <value>] \
+    [--platform-version <value>] \
+    [--force-new-deployment | --no-force-new-deployment] \
+    [--health-check-grace-period-seconds <value>] \
+    [--enable-execute-command | --disable-execute-command] \
+    [--enable-ecs-managed-tags | --no-enable-ecs-managed-tags] \
+    [--load-balancers <value>] \
+    [--propagate-tags <value>] \
+    [--service-registries <value>] \
+    [--service-connect-configuration <value>] \
+    [--volume-configurations <value>]
+```
+
+### Triggers New Deployment
+- `--task-definition`
+- `--force-new-deployment`
+- `--network-configuration`
+- `--load-balancers`
+- `--platform-version`
+- `--service-connect-configuration`
+
+### Force New Deployment Use Cases
+- Pull new image with same tag
+- Update Fargate platform version
+- Apply tag propagation to existing tasks
+
+### Example: Scale Service
+```bash
+aws ecs update-service \
+    --cluster MyCluster \
+    --service MyService \
+    --desired-count 4
+```
+
+### Example: Update Task Definition
+```bash
+aws ecs update-service \
+    --cluster MyCluster \
+    --service MyService \
+    --task-definition my-app:2
+```
+
+### Example: Force Redeploy
+```bash
+aws ecs update-service \
+    --cluster MyCluster \
+    --service MyService \
+    --force-new-deployment
+```
+
+---
+
+## delete-service
+
+### Synopsis
+```bash
+aws ecs delete-service \
+    --service <value> \
+    [--cluster <value>] \
+    [--force | --no-force]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--service` | string | Service name/ARN |
+| `--cluster` | string | Cluster name/ARN |
+| `--force` | boolean | Delete even with running tasks (REPLICA only) |
+
+### Deletion Process
+```
+ACTIVE -> DRAINING -> INACTIVE
+```
+
+### Example
+```bash
+# Scale to 0 first (recommended)
+aws ecs update-service --cluster MyCluster --service MyService --desired-count 0
+
+# Then delete
+aws ecs delete-service --cluster MyCluster --service MyService
+
+# Or force delete
+aws ecs delete-service --cluster MyCluster --service MyService --force
+```

--- a/.claude/skills/ecs-cli-reference/task-commands.md
+++ b/.claude/skills/ecs-cli-reference/task-commands.md
@@ -1,0 +1,388 @@
+# ECS Task CLI Commands
+
+## run-task
+
+### Synopsis
+```bash
+aws ecs run-task \
+    --task-definition <value> \
+    [--cluster <value>] \
+    [--count <value>] \
+    [--launch-type <value>] \
+    [--capacity-provider-strategy <value>] \
+    [--platform-version <value>] \
+    [--network-configuration <value>] \
+    [--overrides <value>] \
+    [--placement-constraints <value>] \
+    [--placement-strategy <value>] \
+    [--group <value>] \
+    [--started-by <value>] \
+    [--tags <value>] \
+    [--enable-ecs-managed-tags | --no-enable-ecs-managed-tags] \
+    [--propagate-tags <value>] \
+    [--enable-execute-command | --disable-execute-command] \
+    [--reference-id <value>] \
+    [--volume-configurations <value>] \
+    [--client-token <value>]
+```
+
+### Required Parameters
+| Option | Type | Description |
+|--------|------|-------------|
+| `--task-definition` | string | family:revision or ARN. Uses latest ACTIVE if revision omitted |
+
+### Key Optional Parameters
+| Option | Type | Description |
+|--------|------|-------------|
+| `--cluster` | string | Cluster name/ARN. Default: `default` |
+| `--count` | integer | Number of tasks (1-10 per call) |
+| `--launch-type` | string | EC2, FARGATE, EXTERNAL, MANAGED_INSTANCES |
+| `--platform-version` | string | Fargate platform. Default: `LATEST` |
+| `--client-token` | string | Idempotency token (max 64 chars) |
+
+### Network Configuration (required for awsvpc)
+```json
+{
+  "awsvpcConfiguration": {
+    "subnets": ["subnet-xxx"],
+    "securityGroups": ["sg-xxx"],
+    "assignPublicIp": "ENABLED|DISABLED"
+  }
+}
+```
+- Max 16 subnets, 5 security groups
+
+### Task Overrides
+```json
+{
+  "containerOverrides": [
+    {
+      "name": "container-name",
+      "command": ["string"],
+      "environment": [{"name": "ENV", "value": "val"}],
+      "environmentFiles": [{"type": "s3", "value": "arn:..."}],
+      "cpu": 256,
+      "memory": 512,
+      "memoryReservation": 256,
+      "resourceRequirements": [
+        {"type": "GPU", "value": "1"}
+      ]
+    }
+  ],
+  "cpu": "1024",
+  "memory": "2048",
+  "taskRoleArn": "arn:aws:iam::...",
+  "executionRoleArn": "arn:aws:iam::...",
+  "ephemeralStorage": {"sizeInGiB": 30}
+}
+```
+- Total override character limit: 8192 bytes
+
+### Capacity Provider Strategy
+```json
+[
+  {
+    "capacityProvider": "FARGATE",
+    "weight": 1,
+    "base": 1
+  }
+]
+```
+- Mutually exclusive with `--launch-type`
+- Max 20 providers per strategy
+
+### Placement Strategy
+```json
+[
+  {"type": "spread", "field": "attribute:ecs.availability-zone"},
+  {"type": "binpack", "field": "memory"}
+]
+```
+- Max 5 strategies per task
+- Not supported with Fargate
+
+### Example: Run Fargate Task
+```bash
+aws ecs run-task \
+    --cluster MyCluster \
+    --task-definition my-app:1 \
+    --launch-type FARGATE \
+    --count 1 \
+    --network-configuration "awsvpcConfiguration={subnets=[subnet-12345],securityGroups=[sg-12345],assignPublicIp=ENABLED}"
+```
+
+### Example: Run with Overrides
+```bash
+aws ecs run-task \
+    --cluster MyCluster \
+    --task-definition my-app:1 \
+    --overrides '{
+      "containerOverrides": [{
+        "name": "app",
+        "command": ["./run-migration.sh"]
+      }]
+    }'
+```
+
+### Output
+```json
+{
+  "tasks": [
+    {
+      "taskArn": "arn:aws:ecs:region:account:task/cluster/task-id",
+      "clusterArn": "string",
+      "taskDefinitionArn": "string",
+      "lastStatus": "PENDING",
+      "desiredStatus": "RUNNING",
+      "containers": [
+        {
+          "containerArn": "string",
+          "name": "string",
+          "lastStatus": "PENDING"
+        }
+      ],
+      "launchType": "FARGATE",
+      "createdAt": "timestamp"
+    }
+  ],
+  "failures": []
+}
+```
+
+### Important Notes
+- **Eventual consistency**: Results may not be immediately reflected. Use DescribeTasks with exponential backoff (max 5 minutes)
+- **ConflictException**: Duplicate clientToken with different parameters
+
+---
+
+## stop-task
+
+### Synopsis
+```bash
+aws ecs stop-task \
+    --task <value> \
+    [--cluster <value>] \
+    [--reason <value>]
+```
+
+### Options
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--task` | string | Yes | Task ARN |
+| `--cluster` | string | No | Cluster name/ARN |
+| `--reason` | string | No | Stop reason message |
+
+### Signal Processing
+1. Sends SIGTERM to containers
+2. 30-second timeout (configurable via `ECS_CONTAINER_STOP_TIMEOUT`)
+3. SIGKILL if not terminated within timeout
+4. Windows containers: CTRL_SHUTDOWN_EVENT
+
+### Example
+```bash
+aws ecs stop-task \
+    --cluster MyCluster \
+    --task arn:aws:ecs:us-west-2:123456789012:task/MyCluster/abc123 \
+    --reason "Scaling down"
+```
+
+### Output
+```json
+{
+  "task": {
+    "taskArn": "string",
+    "lastStatus": "STOPPED",
+    "desiredStatus": "STOPPED",
+    "stopCode": "UserInitiated",
+    "stoppedReason": "Scaling down",
+    "stoppedAt": "timestamp"
+  }
+}
+```
+
+### Stop Codes
+- `UserInitiated`: Stopped by user
+- `TaskFailedToStart`: Task failed during startup
+- `EssentialContainerExited`: Essential container exited
+- `ServiceSchedulerInitiated`: Service scheduler stopped task
+- `SpotInterruption`: Spot instance interrupted
+- `TerminationNotice`: Instance termination notice
+
+---
+
+## describe-tasks
+
+### Synopsis
+```bash
+aws ecs describe-tasks \
+    --tasks <value> \
+    [--cluster <value>] \
+    [--include <value>]
+```
+
+### Options
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--tasks` | list | Yes | Max 100 task IDs/ARNs |
+| `--cluster` | string | No | Cluster name/ARN |
+| `--include` | list | No | `TAGS` |
+
+### Example
+```bash
+aws ecs describe-tasks \
+    --cluster MyCluster \
+    --tasks abc123 def456 \
+    --include TAGS
+```
+
+### Output Structure
+```json
+{
+  "tasks": [
+    {
+      "taskArn": "string",
+      "clusterArn": "string",
+      "taskDefinitionArn": "string",
+      "lastStatus": "RUNNING",
+      "desiredStatus": "RUNNING",
+      "healthStatus": "HEALTHY|UNHEALTHY|UNKNOWN",
+      "launchType": "FARGATE",
+      "cpu": "256",
+      "memory": "512",
+      "containers": [
+        {
+          "containerArn": "string",
+          "name": "string",
+          "image": "string",
+          "lastStatus": "RUNNING",
+          "exitCode": 0,
+          "healthStatus": "HEALTHY",
+          "networkInterfaces": [
+            {"privateIpv4Address": "10.0.0.1"}
+          ]
+        }
+      ],
+      "attachments": [...],
+      "createdAt": "timestamp",
+      "startedAt": "timestamp",
+      "tags": []
+    }
+  ],
+  "failures": []
+}
+```
+
+### Task Status Values
+- `PROVISIONING`
+- `PENDING`
+- `ACTIVATING`
+- `RUNNING`
+- `DEACTIVATING`
+- `STOPPING`
+- `DEPROVISIONING`
+- `STOPPED`
+
+### Notes
+- Stopped tasks visible for at least 1 hour
+- Tagged tasks from deleted clusters don't appear with same-named new clusters
+
+---
+
+## list-tasks
+
+### Synopsis
+```bash
+aws ecs list-tasks \
+    [--cluster <value>] \
+    [--container-instance <value>] \
+    [--family <value>] \
+    [--started-by <value>] \
+    [--service-name <value>] \
+    [--desired-status <value>] \
+    [--launch-type <value>] \
+    [--max-items <value>] \
+    [--starting-token <value>]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--cluster` | string | Cluster name/ARN |
+| `--container-instance` | string | Filter by container instance |
+| `--family` | string | Filter by task definition family |
+| `--started-by` | string | Filter by startedBy (must be only filter) |
+| `--service-name` | string | Filter by service |
+| `--desired-status` | string | RUNNING (default), PENDING, STOPPED |
+| `--launch-type` | string | EC2, FARGATE, EXTERNAL |
+
+### Example
+```bash
+aws ecs list-tasks \
+    --cluster MyCluster \
+    --service-name MyService \
+    --desired-status RUNNING
+```
+
+### Output
+```json
+{
+  "taskArns": [
+    "arn:aws:ecs:region:account:task/cluster/task-id-1",
+    "arn:aws:ecs:region:account:task/cluster/task-id-2"
+  ],
+  "nextToken": "string"
+}
+```
+
+### Notes
+- `--started-by` cannot be combined with other filters
+- `PENDING` filter returns no results
+- Recently stopped tasks may appear
+
+---
+
+## execute-command
+
+### Synopsis
+```bash
+aws ecs execute-command \
+    --task <value> \
+    --command <value> \
+    --interactive \
+    [--cluster <value>] \
+    [--container <value>]
+```
+
+### Required Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--task` | string | Task ARN or ID |
+| `--command` | string | Command to run on container |
+| `--interactive` | boolean | Must be true |
+
+### Optional
+| Option | Type | Description |
+|--------|------|-------------|
+| `--cluster` | string | Cluster name/ARN |
+| `--container` | string | Container name (required for multi-container tasks) |
+
+### Prerequisites
+- Task started with `enableExecuteCommand=true`
+- AWS Systems Manager Session Manager plugin installed
+- Appropriate IAM permissions
+
+### Example
+```bash
+aws ecs execute-command \
+    --cluster MyCluster \
+    --task abc123 \
+    --container app \
+    --interactive \
+    --command "/bin/sh"
+```
+
+### Common Errors
+- `TargetNotConnectedException`:
+  - Invalid IAM permissions
+  - SSM agent not installed/running
+  - Session Manager VPC endpoint not configured

--- a/.claude/skills/ecs-cli-reference/task-definition-commands.md
+++ b/.claude/skills/ecs-cli-reference/task-definition-commands.md
@@ -1,0 +1,406 @@
+# ECS Task Definition CLI Commands
+
+## register-task-definition
+
+### Synopsis
+```bash
+aws ecs register-task-definition \
+    --family <value> \
+    --container-definitions <value> \
+    [--task-role-arn <value>] \
+    [--execution-role-arn <value>] \
+    [--network-mode <value>] \
+    [--volumes <value>] \
+    [--placement-constraints <value>] \
+    [--requires-compatibilities <value>] \
+    [--cpu <value>] \
+    [--memory <value>] \
+    [--tags <value>] \
+    [--pid-mode <value>] \
+    [--ipc-mode <value>] \
+    [--proxy-configuration <value>] \
+    [--inference-accelerators <value>] \
+    [--ephemeral-storage <value>] \
+    [--runtime-platform <value>] \
+    [--enable-fault-injection | --no-enable-fault-injection]
+```
+
+### Required Parameters
+| Option | Type | Description |
+|--------|------|-------------|
+| `--family` | string | Family name (max 255 chars: alphanumeric, underscore, hyphen) |
+| `--container-definitions` | list | Container definitions in JSON |
+
+### Key Optional Parameters
+| Option | Type | Description |
+|--------|------|-------------|
+| `--task-role-arn` | string | IAM role ARN for containers |
+| `--execution-role-arn` | string | IAM role for ECS agent (ECR pull, Secrets Manager) |
+| `--network-mode` | string | `none`, `bridge`, `host`, `awsvpc` |
+| `--cpu` | string | Task CPU (e.g., `256`, `1024`, `1 vCPU`) |
+| `--memory` | string | Task memory (e.g., `512`, `2048`, `1 GB`) |
+| `--requires-compatibilities` | list | `EC2`, `FARGATE`, `EXTERNAL`, `MANAGED_INSTANCES` |
+
+### Container Definition Structure
+```json
+[
+  {
+    "name": "string",
+    "image": "string",
+    "cpu": 256,
+    "memory": 512,
+    "memoryReservation": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp",
+        "name": "http",
+        "appProtocol": "http"
+      }
+    ],
+    "environment": [
+      {"name": "KEY", "value": "value"}
+    ],
+    "environmentFiles": [
+      {"type": "s3", "value": "arn:aws:s3:::bucket/file.env"}
+    ],
+    "secrets": [
+      {"name": "DB_PASSWORD", "valueFrom": "arn:aws:secretsmanager:..."}
+    ],
+    "mountPoints": [
+      {"sourceVolume": "data", "containerPath": "/data", "readOnly": false}
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecs/my-app",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream-prefix": "ecs"
+      }
+    },
+    "healthCheck": {
+      "command": ["CMD-SHELL", "curl -f http://localhost/ || exit 1"],
+      "interval": 30,
+      "timeout": 5,
+      "retries": 3,
+      "startPeriod": 60
+    },
+    "dependsOn": [
+      {"containerName": "init", "condition": "SUCCESS"}
+    ],
+    "command": ["./start.sh"],
+    "entryPoint": ["/bin/sh", "-c"],
+    "workingDirectory": "/app",
+    "user": "1000:1000",
+    "linuxParameters": {
+      "initProcessEnabled": true
+    }
+  }
+]
+```
+
+### Fargate CPU/Memory Combinations
+| CPU (vCPU) | Memory Options |
+|------------|----------------|
+| 256 (0.25) | 512MB, 1GB, 2GB |
+| 512 (0.5) | 1GB-4GB (1GB increments) |
+| 1024 (1) | 2GB-8GB (1GB increments) |
+| 2048 (2) | 4GB-16GB (1GB increments) |
+| 4096 (4) | 8GB-30GB (1GB increments) |
+| 8192 (8) | 16GB-60GB (4GB increments) |
+| 16384 (16) | 32GB-120GB (8GB increments) |
+
+### Runtime Platform
+```json
+{
+  "cpuArchitecture": "X86_64|ARM64",
+  "operatingSystemFamily": "LINUX|WINDOWS_SERVER_2019_FULL|WINDOWS_SERVER_2019_CORE|WINDOWS_SERVER_2022_FULL|WINDOWS_SERVER_2022_CORE"
+}
+```
+
+### Ephemeral Storage (Fargate)
+```json
+{
+  "sizeInGiB": 30
+}
+```
+- Range: 21-200 GiB
+- Requires Linux platform 1.4.0+
+
+### Example: Register with JSON File
+```bash
+aws ecs register-task-definition --cli-input-json file://task-def.json
+```
+
+**task-def.json:**
+```json
+{
+  "family": "my-app",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "nginx:latest",
+      "essential": true,
+      "portMappings": [
+        {"containerPort": 80, "protocol": "tcp"}
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/my-app",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Example: Register Inline
+```bash
+aws ecs register-task-definition \
+    --family my-app \
+    --network-mode awsvpc \
+    --requires-compatibilities FARGATE \
+    --cpu 256 \
+    --memory 512 \
+    --container-definitions '[{
+      "name": "app",
+      "image": "nginx:latest",
+      "essential": true,
+      "portMappings": [{"containerPort": 80}]
+    }]'
+```
+
+### Output
+```json
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "arn:aws:ecs:region:account:task-definition/my-app:1",
+    "family": "my-app",
+    "revision": 1,
+    "status": "ACTIVE",
+    "containerDefinitions": [...],
+    "cpu": "256",
+    "memory": "512",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": ["FARGATE"],
+    "compatibilities": ["EC2", "FARGATE"],
+    "registeredAt": "timestamp",
+    "registeredBy": "arn:aws:iam::..."
+  }
+}
+```
+
+---
+
+## deregister-task-definition
+
+### Synopsis
+```bash
+aws ecs deregister-task-definition \
+    --task-definition <value>
+```
+
+### Options
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--task-definition` | string | Yes | family:revision or full ARN. Revision required. |
+
+### Example
+```bash
+aws ecs deregister-task-definition --task-definition my-app:1
+```
+
+### Output
+```json
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "string",
+    "family": "my-app",
+    "revision": 1,
+    "status": "INACTIVE",
+    ...
+  }
+}
+```
+
+### Important Notes
+- Existing tasks/services continue running
+- Cannot run new tasks or create new services with INACTIVE definitions
+- 10-minute grace period before restrictions take effect
+- INACTIVE definitions remain discoverable indefinitely
+- Required before `delete-task-definitions`
+
+---
+
+## describe-task-definition
+
+### Synopsis
+```bash
+aws ecs describe-task-definition \
+    --task-definition <value> \
+    [--include <value>]
+```
+
+### Options
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--task-definition` | string | Yes | `family` (latest ACTIVE), `family:revision`, or ARN |
+| `--include` | list | No | `TAGS` |
+
+### Example
+```bash
+aws ecs describe-task-definition \
+    --task-definition my-app:1 \
+    --include TAGS
+```
+
+### Output
+```json
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "string",
+    "family": "string",
+    "revision": 1,
+    "status": "ACTIVE",
+    "containerDefinitions": [...],
+    "volumes": [...],
+    "cpu": "string",
+    "memory": "string",
+    "networkMode": "string",
+    "requiresCompatibilities": [...],
+    "compatibilities": [...],
+    "runtimePlatform": {...},
+    "registeredAt": "timestamp",
+    "registeredBy": "string"
+  },
+  "tags": []
+}
+```
+
+### Notes
+- INACTIVE definitions can only be described if active tasks/services reference them
+
+---
+
+## list-task-definitions
+
+### Synopsis
+```bash
+aws ecs list-task-definitions \
+    [--family-prefix <value>] \
+    [--status <value>] \
+    [--sort <value>] \
+    [--max-items <value>] \
+    [--starting-token <value>]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--family-prefix` | string | Filter by family name |
+| `--status` | string | `ACTIVE` (default), `INACTIVE`, `DELETE_IN_PROGRESS` |
+| `--sort` | string | `ASC` (default) or `DESC` |
+| `--max-items` | integer | Max items (1-100) |
+
+### Sort Behavior
+- ASC: Alphabetical by family, ascending by revision (latest last)
+- DESC: Reverse alphabetical, descending by revision (latest first)
+
+### Example
+```bash
+aws ecs list-task-definitions --family-prefix my-app --sort DESC
+```
+
+### Output
+```json
+{
+  "taskDefinitionArns": [
+    "arn:aws:ecs:region:account:task-definition/my-app:3",
+    "arn:aws:ecs:region:account:task-definition/my-app:2",
+    "arn:aws:ecs:region:account:task-definition/my-app:1"
+  ],
+  "nextToken": "string"
+}
+```
+
+---
+
+## list-task-definition-families
+
+### Synopsis
+```bash
+aws ecs list-task-definition-families \
+    [--family-prefix <value>] \
+    [--status <value>] \
+    [--max-items <value>] \
+    [--starting-token <value>]
+```
+
+### Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `--family-prefix` | string | Filter by prefix |
+| `--status` | string | `ACTIVE` (default), `INACTIVE`, `ALL` |
+| `--max-items` | integer | Max items (1-100) |
+
+### Example
+```bash
+aws ecs list-task-definition-families --family-prefix my
+```
+
+### Output
+```json
+{
+  "families": [
+    "my-app",
+    "my-worker",
+    "my-cronjob"
+  ],
+  "nextToken": "string"
+}
+```
+
+---
+
+## delete-task-definitions
+
+### Synopsis
+```bash
+aws ecs delete-task-definitions \
+    --task-definitions <value>
+```
+
+### Options
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--task-definitions` | list | Yes | Max 10 task definition ARNs |
+
+### Prerequisites
+- Task definition must be INACTIVE (deregistered)
+- No running tasks or services referencing it
+
+### Example
+```bash
+aws ecs delete-task-definitions \
+    --task-definitions \
+      arn:aws:ecs:region:account:task-definition/my-app:1 \
+      arn:aws:ecs:region:account:task-definition/my-app:2
+```
+
+### Output
+```json
+{
+  "taskDefinitions": [...],
+  "failures": [...]
+}
+```


### PR DESCRIPTION
## Summary
- Add comprehensive AWS CLI ECS command reference documentation as Claude Skills
- Enables KECS to better understand user expectations when interacting via `aws ecs` commands
- Complements the existing `ecs-api-reference` skills with CLI-specific syntax and examples

## Files Added
- `.claude/skills/ecs-cli-reference/SKILL.md` - Main skill definition with overview
- `.claude/skills/ecs-cli-reference/cluster-commands.md` - Cluster lifecycle commands
- `.claude/skills/ecs-cli-reference/service-commands.md` - Service management commands
- `.claude/skills/ecs-cli-reference/task-commands.md` - Task execution and management
- `.claude/skills/ecs-cli-reference/task-definition-commands.md` - Task definition registration
- `.claude/skills/ecs-cli-reference/other-commands.md` - Tags, Attributes, Account Settings, Capacity Providers, TaskSets

## Coverage
~1,950 lines of documentation covering:
- Command synopsis with all options
- Required vs optional parameters
- JSON structure examples for complex inputs
- Practical usage examples
- Output format specifications
- Global CLI options and pagination patterns

## Test plan
- [x] Skill files created with correct YAML frontmatter
- [x] All markdown files properly formatted
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)