### PR TITLE
docs: Add LocalStack service tiers reference as Claude Skill

### DIFF
--- a/.claude/skills/localstack-services/SKILL.md
+++ b/.claude/skills/localstack-services/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: LocalStack Service Tiers Reference
+description: Reference for LocalStack AWS service availability by tier (Free/Base/Ultimate). Essential for KECS development to understand which AWS-compatible services can be used locally without cost.
+allowed-tools:
+  - Read
+  - WebFetch
+---
+
+# LocalStack Service Tiers Reference
+
+This skill provides knowledge about LocalStack service availability across pricing tiers.
+KECS uses LocalStack for AWS-compatible services, relying on free tier services for ECS integrations.
+
+## Quick Reference
+
+### Key Insight for KECS Development
+
+**ECS is NOT available in LocalStack Free tier** - it requires Base tier ($39/mo).
+This is one of the primary reasons KECS exists: to provide a free, local ECS-compatible environment.
+
+### Pricing Tiers
+
+| Tier | Price | Services |
+|------|-------|----------|
+| Free (Community) | $0 | 30+ services |
+| Base | $39/mo | 55+ services |
+| Ultimate | $89/mo | 110+ services |
+
+### Free Tier Services (Commonly Used with ECS)
+
+These services are available for free and can be used with KECS:
+
+- **S3** - Object storage
+- **DynamoDB** - NoSQL database
+- **SQS** - Simple Queue Service
+- **SNS** - Simple Notification Service
+- **IAM** - Identity and Access Management
+- **SecretsManager** - Secrets management
+- **KMS** - Key Management Service
+- **SSM** - Systems Manager (Parameter Store)
+- **STS** - Security Token Service
+- **ACM** - Certificate Manager
+- **CloudWatch** - Monitoring (basic features)
+- **CloudWatch Logs** - Logging (basic features)
+- **Lambda** - Serverless functions (basic features)
+
+### Paid Tier Only Services (NOT Free)
+
+These require LocalStack Base or Ultimate:
+
+- **ECS** - Elastic Container Service (Base+)
+- **ECR** - Elastic Container Registry (Base+)
+- **ELB/ALB** - Load Balancing (Base+)
+- **EC2** - Docker VM mode (Base+, Mock mode is free)
+
+## Detailed Documentation
+
+See `service-tiers.md` for complete service tier information.

--- a/.claude/skills/localstack-services/service-tiers.md
+++ b/.claude/skills/localstack-services/service-tiers.md
@@ -1,0 +1,141 @@
+# LocalStack Service Availability by Tier
+
+## Overview
+
+LocalStack provides AWS-compatible services for local development.
+Services are available across different pricing tiers:
+
+- **Free (Community)**: Open source, no cost
+- **Base**: $39/month
+- **Ultimate**: $89/month
+
+## Service Tier Matrix
+
+### Core Storage & Database Services
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| S3 | ✅ | ✅ | ✅ | Full API support |
+| DynamoDB | ✅ | ✅ | ✅ | Full API support |
+| SecretsManager | ✅ | ✅ | ✅ | Secret storage and rotation |
+
+### Messaging & Streaming
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| SQS | ✅ | ✅ | ✅ | Standard and FIFO queues |
+| SNS | ✅ | ✅ | ✅ | Topics and subscriptions |
+
+### Identity & Security
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| IAM | ✅ | ✅ | ✅ | Users, roles, policies |
+| STS | ✅ | ✅ | ✅ | Temporary credentials |
+| KMS | ✅ | ✅ | ✅ | Key management |
+| ACM | ✅ | ✅ | ✅ | Certificate management |
+| SSM | ✅ | ✅ | ✅ | Parameter Store |
+
+### Monitoring & Logging
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| CloudWatch | ✅ | ✅ | ✅ | Advanced log queries in Pro |
+| CloudWatch Logs | ✅ | ✅ | ✅ | Filter patterns in Pro only |
+
+### Compute
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| Lambda | ✅ | ✅ | ✅ | Kafka event sources & full Layers in Pro |
+| EC2 | ⚠️ | ✅ | ✅ | Mock VM in Free, Docker VM in Base+, Libvirt in Ultimate |
+
+### Container Services
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| **ECS** | ❌ | ✅ | ✅ | **NOT free - requires Base tier** |
+| **ECR** | ❌ | ✅ | ✅ | **NOT free - requires Base tier** |
+
+### Load Balancing
+
+| Service | Free | Base | Ultimate | Notes |
+|---------|------|------|----------|-------|
+| **ELB/ALB** | ❌ | ✅ | ✅ | **NOT free - requires Base tier** |
+
+## KECS Development Strategy
+
+### Why KECS Exists
+
+LocalStack's ECS service requires a paid tier ($39/mo minimum).
+KECS provides a **free, local ECS-compatible environment** by:
+
+1. Implementing ECS APIs on Kubernetes (k3d)
+2. Leveraging LocalStack's **free tier services** for integrations
+
+### Recommended Architecture
+
+```
+KECS (Free)                  LocalStack Free Tier
+┌─────────────────┐          ┌─────────────────┐
+│ ECS APIs        │          │ S3              │
+│ - Clusters      │◄────────►│ SecretsManager  │
+│ - Services      │          │ SSM             │
+│ - Tasks         │          │ CloudWatch Logs │
+│ - Task Defs     │          │ SQS/SNS         │
+└─────────────────┘          │ DynamoDB        │
+        │                    │ IAM/STS         │
+        ▼                    └─────────────────┘
+┌─────────────────┐
+│ k3d/Kubernetes  │
+└─────────────────┘
+```
+
+### Integration Points
+
+KECS integrates with LocalStack for:
+
+1. **SecretsManager** - Task definition secrets
+2. **SSM Parameter Store** - Configuration values
+3. **S3** - Environment files for containers
+4. **CloudWatch Logs** - Container logging
+5. **IAM/STS** - Credential simulation
+
+### LocalStack Configuration for KECS
+
+```bash
+# Start LocalStack with free tier services
+docker run -d \
+  --name localstack \
+  -p 4566:4566 \
+  -e SERVICES=s3,secretsmanager,ssm,sqs,sns,dynamodb,iam,sts,logs \
+  localstack/localstack
+
+# Configure AWS CLI to use LocalStack
+export AWS_ENDPOINT_URL=http://localhost:4566
+```
+
+## Feature Limitations in Free Tier
+
+### Lambda
+- Basic function creation and invocation: ✅ Free
+- Container image support: ✅ Free
+- Event source mappings (SQS, DynamoDB, Kinesis): ✅ Free
+- **Kafka event source mappings**: ❌ Pro only
+- **Lambda Layers (full functionality)**: ❌ Pro only (creation works, but not applied on invoke)
+
+### CloudWatch
+- Log groups and streams: ✅ Free
+- Basic log storage: ✅ Free
+- **Advanced log queries/filters**: ❌ Pro only
+
+### EC2
+- Mock VM mode: ✅ Free (limited functionality)
+- **Docker VM mode**: ❌ Base+ only
+- **Libvirt VM mode**: ❌ Ultimate only
+
+## References
+
+- LocalStack Documentation: https://docs.localstack.cloud/
+- Service Coverage: https://docs.localstack.cloud/aws/services/
+- Pricing: https://www.localstack.cloud/pricing


### PR DESCRIPTION
## Summary

- Add Claude Skills documentation for LocalStack service availability by tier
- Document which AWS-compatible services are free (Community) vs paid (Base/Ultimate)
- Essential reference for KECS development decisions

## Key Findings

**ECS is NOT available in LocalStack Free tier** - it requires Base tier ($39/mo).
This validates one of KECS's primary value propositions: providing a free, local ECS-compatible environment.

### Free Tier Services (usable with KECS)
- S3, DynamoDB, SQS, SNS
- IAM, STS, KMS, ACM
- SecretsManager, SSM (Parameter Store)
- CloudWatch, CloudWatch Logs (basic features)
- Lambda (basic features)

### Paid Tier Only (NOT Free)
- ECS, ECR - Base tier ($39/mo) required
- ELB/ALB - Base tier required
- EC2 Docker VM mode - Base tier required

## Files Added
- `.claude/skills/localstack-services/SKILL.md` - Quick reference
- `.claude/skills/localstack-services/service-tiers.md` - Detailed tier matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)